### PR TITLE
Issue #32 follow-ups: ID Token hardening, more grants, robust config (#34–#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a scalar value (`additional_audiences: api://x`) is coerced to a one-element list,
   and an unsupported shape (e.g. a non-string item) now fails with a clear,
   client-scoped error instead of an opaque Pydantic `ValidationError` at startup.
+- Minor hardening/polish from the #32 review (#37): `OAuthClient` now validates on
+  direct attribute assignment (`validate_assignment`), discovery advertises `azp` in
+  `claims_supported`, and the MCP `_normalize_audiences` rejects falsy non-list inputs
+  instead of silently returning an empty list.
 
 ### Security
 - Harden the ID Token vs access-token boundary (#34). The resource audience

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden the ID Token vs access-token boundary (#34). The resource audience
   (`oauth.audience`) is now filtered out of the ID Token `aud` even if a client
   lists it in `additional_audiences`, and every token carries a `token_use`
-  marker (`access` / `id` / `refresh`). `/userinfo` rejects non-access tokens and
-  `/introspect` reports ID Tokens as inactive, so an ID Token can no longer be
-  spent as an access token.
+  marker (`access` / `id` / `refresh`). `/userinfo` rejects tokens marked as ID or
+  refresh tokens and `/introspect` reports ID Tokens as inactive, so an ID Token can
+  no longer be spent as an access token. (Refresh tokens stay introspectable per
+  RFC 7662.)
 
 ## [2.0.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grants authenticate an end-user, so an ID Token is meaningful; `client_credentials`
   still never emits one (no end-user).
 
+### Fixed
+- Friendlier loading of client `additional_audiences` from `settings.yaml` (#35):
+  a scalar value (`additional_audiences: api://x`) is coerced to a one-element list,
+  and an unsupported shape (e.g. a non-string item) now fails with a clear,
+  client-scoped error instead of an opaque Pydantic `ValidationError` at startup.
+
 ### Security
 - Harden the ID Token vs access-token boundary (#34). The resource audience
   (`oauth.audience`) is now filtered out of the ID Token `aud` even if a client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Harden the ID Token vs access-token boundary (#34). The resource audience
+  (`oauth.audience`) is now filtered out of the ID Token `aud` even if a client
+  lists it in `additional_audiences`, and every token carries a `token_use`
+  marker (`access` / `id` / `refresh`). `/userinfo` rejects non-access tokens and
+  `/introspect` reports ID Tokens as inactive, so an ID Token can no longer be
+  spent as an access token.
+
 ## [2.0.0] - 2026-05-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ID Tokens are now issued for the **password** and **device** (RFC 8628) grants
+  when `openid` scope is requested, not just `authorization_code` (#36). These
+  grants authenticate an end-user, so an ID Token is meaningful; `client_credentials`
+  still never emits one (no end-user).
+
 ### Security
 - Harden the ID Token vs access-token boundary (#34). The resource audience
   (`oauth.audience`) is now filtered out of the ID Token `aud` even if a client

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -293,11 +293,12 @@ class NanoIDPTestAgent:
                 self.refresh_token = data.get("refresh_token")
                 self.id_token = data.get("id_token")
                 expires = data.get("expires_in", "?")
+                # openid scope was requested → an ID Token must be returned (issue #36).
                 has_id = "id_token" in data
                 return self._add_result(
                     "Password Grant",
                     TestCategory.OAUTH,
-                    True,
+                    has_id,
                     f"Token OK, expires={expires}s, id_token={has_id}",
                     {"expires_in": expires, "has_id_token": has_id}
                 )
@@ -699,12 +700,14 @@ class NanoIDPTestAgent:
 
                 if token_response.status_code == 200:
                     token_data = token_response.json()
+                    # openid scope was requested → expect an ID Token too (issue #36).
+                    has_id = "id_token" in token_data
                     return self._add_result(
                         "Device Flow",
                         TestCategory.OAUTH,
-                        True,
-                        f"Flow completo: device_auth -> verify -> token",
-                        {"user_code": user_code, "has_token": "access_token" in token_data}
+                        "access_token" in token_data and has_id,
+                        f"Flow completo: device_auth -> verify -> token, id_token={has_id}",
+                        {"user_code": user_code, "has_token": "access_token" in token_data, "has_id_token": has_id}
                     )
 
                 # Check if still pending (which is also valid behavior)

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -598,6 +598,52 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("ID Token Audience (array)", TestCategory.OAUTH, False, str(e))
 
+    def test_id_token_not_accepted_as_access_token(self) -> TestResult:
+        """An ID Token must be rejected at /userinfo and /introspect (issue #34).
+
+        ID Tokens are marked ``token_use: "id"``; access-token endpoints reject
+        them so an ID Token can never be spent as an access token.
+        """
+        try:
+            data = self._run_auth_code_flow(self.client_id, self.client_secret)
+            if not data or "id_token" not in data:
+                return self._add_result(
+                    "ID Token Not Access Token", TestCategory.OAUTH, False,
+                    "Could not obtain id_token via authorization_code flow"
+                )
+
+            id_token = data["id_token"]
+
+            # /userinfo must reject the ID Token (expects an access token).
+            userinfo = requests.get(
+                f"{self.base_url}/userinfo",
+                headers={"Authorization": f"Bearer {id_token}"},
+                timeout=5,
+            )
+            userinfo_rejected = userinfo.status_code == 401
+
+            # /introspect must report the ID Token as not active.
+            introspect = self.session.post(
+                f"{self.base_url}/introspect",
+                data={"token": id_token},
+                timeout=5,
+            )
+            introspect_inactive = (
+                introspect.status_code == 200
+                and introspect.json().get("active") is False
+            )
+
+            ok = userinfo_rejected and introspect_inactive
+            return self._add_result(
+                "ID Token Not Access Token",
+                TestCategory.OAUTH,
+                ok,
+                f"userinfo 401={userinfo_rejected}, introspect inactive={introspect_inactive}",
+                {"userinfo_status": userinfo.status_code, "introspect_active": introspect.json().get("active") if introspect.status_code == 200 else None},
+            )
+        except Exception as e:
+            return self._add_result("ID Token Not Access Token", TestCategory.OAUTH, False, str(e))
+
     def test_device_flow(self) -> TestResult:
         """Device Authorization Flow (RFC 8628)."""
         try:
@@ -2367,6 +2413,7 @@ class NanoIDPTestAgent:
                 self.test_authorization_code_pkce,
                 self.test_id_token_audience,
                 self.test_id_token_audience_array,
+                self.test_id_token_not_accepted_as_access_token,
                 self.test_device_flow,
                 self.test_token_decode,
                 self.test_introspection,

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -225,12 +225,14 @@ class NanoIDPTestAgent:
                 ]
                 found = [ep for ep in required if ep in data]
                 grants = data.get("grant_types_supported", [])
+                # azp is emitted for multi-audience ID Tokens, so it must be advertised (#37).
+                azp_advertised = "azp" in data.get("claims_supported", [])
                 return self._add_result(
                     "OIDC Discovery",
                     TestCategory.CORE,
-                    len(found) == len(required),
-                    f"{len(found)}/{len(required)} endpoints, grants: {len(grants)}",
-                    {"endpoints": found, "grants": grants}
+                    len(found) == len(required) and azp_advertised,
+                    f"{len(found)}/{len(required)} endpoints, grants: {len(grants)}, azp advertised: {azp_advertised}",
+                    {"endpoints": found, "grants": grants, "azp_advertised": azp_advertised}
                 )
             return self._add_result(
                 "OIDC Discovery",

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -105,6 +105,10 @@ class User(BaseModel):
 
 class OAuthClient(BaseModel):
     """Represents an OAuth client."""
+    # Validate on direct attribute assignment too (e.g. MCP update_client), so the
+    # field constraints below are enforced beyond construction time (#37).
+    model_config = ConfigDict(validate_assignment=True)
+
     client_id: str = Field(..., min_length=1, description="OAuth client ID")
     client_secret: str = Field(..., min_length=1, description="OAuth client secret")
     description: str = Field(default="", description="Client description")

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -40,6 +40,33 @@ def _expand_env_vars(value: Any) -> Any:
     return value
 
 
+def _coerce_additional_audiences(raw: Any, client_id: str) -> List[str]:
+    """Coerce a client's ``additional_audiences`` YAML value into a clean list.
+
+    The field is a ``List[str]`` on the model, but a single value is an easy
+    footgun in YAML (``additional_audiences: api://x``). Rather than let a raw
+    Pydantic ``ValidationError`` abort startup, accept a scalar string by wrapping
+    it, and raise a clear, client-scoped error for unsupported shapes (#35).
+    """
+    label = client_id or "<missing client_id>"
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw] if raw else []
+    if isinstance(raw, (list, tuple)):
+        non_strings = [a for a in raw if not isinstance(a, str)]
+        if non_strings:
+            raise ValueError(
+                f"Client '{label}': additional_audiences must be a list of strings, "
+                f"got non-string item(s): {non_strings!r}"
+            )
+        return [a for a in raw if a]
+    raise ValueError(
+        f"Client '{label}': additional_audiences must be a string or a list of "
+        f"strings, got {type(raw).__name__}"
+    )
+
+
 class User(BaseModel):
     """Represents a user in the system."""
     model_config = ConfigDict(extra="allow")
@@ -234,11 +261,14 @@ class ConfigManager:
         # Parse OAuth clients
         clients = []
         for client_data in oauth.get("clients", []):
+            client_id = client_data.get("client_id", "")
             clients.append(OAuthClient(
-                client_id=client_data.get("client_id", ""),
+                client_id=client_id,
                 client_secret=client_data.get("client_secret", ""),
                 description=client_data.get("description", ""),
-                additional_audiences=client_data.get("additional_audiences", []),
+                additional_audiences=_coerce_additional_audiences(
+                    client_data.get("additional_audiences", []), client_id
+                ),
             ))
 
         self.settings = Settings(

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -714,12 +714,21 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         if not client:
             return {"success": False, "error": f"Client '{client_id}' not found"}
 
+        # Validate/normalize every input up front so a bad value cannot leave the
+        # client half-updated: with validate_assignment=True, assigning each field
+        # can raise, and OAuthClient is mutated in place.
+        new_audiences = (
+            _normalize_audiences(arguments["additional_audiences"])
+            if "additional_audiences" in arguments
+            else None
+        )
+
         if "client_secret" in arguments:
             client.client_secret = arguments["client_secret"]
         if "description" in arguments:
             client.description = arguments["description"]
-        if "additional_audiences" in arguments:
-            client.additional_audiences = _normalize_audiences(arguments["additional_audiences"])
+        if new_audiences is not None:
+            client.additional_audiences = new_audiences
 
         return {"success": True, "client": _client_to_dict(client)}
 

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -149,11 +149,11 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
 def _normalize_audiences(value: Any) -> list[str]:
     """Coerce a raw audiences argument into a list of non-empty strings.
 
-    ``update_client`` assigns directly to the model (which is not configured with
-    ``validate_assignment``), so the input is validated here for parity with the
-    Pydantic validation that ``create_client`` gets for free.
+    Only ``None`` (argument omitted) and an empty list mean "no audiences"; any
+    other non-list (``""``, ``0``, ``False``) is a type error and is rejected,
+    rather than silently coerced to ``[]`` (#37).
     """
-    if not value:
+    if value is None:
         return []
     if not isinstance(value, list) or not all(isinstance(a, str) for a in value):
         raise ValueError("additional_audiences must be a list of strings")

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -49,7 +49,7 @@ def oidc_config():
             "id_token_signing_alg_values_supported": ["RS256"],
             "scopes_supported": ["openid", "profile", "email", "offline_access"],
             "claims_supported": [
-                "sub", "iss", "aud", "exp", "iat", "nbf",
+                "sub", "iss", "aud", "azp", "exp", "iat", "nbf",
                 "email", "email_verified", "preferred_username",
                 "roles", "tenant", "identity_class", "entitlements",
                 "source_acl", "attributes", "authorities"

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -701,6 +701,19 @@ def userinfo():
         )
         return jsonify({"error": "invalid_token", "error_description": "Token validation failed"}), 401
 
+    # UserInfo requires an *access* token (OIDC Core §5.3.1). Reject ID/refresh
+    # tokens even if they verify against the resource audience (issue #34).
+    if payload.get("token_use") in ("id", "refresh"):
+        audit.log(
+            event_type="userinfo_request",
+            endpoint="/userinfo",
+            method=request.method,
+            status="failed",
+            details={"reason": "Not an access token", "token_use": payload.get("token_use")},
+            **req_info,
+        )
+        return jsonify({"error": "invalid_token", "error_description": "An access token is required"}), 401
+
     # Check if token is revoked
     jti = payload.get("jti")
     if jti and jti in _revoked_tokens:
@@ -785,6 +798,20 @@ def introspect():
             status="success",
             client_id=client_id,
             details={"active": False, "reason": "Invalid or expired token"},
+            **req_info,
+        )
+        return jsonify({"active": False})
+
+    # ID Tokens are OIDC artifacts, not OAuth access/refresh tokens. They must not
+    # be reported as active here (or be usable as access tokens) (issue #34).
+    if payload.get("token_use") == "id":
+        audit.log(
+            event_type="introspection_request",
+            endpoint="/introspect",
+            method="POST",
+            status="success",
+            client_id=client_id,
+            details={"active": False, "reason": "ID Token is not introspectable"},
             **req_info,
         )
         return jsonify({"active": False})

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -423,6 +423,12 @@ def token():
             )
             return abort(401, description="Invalid credentials")
 
+        # An authenticated end-user is present, so honour an openid scope and
+        # emit an ID Token (issue #36). nonce is non-standard for this grant but
+        # accepted as a dev convenience.
+        scope = request.form.get("scope")
+        nonce = request.form.get("nonce")
+
     # Authorization code grant
     elif grant_type == "authorization_code":
         code = request.form.get("code", "")
@@ -590,6 +596,10 @@ def token():
                     "error": "server_error",
                     "error_description": "User not found"
                 }), 500
+
+            # The device flow authenticates an end-user, so honour the requested
+            # scope and emit an ID Token when 'openid' was asked for (issue #36).
+            scope = device_info.get("scope")
 
             # Clean up the device code (one-time use)
             user_code = device_info["user_code"]

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -425,9 +425,10 @@ def token():
 
         # An authenticated end-user is present, so honour an openid scope and
         # emit an ID Token (issue #36). nonce is non-standard for this grant but
-        # accepted as a dev convenience.
+        # accepted as a dev convenience; normalize an empty field to None so we
+        # don't emit an empty nonce claim (matches the authorization_code path).
         scope = request.form.get("scope")
-        nonce = request.form.get("nonce")
+        nonce = request.form.get("nonce") or None
 
     # Authorization code grant
     elif grant_type == "authorization_code":
@@ -713,6 +714,12 @@ def userinfo():
 
     # UserInfo requires an *access* token (OIDC Core §5.3.1). Reject ID/refresh
     # tokens even if they verify against the resource audience (issue #34).
+    #
+    # Deliberate compat (not strict) choice: we reject tokens *marked* as id/refresh
+    # rather than requiring token_use == "access". A validly-signed token without the
+    # marker (legacy, or hand-crafted with the IdP key — a first-class workflow for a
+    # dev IdP) is still accepted. The security goal still holds: the IdP marks every
+    # ID/refresh token it issues, so an ID Token can never be spent as an access token.
     if payload.get("token_use") in ("id", "refresh"):
         audit.log(
             event_type="userinfo_request",

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -71,15 +71,30 @@ class TokenService:
 
         When no client is known we fall back to the configured resource audience
         (a safety fallback — a real OIDC token endpoint always has a client).
+
+        The resource audience (``settings.audience``, used by access/refresh
+        tokens) is never allowed into the ID Token ``aud``: otherwise
+        ``verify_jwt(token, settings.audience)`` would accept an ID Token at the
+        access-token endpoints, letting it be spent as an access token (issue #34).
         """
         if not client_id:
             return self.config.settings.audience, None
 
+        resource_audience = self.config.settings.audience
         client = self.config.get_client(client_id)
         extras = client.additional_audiences if client else []
 
         aud = [client_id]
         for extra in extras:
+            if extra == resource_audience and extra != client_id:
+                logger.warning(
+                    "Ignoring additional_audience %r for client %r: it matches the "
+                    "resource audience (oauth.audience) and must not appear in an "
+                    "ID Token aud.",
+                    extra,
+                    client_id,
+                )
+                continue
             if extra and extra not in aud:
                 aud.append(extra)
 
@@ -126,6 +141,11 @@ class TokenService:
         if extra_claims:
             extra.update(extra_claims)
 
+        # Mark the token type so access-token endpoints can reject ID/refresh
+        # tokens presented as access tokens (issue #34). Set last so it cannot be
+        # overridden by caller-supplied extra_claims.
+        extra["token_use"] = "access"
+
         # Create access token JWT
         token = self.crypto.create_jwt(
             sub=user.username,
@@ -140,18 +160,21 @@ class TokenService:
         id_token = None
         if scope and "openid" in scope.split():
             id_aud, azp = self._resolve_id_token_audience(client_id)
+            id_extra = {"token_use": "id"}
+            if azp:
+                id_extra["azp"] = azp
             id_token = self.crypto.create_jwt(
                 sub=user.username,
                 issuer=settings.issuer,
                 audience=id_aud,
                 exp_minutes=exp_minutes,
                 nonce=nonce,
-                extra={"azp": azp} if azp else None,
+                extra=id_extra,
             )
 
 
         # Create refresh token (valid for 7 days)
-        refresh_extra = {"token_type": "refresh"}
+        refresh_extra = {"token_type": "refresh", "token_use": "refresh"}
         refresh_token = self.crypto.create_jwt(
             sub=user.username,
             issuer=settings.issuer,

--- a/tests/test_client_audiences_load.py
+++ b/tests/test_client_audiences_load.py
@@ -1,0 +1,79 @@
+"""
+Tests for friendly loading of client ``additional_audiences`` from settings.yaml
+(issue #35).
+
+A scalar value is a common single-value footgun; it is coerced to a one-element
+list. Unsupported shapes raise a clear, client-scoped error at load time instead
+of a raw Pydantic ValidationError that aborts startup with an opaque trace.
+"""
+
+import pytest
+
+from nanoidp.config import ConfigManager, _coerce_additional_audiences
+
+
+def _write_config(tmp_path, audiences_yaml: str):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "settings.yaml").write_text(
+        'oauth:\n'
+        '  issuer: "http://localhost:8000"\n'
+        '  audience: "my-app"\n'
+        '  clients:\n'
+        '    - client_id: "c1"\n'
+        '      client_secret: "s1"\n'
+        f'{audiences_yaml}'
+    )
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+class TestCoerceHelper:
+    def test_none_returns_empty(self):
+        assert _coerce_additional_audiences(None, "c1") == []
+
+    def test_scalar_string_wrapped(self):
+        assert _coerce_additional_audiences("api://x", "c1") == ["api://x"]
+
+    def test_empty_scalar_returns_empty(self):
+        assert _coerce_additional_audiences("", "c1") == []
+
+    def test_list_of_strings_passthrough_drops_empty(self):
+        assert _coerce_additional_audiences(["a", "", "b"], "c1") == ["a", "b"]
+
+    def test_non_string_item_raises_with_client_name(self):
+        with pytest.raises(ValueError, match="c1"):
+            _coerce_additional_audiences([123], "c1")
+
+    def test_wrong_type_raises_with_client_name(self):
+        with pytest.raises(ValueError, match="c1"):
+            _coerce_additional_audiences({"a": 1}, "c1")
+
+
+class TestLoadFromYaml:
+    def test_scalar_additional_audiences_loads_as_list(self, tmp_path):
+        config_dir = _write_config(tmp_path, '      additional_audiences: "api://single"\n')
+        config = ConfigManager(str(config_dir))
+        client = config.get_client("c1")
+        assert client.additional_audiences == ["api://single"]
+
+    def test_list_additional_audiences_loads(self, tmp_path):
+        config_dir = _write_config(
+            tmp_path,
+            '      additional_audiences:\n'
+            '        - "api://a"\n'
+            '        - "api://b"\n',
+        )
+        config = ConfigManager(str(config_dir))
+        assert config.get_client("c1").additional_audiences == ["api://a", "api://b"]
+
+    def test_non_string_item_aborts_with_clear_error(self, tmp_path):
+        config_dir = _write_config(
+            tmp_path,
+            '      additional_audiences:\n'
+            '        - 123\n',
+        )
+        with pytest.raises(ValueError, match="c1"):
+            ConfigManager(str(config_dir))

--- a/tests/test_id_token_audience.py
+++ b/tests/test_id_token_audience.py
@@ -235,3 +235,131 @@ class TestIdTokenAudienceIntegration:
         claims = _decode(data["id_token"])
         assert claims["aud"] == "demo-client"
         assert "azp" not in claims
+
+
+class TestResourceAudienceNeverInIdToken:
+    """Issue #34: the resource audience must never leak into the ID Token ``aud``."""
+
+    def test_settings_audience_filtered_from_extras(self, token_service, basic_user, app):
+        """A client listing ``oauth.audience`` in extras does NOT get it in the ID Token aud."""
+        with app.app_context():
+            resource_aud = token_service.config.settings.audience
+            _register_client(token_service, "demo-client", [resource_aud])
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client"
+            )
+        claims = _decode(result["id_token"])
+        # Only the client_id remains → plain string, no azp, no resource audience.
+        assert claims["aud"] == "demo-client"
+        assert "azp" not in claims
+
+    def test_settings_audience_filtered_but_other_extras_kept(self, token_service, basic_user, app):
+        """The resource audience is dropped while genuine extra audiences survive."""
+        with app.app_context():
+            resource_aud = token_service.config.settings.audience
+            _register_client(
+                token_service, "demo-client", [resource_aud, "https://api.example.com"]
+            )
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client"
+            )
+        aud = _decode(result["id_token"])["aud"]
+        assert aud == ["demo-client", "https://api.example.com"]
+        assert resource_aud not in aud
+
+
+class TestTokenUseMarker:
+    """Issue #34: every token carries a ``token_use`` marker for type disambiguation."""
+
+    def test_access_token_marked_access(self, token_service, basic_user, app):
+        with app.app_context():
+            result = token_service.create_token(basic_user, client_id="demo-client")
+        assert _decode(result["access_token"])["token_use"] == "access"
+
+    def test_refresh_token_marked_refresh(self, token_service, basic_user, app):
+        with app.app_context():
+            result = token_service.create_token(basic_user, client_id="demo-client")
+        assert _decode(result["refresh_token"])["token_use"] == "refresh"
+
+    def test_id_token_marked_id(self, token_service, basic_user, app):
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, scope="openid", client_id="demo-client"
+            )
+        assert _decode(result["id_token"])["token_use"] == "id"
+
+    def test_token_use_not_overridable_via_extra_claims(self, token_service, basic_user, app):
+        """A caller cannot downgrade an access token's marker through extra_claims."""
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, client_id="demo-client", extra_claims={"token_use": "id"}
+            )
+        assert _decode(result["access_token"])["token_use"] == "access"
+
+
+class TestIdTokenRejectedAtAccessEndpoints:
+    """Issue #34: an ID Token must not be accepted at access-token endpoints."""
+
+    def _id_token_for_resource_aud_client(self, client, app):
+        """Obtain an ID Token from a client that (mis)configures the resource audience.
+
+        Even with the misconfiguration the resource audience is filtered out, so the
+        defense relies on the ``token_use`` marker, exercised end-to-end here.
+        """
+        import base64
+
+        with app.app_context():
+            config = get_config()
+            resource_aud = config.settings.audience
+            config.settings.clients = [
+                c for c in config.settings.clients if c.client_id != "leak-client"
+            ]
+            config.settings.clients.append(
+                OAuthClient(
+                    client_id="leak-client",
+                    client_secret="leak-secret",
+                    additional_audiences=[resource_aud],
+                )
+            )
+        creds = base64.b64encode(b"leak-client:leak-secret").decode()
+        header = {"Authorization": f"Basic {creds}"}
+        client.get(
+            "/authorize?response_type=code&client_id=leak-client"
+            "&redirect_uri=http://localhost:3000/callback&scope=openid"
+        )
+        resp = client.post(
+            "/authorize",
+            data={"username": "admin", "password": "admin"},
+            follow_redirects=False,
+        )
+        code = resp.headers["Location"].split("code=")[1].split("&")[0]
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "http://localhost:3000/callback",
+            },
+            headers=header,
+        )
+        import json
+
+        return json.loads(resp.data)["id_token"], header
+
+    def test_id_token_rejected_at_userinfo(self, client, app):
+        id_token, _ = self._id_token_for_resource_aud_client(client, app)
+        resp = client.get("/userinfo", headers={"Authorization": f"Bearer {id_token}"})
+        assert resp.status_code == 401
+
+    def test_id_token_inactive_at_introspect(self, client, app):
+        id_token, header = self._id_token_for_resource_aud_client(client, app)
+        resp = client.post("/introspect", data={"token": id_token}, headers=header)
+        import json
+
+        assert resp.status_code == 200
+        assert json.loads(resp.data)["active"] is False
+
+    def test_access_token_still_works_at_userinfo(self, client, bearer_header):
+        """Regression: a real access token is still accepted at /userinfo."""
+        resp = client.get("/userinfo", headers=bearer_header)
+        assert resp.status_code == 200

--- a/tests/test_id_token_grants.py
+++ b/tests/test_id_token_grants.py
@@ -73,6 +73,39 @@ class TestPasswordGrantIdToken:
         assert resp.status_code == 200
         assert "id_token" not in json.loads(resp.data)
 
+    def test_password_grant_empty_nonce_omits_nonce_claim(self, client, auth_header):
+        """An empty nonce form field must not produce an empty `nonce` claim."""
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "openid",
+                "nonce": "",
+            },
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        claims = _decode(json.loads(resp.data)["id_token"])
+        assert "nonce" not in claims
+
+    def test_password_grant_passes_nonce_when_provided(self, client, auth_header):
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "openid",
+                "nonce": "n-xyz",
+            },
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        claims = _decode(json.loads(resp.data)["id_token"])
+        assert claims["nonce"] == "n-xyz"
+
 
 class TestDeviceFlowIdToken:
     """The device flow authenticates an end-user → emits an ID Token."""

--- a/tests/test_id_token_grants.py
+++ b/tests/test_id_token_grants.py
@@ -1,0 +1,127 @@
+"""
+Tests for which OAuth grants emit an ID Token when ``openid`` scope is requested
+(issue #36).
+
+Spec rationale: an ID Token represents an authenticated end-user, so it is emitted
+for grants that authenticate one — ``authorization_code`` (covered elsewhere),
+``password`` and the device flow (RFC 8628). ``client_credentials`` has no
+end-user, so it never emits an ID Token even if ``openid`` is requested.
+"""
+
+import json
+
+import jwt as pyjwt
+import pytest
+
+
+def _decode(token: str) -> dict:
+    return pyjwt.decode(token, options={"verify_signature": False})
+
+
+@pytest.fixture(autouse=True)
+def cleanup_device_codes():
+    yield
+    try:
+        from nanoidp.routes.oauth import _device_codes
+        _device_codes.clear()
+    except (ImportError, AttributeError):
+        pass
+
+
+class TestPasswordGrantIdToken:
+    """The password grant authenticates an end-user → emits an ID Token."""
+
+    def test_password_grant_with_openid_returns_id_token(self, client, auth_header):
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "openid",
+            },
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert "id_token" in data
+        claims = _decode(data["id_token"])
+        # aud is the requesting client_id (issue #32 contract carries over).
+        assert claims["aud"] == "demo-client"
+        assert claims["token_use"] == "id"
+
+    def test_password_grant_without_openid_has_no_id_token(self, client, auth_header):
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "profile email",
+            },
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        assert "id_token" not in json.loads(resp.data)
+
+    def test_password_grant_no_scope_has_no_id_token(self, client, auth_header):
+        resp = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        assert "id_token" not in json.loads(resp.data)
+
+
+class TestDeviceFlowIdToken:
+    """The device flow authenticates an end-user → emits an ID Token."""
+
+    def _run(self, client, auth_header, scope):
+        data = {"scope": scope} if scope else {}
+        resp = client.post("/device_authorization", data=data, headers=auth_header)
+        assert resp.status_code == 200
+        info = json.loads(resp.data)
+        client.post(
+            "/device",
+            data={
+                "user_code": info["user_code"],
+                "username": "admin",
+                "password": "admin",
+                "action": "authorize",
+            },
+        )
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": info["device_code"],
+            },
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        return json.loads(resp.data)
+
+    def test_device_flow_with_openid_returns_id_token(self, client, auth_header):
+        data = self._run(client, auth_header, "openid")
+        assert "id_token" in data
+        claims = _decode(data["id_token"])
+        assert claims["aud"] == "demo-client"
+        assert claims["token_use"] == "id"
+
+    def test_device_flow_without_openid_has_no_id_token(self, client, auth_header):
+        data = self._run(client, auth_header, "profile")
+        assert "id_token" not in data
+
+
+class TestClientCredentialsNoIdToken:
+    """client_credentials has no end-user → never emits an ID Token."""
+
+    def test_client_credentials_with_openid_has_no_id_token(self, client, auth_header):
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "openid"},
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        assert "id_token" not in json.loads(resp.data)

--- a/tests/test_issue_37_polish.py
+++ b/tests/test_issue_37_polish.py
@@ -1,0 +1,67 @@
+"""
+Tests for the minor polish items from the #32 review (issue #37):
+
+1. ``OAuthClient`` validates on direct attribute assignment.
+2. Discovery advertises ``azp`` in ``claims_supported``.
+3. ``_normalize_audiences`` rejects falsy non-list inputs instead of silently
+   returning ``[]``.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from nanoidp.config import OAuthClient
+from nanoidp.mcp_server import _normalize_audiences
+
+
+class TestValidateAssignment:
+    def test_blank_secret_assignment_raises(self):
+        client = OAuthClient(client_id="c1", client_secret="s1")
+        with pytest.raises(ValidationError):
+            client.client_secret = ""
+
+    def test_blank_client_id_assignment_raises(self):
+        client = OAuthClient(client_id="c1", client_secret="s1")
+        with pytest.raises(ValidationError):
+            client.client_id = ""
+
+    def test_non_list_audiences_assignment_raises(self):
+        client = OAuthClient(client_id="c1", client_secret="s1")
+        with pytest.raises(ValidationError):
+            client.additional_audiences = "api://x"
+
+    def test_valid_assignment_succeeds(self):
+        client = OAuthClient(client_id="c1", client_secret="s1")
+        client.additional_audiences = ["api://x"]
+        client.client_secret = "s2"
+        assert client.additional_audiences == ["api://x"]
+        assert client.client_secret == "s2"
+
+
+class TestDiscoveryAdvertisesAzp:
+    def test_azp_in_claims_supported(self, client):
+        resp = client.get("/.well-known/openid-configuration")
+        claims = json.loads(resp.data).get("claims_supported", [])
+        assert "azp" in claims
+
+
+class TestNormalizeAudiencesStrictness:
+    def test_none_returns_empty(self):
+        assert _normalize_audiences(None) == []
+
+    def test_empty_list_returns_empty(self):
+        assert _normalize_audiences([]) == []
+
+    def test_list_of_strings_passthrough(self):
+        assert _normalize_audiences(["a", "b"]) == ["a", "b"]
+
+    @pytest.mark.parametrize("falsy", ["", 0, False])
+    def test_falsy_non_list_rejected(self, falsy):
+        with pytest.raises(ValueError):
+            _normalize_audiences(falsy)
+
+    def test_non_string_items_rejected(self):
+        with pytest.raises(ValueError):
+            _normalize_audiences([123])

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -375,6 +375,35 @@ class TestMCPClientAdditionalAudiences:
         assert config.get_client("c").additional_audiences == ["aud://x"]
 
     @pytest.mark.asyncio
+    async def test_update_client_invalid_audiences_does_not_partially_mutate(self, tmp_path):
+        """A bad additional_audiences must not leave client_secret/description changed (#37)."""
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        await _execute_tool(
+            "create_client",
+            {"client_id": "c", "client_secret": "orig", "description": "orig-desc"},
+            config,
+        )
+
+        with pytest.raises(ValueError):
+            await _execute_tool(
+                "update_client",
+                {
+                    "client_id": "c",
+                    "client_secret": "newsecret",
+                    "description": "newdesc",
+                    "additional_audiences": "not-a-list",  # invalid → must raise
+                },
+                config,
+            )
+
+        # The failed update must not have applied the other fields.
+        client = config.get_client("c")
+        assert client.client_secret == "orig"
+        assert client.description == "orig-desc"
+        assert client.additional_audiences == []
+
+    @pytest.mark.asyncio
     async def test_get_client_reports_additional_audiences(self, tmp_path):
         from nanoidp.mcp_server import _execute_tool
         config = self._config(tmp_path)

--- a/tests/test_security_edge_cases.py
+++ b/tests/test_security_edge_cases.py
@@ -359,12 +359,12 @@ class TestTokenTypeValidation:
     'token_type' claim in the JWT payload.
     """
 
-    def test_refresh_token_can_access_userinfo(self, client, auth_header):
-        """Test that refresh tokens CAN access userinfo in NanoIDP.
+    def test_refresh_token_rejected_at_userinfo(self, client, auth_header):
+        """Refresh tokens must NOT be accepted at /userinfo (issue #34).
 
-        Note: NanoIDP does not validate token_type on userinfo endpoint.
-        This is acceptable for a dev tool - the token has a valid signature.
-        Production IdPs typically check token_type='access' here.
+        UserInfo requires an access token (OIDC Core §5.3.1). Tokens are marked
+        with ``token_use`` and the endpoint rejects anything that is not an access
+        token, even though the signature is valid.
         """
         # Get tokens including refresh token
         response = client.post('/token',
@@ -378,13 +378,11 @@ class TestTokenTypeValidation:
         data = json.loads(response.data)
         refresh_token = data.get('refresh_token')
 
-        if refresh_token:
-            # Refresh token CAN access userinfo in NanoIDP
-            response = client.get('/userinfo',
-                headers={'Authorization': f'Bearer {refresh_token}'}
-            )
-            # NanoIDP accepts any valid signed token
-            assert response.status_code == 200
+        assert refresh_token
+        response = client.get('/userinfo',
+            headers={'Authorization': f'Bearer {refresh_token}'}
+        )
+        assert response.status_code == 401
 
     def test_access_token_cannot_be_used_for_refresh(self, client, auth_header):
         """Test that access tokens cannot be used for refresh grant.

--- a/tests/test_security_edge_cases.py
+++ b/tests/test_security_edge_cases.py
@@ -362,9 +362,9 @@ class TestTokenTypeValidation:
     def test_refresh_token_rejected_at_userinfo(self, client, auth_header):
         """Refresh tokens must NOT be accepted at /userinfo (issue #34).
 
-        UserInfo requires an access token (OIDC Core §5.3.1). Tokens are marked
-        with ``token_use`` and the endpoint rejects anything that is not an access
-        token, even though the signature is valid.
+        UserInfo requires an access token (OIDC Core §5.3.1). NanoIDP marks
+        issued tokens with ``token_use`` and rejects tokens explicitly marked as
+        ID or refresh tokens, even though their signature is valid.
         """
         # Get tokens including refresh token
         response = client.post('/token',


### PR DESCRIPTION
Follow-ups from the code review of #32 (ID Token `aud` = `client_id`, shipped in 2.0.0). Each commit addresses one issue; a final commit folds in review findings.

## What's in here

### #34 — Harden the ID Token vs access-token boundary (security)
- Filter the resource audience (`oauth.audience`) out of the ID Token `aud`, even if a client lists it in `additional_audiences`.
- Add a `token_use` marker to every token (`access` / `id` / `refresh`), set authoritatively in `create_token` (not overridable via `extra_claims`).
- `/userinfo` rejects tokens marked as ID/refresh; `/introspect` reports ID Tokens as inactive. Refresh tokens stay introspectable (RFC 7662).
- **Deliberate compat (not strict) choice**: `/userinfo` rejects tokens *marked* id/refresh rather than requiring `token_use == "access"`, so legacy and hand-crafted-with-IdP-key tokens (a first-class dev-IdP workflow) keep working. The security goal still holds — the IdP marks every ID/refresh token it issues. Documented inline.

### #36 — Issue ID Tokens for password and device grants
- Thread the requested `scope` (and `nonce` where applicable) into `create_token` for the **password** and **device** (RFC 8628) grants — both authenticate an end-user.
- `client_credentials` intentionally excluded: no end-user → an ID Token would violate OIDC semantics.

### #35 — Friendlier malformed `additional_audiences` in `settings.yaml`
- Coerce a scalar (`additional_audiences: api://x`) into a one-element list.
- Raise a clear, client-scoped error for unsupported shapes instead of an opaque Pydantic `ValidationError` aborting startup.

### #37 — Minor polish
- `validate_assignment=True` on `OAuthClient` (enforces constraints on direct attribute assignment, e.g. MCP `update_client`).
- Advertise `azp` in discovery `claims_supported`.
- MCP `_normalize_audiences` rejects falsy non-list inputs instead of silently returning `[]`.

## Review findings addressed
- password grant: normalize an empty `nonce` field to `None` so no empty `nonce` claim is emitted.
- MCP `update_client`: normalize `additional_audiences` before mutating, so a bad value can't leave the client half-updated under `validate_assignment`.

## Tests
- 594 unit tests pass; 39/39 live E2E (`examples/test_agent.py`) pass.
- New: `test_id_token_grants.py`, `test_client_audiences_load.py`, `test_issue_37_polish.py`, plus classes added to `test_id_token_audience.py` and an `update_client` regression test in `test_mcp.py`.
- MCP server and E2E agent updated in-PR per project convention.

Closes #34, #35, #36, #37.
