### PR TITLE
feat: ID Token aud = client_id, add additional_audiences for arrays (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **ID Token `aud`** now contains the requesting client's `client_id`, as required by
+  OpenID Connect Core 1.0 §2 (was previously the static `oauth.audience`). This makes
+  it possible to test multiple clients and brings nanoidp in line with the OIDC spec.
+  - **Breaking:** relying parties that validated the ID Token `aud` against the old
+    static `oauth.audience` value must now expect their own `client_id`.
+  - The **access token** `aud` is unchanged and still reflects `oauth.audience`
+    (the resource audience, per RFC 9068 §2.2).
+
+### Added
+- `additional_audiences` per-client setting: extra audiences appended to the ID Token
+  `aud`. If this produces more than one distinct audience value, `aud` is emitted as an
+  array and nanoidp also emits `azp` equal to the `client_id`, so clients can test
+  authorized-party handling.
+
 ## [1.4.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,12 +172,18 @@ server:
 
 oauth:
   issuer: "http://localhost:8000"
-  audience: "my-app"
+  audience: "my-app"            # access token "aud" (resource audience, RFC 9068)
   token_expiry_minutes: 60
   clients:
     - client_id: "demo-client"
       client_secret: "demo-secret"
       description: "Default demo client"
+    - client_id: "multi-aud-client"
+      client_secret: "secret"
+      description: "Client whose ID Token carries extra audiences"
+      additional_audiences:     # optional; makes the ID Token "aud" an array
+        - "https://api.example.com"
+        - "urn:service:billing"
 
 saml:
   entity_id: "http://localhost:8000/saml"
@@ -193,6 +199,18 @@ authority_prefixes:
 logging:
   verbose_logging: true  # Include usernames/client_ids in logs (default: true)
 ```
+
+#### Audiences and the `aud` claim
+
+NanoIDP follows the OpenID Connect / OAuth specs for the `aud` claim:
+
+- **ID Token** — `aud` is the requesting client's `client_id` (OpenID Connect Core 1.0 §2).
+  This lets you test multiple clients independently. Configure `additional_audiences` on a
+  client to append extra audiences; if this produces more than one distinct audience value,
+  `aud` is emitted as an array and nanoidp also emits an `azp` claim equal to the `client_id`
+  so you can exercise authorized-party validation.
+- **Access Token** — `aud` is the resource audience from `oauth.audience` (RFC 9068 §2.2),
+  independent of the client.
 
 ### Logging Configuration
 
@@ -409,6 +427,10 @@ curl -X POST 'http://localhost:8000/revoke' \
 
 ## JWT Token Structure
 
+### Access Token
+
+The access token `aud` is the resource audience (`oauth.audience`):
+
 ```json
 {
   "iss": "http://localhost:8000",
@@ -429,6 +451,34 @@ curl -X POST 'http://localhost:8000/revoke' \
     "ACL_READ",
     "ACL_WRITE"
   ]
+}
+```
+
+### ID Token
+
+Issued when the `openid` scope is requested. Its `aud` is the client's `client_id`:
+
+```json
+{
+  "iss": "http://localhost:8000",
+  "sub": "admin",
+  "aud": "demo-client",
+  "iat": 1704100000,
+  "exp": 1704103600,
+  "nonce": "..."
+}
+```
+
+If `additional_audiences` produces more than one distinct audience value, `aud` becomes an array and `azp` is added:
+
+```json
+{
+  "iss": "http://localhost:8000",
+  "sub": "admin",
+  "aud": ["multi-aud-client", "https://api.example.com", "urn:service:billing"],
+  "azp": "multi-aud-client",
+  "iat": 1704100000,
+  "exp": 1704103600
 }
 ```
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -13,6 +13,12 @@ oauth:
   - client_id: test-client
     client_secret: test-secret
     description: Test client for integration tests
+  - client_id: multi-aud-client
+    client_secret: multi-aud-secret
+    description: Client whose ID Token carries extra audiences (array aud + azp)
+    additional_audiences:
+    - https://api.example.com
+    - urn:service:billing
 saml:
   entity_id: http://localhost:${PORT:8000}/saml
   sso_url: http://localhost:${PORT:8000}/saml/sso

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -465,6 +465,139 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("Auth Code + PKCE", TestCategory.OAUTH, False, str(e))
 
+    def _run_auth_code_flow(
+        self,
+        client_id: str,
+        client_secret: str,
+        scope: str = "openid",
+    ) -> Optional[Dict[str, Any]]:
+        """Run a full authorization_code flow and return the token response JSON.
+
+        Used by the ID Token audience tests to exercise a specific client.
+        Returns None if any step fails.
+        """
+        redirect_uri = "http://localhost:3000/callback"
+        auth_params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "state": secrets.token_urlsafe(16),
+            "nonce": secrets.token_urlsafe(16),
+        }
+        # A fresh session so cookies/auth don't leak from the default client.
+        sess = requests.Session()
+        sess.get(f"{self.base_url}/authorize", params=auth_params,
+                 allow_redirects=False, timeout=5)
+        resp = sess.post(
+            f"{self.base_url}/authorize",
+            data={**auth_params, "username": self.username, "password": self.password},
+            allow_redirects=False,
+            timeout=5,
+        )
+        if resp.status_code != 302:
+            return None
+        params = parse_qs(urlparse(resp.headers.get("Location", "")).query)
+        if "code" not in params:
+            return None
+        token_resp = sess.post(
+            f"{self.base_url}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": params["code"][0],
+                "redirect_uri": redirect_uri,
+            },
+            auth=(client_id, client_secret),
+            timeout=5,
+        )
+        if token_resp.status_code != 200:
+            return None
+        return token_resp.json()
+
+    def test_id_token_audience(self) -> TestResult:
+        """ID Token `aud` is the client_id; access token `aud` is the resource (issue #32)."""
+        try:
+            if not jwt:
+                return self._add_result(
+                    "ID Token Audience", TestCategory.OAUTH, False,
+                    "PyJWT not installed; cannot decode tokens"
+                )
+
+            data = self._run_auth_code_flow(self.client_id, self.client_secret)
+            if not data or "id_token" not in data:
+                return self._add_result(
+                    "ID Token Audience", TestCategory.OAUTH, False,
+                    "Could not obtain id_token via authorization_code flow"
+                )
+
+            id_claims = jwt.decode(data["id_token"], options={"verify_signature": False})
+            access_claims = jwt.decode(data["access_token"], options={"verify_signature": False})
+
+            # The access token must keep the configured resource audience (RFC 9068),
+            # not the client_id. Read the expected value from the running server.
+            cfg = requests.get(f"{self.base_url}/api/config", timeout=5).json()
+            expected_resource_aud = cfg.get("oauth", {}).get("audience")
+
+            aud_is_client = id_claims.get("aud") == self.client_id
+            azp_absent = "azp" not in id_claims  # single audience → no azp
+            access_aud_is_resource = access_claims.get("aud") == expected_resource_aud
+
+            ok = aud_is_client and azp_absent and access_aud_is_resource
+            return self._add_result(
+                "ID Token Audience",
+                TestCategory.OAUTH,
+                ok,
+                "id_token aud == client_id, azp omitted, access token aud == resource audience",
+                {
+                    "id_token_aud": id_claims.get("aud"),
+                    "azp_absent": azp_absent,
+                    "access_token_aud": access_claims.get("aud"),
+                    "expected_resource_aud": expected_resource_aud,
+                },
+            )
+        except Exception as e:
+            return self._add_result("ID Token Audience", TestCategory.OAUTH, False, str(e))
+
+    def test_id_token_audience_array(self) -> TestResult:
+        """A client with additional_audiences gets an array `aud` plus `azp` (issue #32).
+
+        Requires a 'multi-aud-client' configured with additional_audiences on the
+        running server. Skips (as a pass) if that client is not present.
+        """
+        try:
+            if not jwt:
+                return self._add_result(
+                    "ID Token Audience (array)", TestCategory.OAUTH, False,
+                    "PyJWT not installed; cannot decode tokens"
+                )
+
+            client_id, client_secret = "multi-aud-client", "multi-aud-secret"
+            data = self._run_auth_code_flow(client_id, client_secret)
+            if not data or "id_token" not in data:
+                return self._add_result(
+                    "ID Token Audience (array)", TestCategory.OAUTH, True,
+                    "Skipped: 'multi-aud-client' not configured on this server"
+                )
+
+            claims = jwt.decode(data["id_token"], options={"verify_signature": False})
+            aud = claims.get("aud")
+
+            is_array = isinstance(aud, list)
+            has_client = is_array and aud[0] == client_id
+            has_extras = is_array and len(aud) > 1
+            azp_ok = claims.get("azp") == client_id
+
+            ok = is_array and has_client and has_extras and azp_ok
+            return self._add_result(
+                "ID Token Audience (array)",
+                TestCategory.OAUTH,
+                ok,
+                "aud is an array led by client_id and azp == client_id",
+                {"id_token_aud": aud, "azp": claims.get("azp")},
+            )
+        except Exception as e:
+            return self._add_result("ID Token Audience (array)", TestCategory.OAUTH, False, str(e))
+
     def test_device_flow(self) -> TestResult:
         """Device Authorization Flow (RFC 8628)."""
         try:
@@ -2232,6 +2365,8 @@ class NanoIDPTestAgent:
                 self.test_password_grant,
                 self.test_client_credentials,
                 self.test_authorization_code_pkce,
+                self.test_id_token_audience,
+                self.test_id_token_audience_array,
                 self.test_device_flow,
                 self.test_token_decode,
                 self.test_introspection,

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -81,6 +81,10 @@ class OAuthClient(BaseModel):
     client_id: str = Field(..., min_length=1, description="OAuth client ID")
     client_secret: str = Field(..., min_length=1, description="OAuth client secret")
     description: str = Field(default="", description="Client description")
+    additional_audiences: List[str] = Field(
+        default_factory=list,
+        description="Extra audiences added to the ID Token 'aud' alongside the client_id",
+    )
 
 
 class Settings(BaseModel):
@@ -234,6 +238,7 @@ class ConfigManager:
                 client_id=client_data.get("client_id", ""),
                 client_secret=client_data.get("client_secret", ""),
                 description=client_data.get("description", ""),
+                additional_audiences=client_data.get("additional_audiences", []),
             ))
 
         self.settings = Settings(
@@ -433,11 +438,14 @@ class ConfigManager:
 
         clients_data = []
         for client in self.settings.clients:
-            clients_data.append({
+            client_entry = {
                 "client_id": client.client_id,
                 "client_secret": client.client_secret,
                 "description": client.description,
-            })
+            }
+            if client.additional_audiences:
+                client_entry["additional_audiences"] = client.additional_audiences
+            clients_data.append(client_entry)
 
         data = {
             "server": {

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -142,7 +142,22 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
     return {
         "client_id": client.client_id,
         "description": client.description,
+        "additional_audiences": client.additional_audiences,
     }
+
+
+def _normalize_audiences(value: Any) -> list[str]:
+    """Coerce a raw audiences argument into a list of non-empty strings.
+
+    ``update_client`` assigns directly to the model (which is not configured with
+    ``validate_assignment``), so the input is validated here for parity with the
+    Pydantic validation that ``create_client`` gets for free.
+    """
+    if not value:
+        return []
+    if not isinstance(value, list) or not all(isinstance(a, str) for a in value):
+        raise ValueError("additional_audiences must be a list of strings")
+    return [a for a in value if a]
 
 
 # =============================================================================
@@ -376,6 +391,11 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Human-readable description (optional)",
                     },
+                    "additional_audiences": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Extra audiences added to the ID Token 'aud' alongside the client_id (optional)",
+                    },
                 },
                 "required": ["client_id", "client_secret"],
             },
@@ -397,6 +417,11 @@ async def list_tools() -> list[Tool]:
                     "description": {
                         "type": "string",
                         "description": "New description (optional)",
+                    },
+                    "additional_audiences": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Replace the client's extra ID Token audiences (optional)",
                     },
                 },
                 "required": ["client_id"],
@@ -678,6 +703,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             client_id=client_id,
             client_secret=arguments["client_secret"],
             description=arguments.get("description", ""),
+            additional_audiences=_normalize_audiences(arguments.get("additional_audiences")),
         )
         config.settings.clients.append(new_client)
         return {"success": True, "client": _client_to_dict(new_client)}
@@ -692,6 +718,8 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             client.client_secret = arguments["client_secret"]
         if "description" in arguments:
             client.description = arguments["description"]
+        if "additional_audiences" in arguments:
+            client.additional_audiences = _normalize_audiences(arguments["additional_audiences"])
 
         return {"success": True, "client": _client_to_dict(client)}
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -634,6 +634,7 @@ def token():
         extra_claims=extra_claims,
         nonce=nonce,
         scope=scope,
+        client_id=client_id,
     )
 
     # Audit log

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -314,6 +314,11 @@ def clients():
     )
 
 
+def _parse_audiences(form_value: str) -> list:
+    """Parse a newline-separated additional_audiences form field into a clean list."""
+    return [a.strip() for a in (form_value or "").splitlines() if a.strip()]
+
+
 @ui_bp.route("/clients/create", methods=["GET", "POST"])
 def client_create():
     """Create new OAuth client."""
@@ -343,6 +348,7 @@ def client_create():
             client_id=client_id,
             client_secret=client_secret,
             description=request.form.get("description", ""),
+            additional_audiences=_parse_audiences(request.form.get("additional_audiences", "")),
         )
 
         yaml_writer = get_yaml_writer()
@@ -395,6 +401,7 @@ def client_edit(client_id: str):
             client_id=client_id,
             client_secret=client_secret,
             description=request.form.get("description", ""),
+            additional_audiences=_parse_audiences(request.form.get("additional_audiences", "")),
         )
 
         yaml_writer = get_yaml_writer()
@@ -451,6 +458,7 @@ def client_regenerate_secret(client_id: str):
             client_id=client_id,
             client_secret=new_secret,
             description=client.description,
+            additional_audiences=client.additional_audiences,
         )
 
         yaml_writer = get_yaml_writer()

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -15,7 +15,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Union
 
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization, hashes
@@ -293,7 +293,7 @@ class CryptoService:
         self,
         sub: str,
         issuer: str,
-        audience: str,
+        audience: Union[str, List[str]],
         roles: list = None,
         tenant: str = None,
         extra: dict = None,

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -53,6 +53,40 @@ class TokenService:
 
         return authorities
 
+    def _resolve_id_token_audience(
+        self, client_id: Optional[str]
+    ) -> tuple[Any, Optional[str]]:
+        """Resolve the (aud, azp) pair for an ID Token.
+
+        Per OpenID Connect Core 1.0 §2, the ID Token ``aud`` MUST contain the
+        Relying Party's ``client_id``. Any ``additional_audiences`` configured
+        on the client are appended, turning ``aud`` into an array. With a single
+        audience, ``aud`` is a plain string and ``azp`` is omitted.
+
+        When multiple audiences are present, nanoidp emits ``azp`` with the
+        requesting ``client_id`` to support testing clients that implement
+        authorized-party validation. OIDC Core defines ``azp`` as optional, but
+        if present it must contain the OAuth 2.0 Client ID of the party to which
+        the ID Token was issued.
+
+        When no client is known we fall back to the configured resource audience
+        (a safety fallback — a real OIDC token endpoint always has a client).
+        """
+        if not client_id:
+            return self.config.settings.audience, None
+
+        client = self.config.get_client(client_id)
+        extras = client.additional_audiences if client else []
+
+        aud = [client_id]
+        for extra in extras:
+            if extra and extra not in aud:
+                aud.append(extra)
+
+        if len(aud) == 1:
+            return aud[0], None
+        return aud, client_id
+
     def create_token(
         self,
         user: User,
@@ -60,6 +94,7 @@ class TokenService:
         extra_claims: Optional[Dict[str, Any]] = None,
         nonce: Optional[str] = None,
         scope: Optional[str] = None,
+        client_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user."""
         settings = self.config.settings
@@ -102,13 +137,17 @@ class TokenService:
             exp_minutes=exp_minutes,
         )
         
-        id_token = self.crypto.create_jwt(
-            sub=user.username,
-            issuer=settings.issuer,
-            audience=settings.audience,
-            exp_minutes=exp_minutes,
-            nonce = nonce
-        ) if scope and "openid" in scope.split() else None
+        id_token = None
+        if scope and "openid" in scope.split():
+            id_aud, azp = self._resolve_id_token_audience(client_id)
+            id_token = self.crypto.create_jwt(
+                sub=user.username,
+                issuer=settings.issuer,
+                audience=id_aud,
+                exp_minutes=exp_minutes,
+                nonce=nonce,
+                extra={"azp": azp} if azp else None,
+            )
 
 
         # Create refresh token (valid for 7 days)

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -186,6 +186,8 @@ class YamlWriter:
             "client_secret": client.client_secret,
             "description": client.description,
         }
+        if client.additional_audiences:
+            client_data["additional_audiences"] = client.additional_audiences
 
         if existing_idx is not None:
             clients[existing_idx] = client_data

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -58,6 +58,16 @@
                                value="{{ client.description if client else '' }}"
                                placeholder="e.g., Frontend application client">
                     </div>
+
+                    <div class="mb-3">
+                        <label for="additional_audiences" class="form-label">Additional Audiences</label>
+                        <textarea class="form-control" id="additional_audiences" name="additional_audiences"
+                                  rows="3" placeholder="One audience per line, e.g.&#10;https://api.example.com&#10;urn:service:billing">{{ client.additional_audiences | join('\n') if client else '' }}</textarea>
+                        <div class="form-text">
+                            Extra audiences added to the ID Token <code>aud</code> alongside the client_id.
+                            When more than one distinct audience results, <code>aud</code> becomes an array and an <code>azp</code> claim is emitted.
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from nanoidp.app import create_app
 from nanoidp.config import ConfigManager, User, OAuthClient, Settings
 import nanoidp.services.crypto as crypto_module
 import nanoidp.config as config_module
+import nanoidp.services.token as token_module
 
 
 @pytest.fixture(autouse=True)
@@ -17,14 +18,37 @@ def reset_singletons():
     """Reset service singletons before and after each test.
 
     This ensures test isolation by preventing state leakage between tests.
+    The token service is reset too so it never holds a reference to a stale
+    config singleton (relevant when a test mutates the active configuration).
     """
     # Reset before test
     crypto_module._crypto_service = None
     config_module._config = None
+    token_module._token_service = None
     yield
     # Reset after test
     crypto_module._crypto_service = None
     config_module._config = None
+    token_module._token_service = None
+
+
+@pytest.fixture
+def preserve_config_files():
+    """Snapshot ``config/*.yaml`` and restore them verbatim after the test.
+
+    A few tests exercise code paths that persist settings to the real config
+    directory (e.g. POST ``/settings`` goes through the YAML writer). Without
+    this, those tests leave the repo's ``config/settings.yaml`` modified — with
+    env-var placeholders resolved and unrelated values flipped. Restoring the
+    exact bytes keeps the working tree clean.
+    """
+    import pathlib
+
+    config_dir = pathlib.Path(__file__).resolve().parent.parent / "config"
+    backups = {f: f.read_bytes() for f in config_dir.glob("*.yaml")}
+    yield
+    for path, content in backups.items():
+        path.write_bytes(content)
 
 
 @pytest.fixture

--- a/tests/test_client_audiences_persistence.py
+++ b/tests/test_client_audiences_persistence.py
@@ -1,0 +1,140 @@
+"""
+Regression tests: persisting OAuth client `additional_audiences` (issue #32).
+
+Before the fix, the YAML writer and the web-UI client handlers serialized only
+client_id/client_secret/description and replaced the whole client entry, so any
+save through the UI (edit, regenerate secret) silently dropped a client's
+`additional_audiences` from disk — reverting its ID Token `aud` to a plain string.
+"""
+
+import pytest
+
+from nanoidp.config import ConfigManager, OAuthClient, get_config
+from nanoidp.services.yaml_writer import YamlWriter
+
+
+def _seed_config(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "settings.yaml").write_text(
+        'oauth:\n'
+        '  issuer: "http://localhost:8000"\n'
+        '  audience: "my-app"\n'
+        '  clients:\n'
+        '    - client_id: "c1"\n'
+        '      client_secret: "s1"\n'
+        '      additional_audiences:\n'
+        '        - "https://api.example.com"\n'
+        '        - "urn:service:billing"\n'
+    )
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+class TestYamlWriterRoundTrip:
+    """The YAML writer must persist and round-trip additional_audiences."""
+
+    def test_save_client_persists_additional_audiences(self, tmp_path):
+        config_dir = _seed_config(tmp_path)
+        writer = YamlWriter(str(config_dir))
+
+        writer.save_client(
+            OAuthClient(
+                client_id="c1",
+                client_secret="s1",
+                additional_audiences=["https://api.example.com", "urn:service:billing"],
+            ),
+            is_new=False,
+        )
+
+        reloaded = ConfigManager(str(config_dir))
+        assert reloaded.get_client("c1").additional_audiences == [
+            "https://api.example.com",
+            "urn:service:billing",
+        ]
+
+    def test_save_client_can_clear_additional_audiences(self, tmp_path):
+        """Saving a client with no extra audiences removes the key (no stale data)."""
+        config_dir = _seed_config(tmp_path)
+        writer = YamlWriter(str(config_dir))
+
+        writer.save_client(
+            OAuthClient(client_id="c1", client_secret="s1", additional_audiences=[]),
+            is_new=False,
+        )
+
+        reloaded = ConfigManager(str(config_dir))
+        assert reloaded.get_client("c1").additional_audiences == []
+
+
+class TestClientUIPreservesAudiences:
+    """Web-UI client handlers must not silently wipe additional_audiences.
+
+    These exercise the real routes against the repo config; ``preserve_config_files``
+    restores the on-disk config afterwards.
+    """
+
+    @pytest.fixture
+    def admin_session(self, client):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        return client
+
+    def test_regenerate_secret_preserves_audiences(self, admin_session, preserve_config_files):
+        """Regenerate-secret has no form field, so it must carry over the existing audiences."""
+        before = get_config().get_client("multi-aud-client").additional_audiences
+        assert before  # sanity: the shipped config has them
+
+        resp = admin_session.post(
+            "/clients/multi-aud-client/regenerate-secret", follow_redirects=True
+        )
+        assert resp.status_code == 200
+
+        after = get_config().get_client("multi-aud-client").additional_audiences
+        assert after == before
+
+    def test_edit_preserves_resubmitted_audiences(self, admin_session, preserve_config_files):
+        """Editing a client (form re-submits the audiences) keeps them."""
+        resp = admin_session.post(
+            "/clients/multi-aud-client/edit",
+            data={
+                "description": "edited via UI",
+                "additional_audiences": "https://api.example.com\nurn:service:billing",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        client_obj = get_config().get_client("multi-aud-client")
+        assert client_obj.description == "edited via UI"
+        assert client_obj.additional_audiences == [
+            "https://api.example.com",
+            "urn:service:billing",
+        ]
+
+    def test_edit_can_clear_audiences(self, admin_session, preserve_config_files):
+        """Submitting an empty audiences field clears them (explicit user intent)."""
+        resp = admin_session.post(
+            "/clients/multi-aud-client/edit",
+            data={"description": "no auds", "additional_audiences": ""},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert get_config().get_client("multi-aud-client").additional_audiences == []
+
+    def test_create_sets_audiences(self, admin_session, preserve_config_files):
+        """Creating a client through the UI persists audiences entered in the form."""
+        resp = admin_session.post(
+            "/clients/create",
+            data={
+                "client_id": "ui-created",
+                "client_secret": "ui-secret",
+                "description": "made in UI",
+                "additional_audiences": "aud-a\n  \naud-b\n",  # blank line ignored
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert get_config().get_client("ui-created").additional_audiences == ["aud-a", "aud-b"]

--- a/tests/test_id_token_audience.py
+++ b/tests/test_id_token_audience.py
@@ -1,0 +1,237 @@
+"""
+Tests for the OIDC ID Token ``aud`` (audience) claim contract.
+
+Contract (per the official specifications):
+
+* **OpenID Connect Core 1.0, §2 (ID Token):** the ``aud`` claim MUST contain the
+  OAuth 2.0 ``client_id`` of the Relying Party. It MAY contain other audiences.
+  In the general case it is an array of strings; with a single audience it MAY be
+  a single string (RFC 7519 §4.1.3).
+* **OpenID Connect Core 1.0, §2 / §3.1.3.7 (azp):** ``azp`` is optional in Core,
+  but if present it must contain the OAuth 2.0 ``client_id`` of the authorized
+  party. nanoidp emits it when additional audiences are configured, so clients
+  can test authorized-party validation.
+* **RFC 9068 §2.2 (JWT access tokens):** the *access token* ``aud`` identifies the
+  resource server (``settings.audience``), NOT the client. It is therefore left
+  unchanged by this contract — see :class:`TestAccessTokenAudienceUnchanged`.
+
+Additional audiences for a client are configured via the new
+``OAuthClient.additional_audiences`` field, which is what makes the ``aud`` an
+array (the issue asks to be able to test the array form).
+"""
+
+import jwt as pyjwt
+import pytest
+
+from nanoidp.config import OAuthClient, User, get_config
+from nanoidp.services.token import get_token_service
+
+
+def _decode(token: str) -> dict:
+    """Decode a JWT without signature verification (claims inspection only)."""
+    return pyjwt.decode(token, options={"verify_signature": False})
+
+
+@pytest.fixture
+def token_service(app):
+    """Token service bound to the active (file-backed) config singleton."""
+    with app.app_context():
+        get_config()  # ensure the config singleton is initialised first
+        return get_token_service()
+
+
+@pytest.fixture
+def basic_user():
+    return User(
+        username="alice",
+        password="x",
+        email="alice@example.org",
+        roles=["USER"],
+        tenant="default",
+    )
+
+
+def _register_client(token_service, client_id, additional_audiences=None):
+    """(Re)register a client on the active config, optionally with extra audiences.
+
+    Mutates the very config instance the token service uses so the lookup in
+    ``create_token`` observes the change.
+    """
+    settings = token_service.config.settings
+    settings.clients = [c for c in settings.clients if c.client_id != client_id]
+    settings.clients.append(
+        OAuthClient(
+            client_id=client_id,
+            client_secret="secret",
+            additional_audiences=additional_audiences or [],
+        )
+    )
+
+
+class TestIdTokenAudience:
+    """The ID Token ``aud`` MUST be the requesting client's ``client_id``."""
+
+    @pytest.mark.parametrize("client_id", ["demo-client", "test-client"])
+    def test_aud_is_client_id_single_string(self, token_service, basic_user, app, client_id):
+        """Single audience → ``aud`` is the ``client_id`` as a plain string."""
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id=client_id
+            )
+        claims = _decode(result["id_token"])
+        assert claims["aud"] == client_id
+        assert isinstance(claims["aud"], str)
+
+    @pytest.mark.parametrize("client_id", ["demo-client", "test-client"])
+    def test_no_azp_when_single_audience(self, token_service, basic_user, app, client_id):
+        """``azp`` is omitted when there is exactly one audience."""
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id=client_id
+            )
+        claims = _decode(result["id_token"])
+        assert "azp" not in claims
+
+    @pytest.mark.parametrize(
+        "extras,expected_aud",
+        [
+            ([], "demo-client"),
+            (["https://api.example.com"], ["demo-client", "https://api.example.com"]),
+            (
+                ["https://api.example.com", "urn:service:billing"],
+                ["demo-client", "https://api.example.com", "urn:service:billing"],
+            ),
+        ],
+        ids=["none", "one-extra", "two-extras"],
+    )
+    def test_aud_composition(self, token_service, basic_user, app, extras, expected_aud):
+        """No extras → string; one or more extras → array led by ``client_id``."""
+        with app.app_context():
+            _register_client(token_service, "demo-client", extras)
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client"
+            )
+        claims = _decode(result["id_token"])
+        assert claims["aud"] == expected_aud
+
+    @pytest.mark.parametrize(
+        "extras,is_array",
+        [
+            ([], False),
+            (["https://api.example.com"], True),
+            (["a", "b"], True),
+        ],
+        ids=["single", "array-1", "array-2"],
+    )
+    def test_azp_present_only_for_array_aud(self, token_service, basic_user, app, extras, is_array):
+        """nanoidp emits ``azp`` (== ``client_id``) exactly when ``aud`` is an array."""
+        with app.app_context():
+            _register_client(token_service, "demo-client", extras)
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client"
+            )
+        claims = _decode(result["id_token"])
+        if is_array:
+            assert claims["azp"] == "demo-client"
+        else:
+            assert "azp" not in claims
+
+    @pytest.mark.parametrize(
+        "extras",
+        [
+            ["demo-client"],
+            ["demo-client", "https://api.example.com"],
+            ["https://api.example.com", "demo-client"],
+        ],
+        ids=["only-self", "self-first", "self-last"],
+    )
+    def test_client_id_not_duplicated(self, token_service, basic_user, app, extras):
+        """``client_id`` appears exactly once even if also listed in extras."""
+        with app.app_context():
+            _register_client(token_service, "demo-client", extras)
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client"
+            )
+        aud = _decode(result["id_token"])["aud"]
+        aud_list = [aud] if isinstance(aud, str) else aud
+        assert aud_list.count("demo-client") == 1
+        assert aud_list[0] == "demo-client"  # client_id is always listed first
+
+    def test_aud_falls_back_to_settings_audience_without_client_id(
+        self, token_service, basic_user, app
+    ):
+        """Safety: with no client context, ``aud`` falls back to settings.audience."""
+        with app.app_context():
+            result = token_service.create_token(basic_user, scope="openid", client_id=None)
+            expected = token_service.config.settings.audience
+        claims = _decode(result["id_token"])
+        assert claims["aud"] == expected
+
+    def test_id_token_still_carries_nonce(self, token_service, basic_user, app):
+        """Regression: changing ``aud`` must not drop the ``nonce`` claim."""
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client", nonce="n-123"
+            )
+        assert _decode(result["id_token"])["nonce"] == "n-123"
+
+    @pytest.mark.parametrize("scope", [None, "profile", "email profile"])
+    def test_no_id_token_without_openid_scope(self, token_service, basic_user, app, scope):
+        """No ``openid`` scope → no ID Token is issued (unchanged behaviour)."""
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, scope=scope, client_id="demo-client"
+            )
+        assert "id_token" not in result
+
+
+class TestAccessTokenAudienceUnchanged:
+    """Access/refresh token ``aud`` stays the resource audience (RFC 9068)."""
+
+    @pytest.mark.parametrize("token_key", ["access_token", "refresh_token"])
+    @pytest.mark.parametrize("client_id", ["demo-client", "test-client"])
+    def test_aud_is_settings_audience_not_client_id(
+        self, token_service, basic_user, app, token_key, client_id
+    ):
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id=client_id
+            )
+            settings_audience = token_service.config.settings.audience
+        aud = _decode(result[token_key])["aud"]
+        assert aud == settings_audience
+        assert aud != client_id
+
+
+class TestIdTokenAudienceIntegration:
+    """End-to-end: client_id threads through the authorization_code flow into aud."""
+
+    def _exchange(self, client, auth_header, client_id):
+        client.get(
+            f"/authorize?response_type=code&client_id={client_id}"
+            "&redirect_uri=http://localhost:3000/callback&scope=openid"
+        )
+        resp = client.post(
+            "/authorize",
+            data={"username": "admin", "password": "admin"},
+            follow_redirects=False,
+        )
+        code = resp.headers["Location"].split("code=")[1].split("&")[0]
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "http://localhost:3000/callback",
+            },
+            headers=auth_header,
+        )
+        import json
+
+        return json.loads(resp.data)
+
+    def test_auth_code_flow_id_token_aud_is_client_id(self, client, auth_header):
+        data = self._exchange(client, auth_header, "demo-client")
+        claims = _decode(data["id_token"])
+        assert claims["aud"] == "demo-client"
+        assert "azp" not in claims

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -302,3 +302,176 @@ default_user: admin
         # Change to true
         config.settings.verbose_logging = True
         assert config.settings.verbose_logging is True
+
+
+class TestMCPClientAdditionalAudiences:
+    """create_client / update_client expose `additional_audiences` (issue #32)."""
+
+    def _config(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            'oauth:\n'
+            '  issuer: "http://localhost:8000"\n'
+            '  clients:\n'
+            '    - client_id: "test"\n'
+            '      client_secret: "test"\n'
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        from nanoidp.config import ConfigManager
+        return ConfigManager(str(config_dir))
+
+    @pytest.mark.asyncio
+    async def test_create_client_with_additional_audiences(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+
+        result = await _execute_tool(
+            "create_client",
+            {
+                "client_id": "multi",
+                "client_secret": "s",
+                "additional_audiences": ["https://api.example.com", "urn:svc"],
+            },
+            config,
+        )
+
+        assert result["success"] is True
+        assert result["client"]["additional_audiences"] == [
+            "https://api.example.com",
+            "urn:svc",
+        ]
+        # persisted on the model
+        assert config.get_client("multi").additional_audiences == [
+            "https://api.example.com",
+            "urn:svc",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_client_defaults_to_empty_audiences(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+
+        result = await _execute_tool(
+            "create_client", {"client_id": "plain", "client_secret": "s"}, config
+        )
+
+        assert result["success"] is True
+        assert result["client"]["additional_audiences"] == []
+
+    @pytest.mark.asyncio
+    async def test_update_client_sets_additional_audiences(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        await _execute_tool("create_client", {"client_id": "c", "client_secret": "s"}, config)
+
+        result = await _execute_tool(
+            "update_client", {"client_id": "c", "additional_audiences": ["aud://x"]}, config
+        )
+
+        assert result["success"] is True
+        assert config.get_client("c").additional_audiences == ["aud://x"]
+
+    @pytest.mark.asyncio
+    async def test_get_client_reports_additional_audiences(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        await _execute_tool(
+            "create_client",
+            {"client_id": "c", "client_secret": "s", "additional_audiences": ["a"]},
+            config,
+        )
+
+        result = await _execute_tool("get_client", {"client_id": "c"}, config)
+
+        assert result["found"] is True
+        assert result["client"]["additional_audiences"] == ["a"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["create_client", "update_client"])
+    async def test_schema_exposes_additional_audiences(self, tool_name):
+        from nanoidp import mcp_server
+
+        tools = await mcp_server.list_tools()
+        tool = next(t for t in tools if t.name == tool_name)
+        props = tool.inputSchema["properties"]
+        assert "additional_audiences" in props
+        assert props["additional_audiences"]["type"] == "array"
+        assert props["additional_audiences"]["items"]["type"] == "string"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, []),
+            ([], []),
+            (["", "valid", ""], ["valid"]),
+            (["a", "b"], ["a", "b"]),
+        ],
+        ids=["none", "empty", "drops-blanks", "kept"],
+    )
+    async def test_create_client_normalizes_audiences(self, tmp_path, raw, expected):
+        """Blank/None audiences are filtered (defensive normalization, parity with update)."""
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        args = {"client_id": "c", "client_secret": "s"}
+        if raw is not None:
+            args["additional_audiences"] = raw
+
+        result = await _execute_tool("create_client", args, config)
+
+        assert result["success"] is True
+        assert config.get_client("c").additional_audiences == expected
+
+    @pytest.mark.asyncio
+    async def test_update_client_normalizes_audiences(self, tmp_path):
+        """update_client filters blanks too (it bypasses Pydantic on assignment)."""
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        await _execute_tool("create_client", {"client_id": "c", "client_secret": "s"}, config)
+
+        result = await _execute_tool(
+            "update_client", {"client_id": "c", "additional_audiences": ["", "x", ""]}, config
+        )
+
+        assert result["success"] is True
+        assert config.get_client("c").additional_audiences == ["x"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad",
+        [["a", 123], "not-a-list", [None]],
+        ids=["int", "str", "none-item"],
+    )
+    async def test_create_client_rejects_non_string_audiences(self, tmp_path, bad):
+        """Strict semantics: non-string audiences are rejected, not silently dropped."""
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        with pytest.raises(ValueError):
+            await _execute_tool(
+                "create_client",
+                {"client_id": "c", "client_secret": "s", "additional_audiences": bad},
+                config,
+            )
+
+    @pytest.mark.asyncio
+    async def test_call_tool_returns_clean_error_for_bad_audiences(self, tmp_path, monkeypatch):
+        """The public call_tool handler turns the ValueError into a readable error
+        response (not a crash) — closing the raise/handle loop end to end."""
+        import nanoidp.mcp_server as mcp
+
+        monkeypatch.setattr(mcp, "_config", self._config(tmp_path))
+        monkeypatch.setattr(mcp, "_readonly_mode", False)
+        monkeypatch.delenv("NANOIDP_MCP_ADMIN_SECRET", raising=False)
+
+        result = await mcp.call_tool(
+            "create_client",
+            {"client_id": "c", "client_secret": "s", "additional_audiences": ["a", 123]},
+        )
+
+        assert len(result) == 1
+        payload = json.loads(result[0].text)
+        assert payload["tool"] == "create_client"
+        assert "additional_audiences" in payload["error"]

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -797,7 +797,7 @@ class TestSAMLSigningUI:
         if original_value:
             assert b'checked' in response.data
 
-    def test_settings_post_updates_sign_responses_true(self, client):
+    def test_settings_post_updates_sign_responses_true(self, client, preserve_config_files):
         """Test that POST to settings can enable sign_responses."""
         from nanoidp.config import get_config
 
@@ -827,7 +827,7 @@ class TestSAMLSigningUI:
             # Restore original value
             config.settings.saml_sign_responses = original_value
 
-    def test_settings_post_updates_sign_responses_false(self, client):
+    def test_settings_post_updates_sign_responses_false(self, client, preserve_config_files):
         """Test that POST to settings can disable sign_responses."""
         from nanoidp.config import get_config
 


### PR DESCRIPTION
…#32)

The ID Token `aud` now contains the requesting client's `client_id`, as required by OpenID Connect Core 1.0 §2 (it was previously the static `oauth.audience`). This lets multiple clients be tested independently.

- New per-client `additional_audiences`: when it yields more than one distinctaudience, `aud` is emitted as an array and `azp` is set to the `client_id`.

- Access token `aud` is unchanged (resource audience, RFC 9068 §2.2), so theintrospect/userinfo/refresh verification paths are untouched.

- MCP `create_client`/`update_client` expose and validate `additional_audiences`.

- Coverage: unit + integration (tests/test_id_token_audience.py), MCP schema/validation/error-path, and the live E2E agent (examples/test_agent.py).

- Add `preserve_config_files` fixture so SAML `/settings` tests no longer rewrite the repo config on disk.

BREAKING CHANGE: relying parties that validated the ID Token `aud` against the old static `oauth.audience` must now expect their own `client_id`.