### PR TITLE
Build and publish nanoidp docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Publish to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -39,5 +42,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,7 +28,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -82,3 +82,4 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxmlsec1-dev \
     libxmlsec1-openssl \
     pkg-config \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy project files
@@ -41,7 +42,7 @@ EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')" || exit 1
+    CMD curl -fsSL http://localhost:8000/api/health || exit 1
 
 # Run the application
 CMD ["nanoidp", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
 pip install nanoidp
 ```
 
+### From GHCR (Docker Image)
+
+```bash
+docker pull ghcr.io/cdelmonte-zg/nanoidp:latest
+```
+
 ### From Source
 
 ```bash
@@ -111,6 +117,14 @@ docker-compose up -d
 ```
 
 The server will be available at `http://localhost:8000`
+
+You can also run the published GHCR image directly:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -v $(pwd)/config:/app/config \
+  ghcr.io/cdelmonte-zg/nanoidp:latest
+```
 
 ## Web Interface
 
@@ -684,7 +698,7 @@ For detailed usage examples with Claude Code, see [docs/MCP_WORKFLOW.md](docs/MC
 
 ## Releasing
 
-NanoIDP uses GitHub Actions with PyPI Trusted Publishing for automated releases.
+NanoIDP uses GitHub Actions for automated releases to both PyPI and GHCR.
 
 ### Release Process
 
@@ -704,13 +718,16 @@ The workflow automatically:
 2. Builds the package
 3. Publishes to TestPyPI
 4. Publishes to PyPI (only for non-prerelease tags)
+5. Builds and publishes Docker images to GHCR
+
+Container tags are derived from the git tag (for example `v1.0.1`); the `latest` tag is only published for non-prerelease tags.
 
 ### Pre-release Testing
 
 For testing releases before publishing to PyPI:
 
 ```bash
-# Create a pre-release tag (only publishes to TestPyPI)
+# Create a pre-release tag (publishes to TestPyPI and GHCR)
 git tag v1.0.1-rc1
 git push origin v1.0.1-rc1
 


### PR DESCRIPTION
**Summary**: This PR adds a workflow which builds the nanoidp Dockerfile and publishes the container to the GitHub Container Registry.

Additionally, I changed the Dockerfile slightly to install and use curl for the healthcheck. The current healthcheck fails when using Podman, which runs CMD through `/bin/sh -c` and therefore breaks on the semicolon. There may be ways around that using `__import__(..)` magic, but I figured switching to curl was worth it as it also gets rid of the python interpreter [startup overhead](https://pythondev.readthedocs.io/startup_time.html) on every healthcheck, and is a reasonably small addition (~450kB).

**Why?** I would like to use NanoIDP in my compose files without having to clone the repo and build the Docker images myself.

**See also:**

- Workflow runs: <https://github.com/nicholasdehnen/nanoidp/actions>
- Container registry: <https://github.com/nicholasdehnen/nanoidp/pkgs/container/nanoidp>

Thanks 🙂

