### PR TITLE
fix docker build by excluding README.md from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@ htmlcov
 
 # Docs
 *.md
+!README.md
 docs/
 
 # Keys (will be generated)


### PR DESCRIPTION
Exclude `README.md` from the `.dockerignore` to fix the Docker build error.
Previously the build process failed due to a missing `README.md`

# Reproduce Bug
To reproduce the bug, clone the current main branch from the repository and run `docker compose up --build`
```cmd
$ docker compose up --build
WARN[0000] /home/user/nanoidp/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Building 0.5s (10/15)                                                                                                                             
 => [internal] load local bake definitions                                                                                                       0.0s
 => => reading from stdin 524B                                                                                                                   0.0s
 => [internal] load build definition from Dockerfile                                                                                             0.0s
 => => transferring dockerfile: 1.12kB                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/python:3.12-slim                                                                              0.4s
 => [internal] load .dockerignore                                                                                                                0.0s
 => => transferring context: 318B                                                                                                                0.0s
 => [internal] load build context                                                                                                                0.0s
 => => transferring context: 2.04kB                                                                                                              0.0s
 => [ 1/10] FROM docker.io/library/python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c                      0.0s
 => CACHED [ 2/10] WORKDIR /app                                                                                                                  0.0s
 => CACHED [ 3/10] RUN apt-get update && apt-get install -y --no-install-recommends     libxml2-dev     libxmlsec1-dev     libxmlsec1-openssl    0.0s
 => CACHED [ 4/10] COPY pyproject.toml .                                                                                                         0.0s
 => ERROR [ 5/10] COPY README.md .                                                                                                               0.0s
------
 > [ 5/10] COPY README.md .:
------
[+] up 0/1
 ⠙ Image nanoidp-nanoidp Building                                                                                                                 0.6s
Dockerfile:24

--------------------

  22 |     # Copy project files

  23 |     COPY pyproject.toml .

  24 | >>> COPY README.md .

  25 |     COPY LICENSE .

  26 |     COPY src/ ./src/

--------------------

failed to solve: failed to compute cache key: failed to calculate checksum of ref beadc424-9df2-4a52-af01-af8c86b3d2a1::440cuzrvlxhmstqgt9sdmqdyc: "/README.md": not found

``` 
