### PR TITLE
fix: allow authentication flow without authentication headers

### DIFF
--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -262,9 +262,25 @@ def token():
     audit = get_audit_log()
     req_info = _get_request_info()
 
-    # Check client authentication
     auth = request.authorization
-    if not auth or not config.check_client(auth.username, auth.password):
+    grant_type = request.form.get("grant_type", "client_credentials")
+    client_id = request.form.get("client_id") or (auth.username if auth else None)
+
+    # For grant types that require client authentication, enforce it
+    if not auth and grant_type != "authorization_code":
+        audit.log(
+            event_type="token_request",
+            endpoint="/token",
+            method="POST",
+            status="failed",
+            client_id=client_id,
+            details={"reason": "Client authentication required", "grant_type": grant_type},
+            **req_info,
+        )
+        return abort(401, description="Client authentication required")
+
+    # Check client authentication
+    if auth and not config.check_client(auth.username, auth.password):
         audit.log(
             event_type="token_request",
             endpoint="/token",
@@ -275,9 +291,6 @@ def token():
             **req_info,
         )
         return abort(401, description="Invalid client credentials")
-
-    client_id = auth.username
-    grant_type = request.form.get("grant_type", "client_credentials")
 
     # Refresh token grant
     if grant_type == "refresh_token":

--- a/tests/test_oauth_flows.py
+++ b/tests/test_oauth_flows.py
@@ -221,6 +221,33 @@ class TestAuthorizationCodeFlowWithPKCE:
 
         assert response.status_code == 200
 
+    def test_pkce_plain_flow_no_auth_header(self, client, pkce_verifier):
+        """Test complete flow with PKCE plain method."""
+        # Get authorization code with plain challenge
+        client.get(
+            f'/authorize?response_type=code&client_id=demo-client'
+            f'&redirect_uri=http://localhost:3000/callback&scope=openid'
+            f'&code_challenge={pkce_verifier}&code_challenge_method=plain'
+        )
+        response = client.post('/authorize', data={
+            'username': 'admin',
+            'password': 'admin'
+        }, follow_redirects=False)
+
+        location = response.headers.get('Location')
+        code = location.split('code=')[1].split('&')[0]
+
+        # Exchange with code_verifier and client_id in body (public client, no auth header)
+        response = client.post('/token', data={
+            'grant_type': 'authorization_code',
+            'code': code,
+            'client_id': 'demo-client',
+            'redirect_uri': 'http://localhost:3000/callback',
+            'code_verifier': pkce_verifier
+        })
+
+        assert response.status_code == 200
+
     def test_pkce_missing_verifier_fails(self, client, auth_header, pkce_challenge_s256):
         """Test that missing code_verifier fails when challenge was provided."""
         # Get authorization code with code_challenge


### PR DESCRIPTION
When authentication-code flow is used with PKCE, libraries like authlib are not sending the Authentication header, as there is no secret to send. The client_id in this case is also usually available in the body, not in the header.

For that reason, the auth header validation is disabled in this particular case to make the PKCE authentication flow work.

I've successfully tested this fix with authlib manually.