### PR TITLE
fix: re-issue ID Token on refresh_token grant when openid was granted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- The **refresh_token** grant now re-issues an ID Token when the original grant
+  included the `openid` scope (OIDC Core §12.2, #39). The granted scope is
+  persisted in the refresh token claims and recovered on refresh; a `scope`
+  form parameter may narrow, but never broaden, the original grant (RFC 6749
+  §6 — broadening is rejected with `400`). The refreshed ID Token carries no
+  `nonce` (it binds the original authentication request). Refresh tokens minted
+  before this change have no persisted scope and keep the old behavior.
+- The MCP `generate_token` tool accepts an optional `scope` argument and
+  returns an `id_token` when `openid` is included, matching the HTTP token
+  endpoint.
+
 ## [2.1.0] - 2026-05-26
 
 ### Added

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -896,6 +896,11 @@ class NanoIDPTestAgent:
                 # Verify new token is different
                 token_changed = new_access != old_token
 
+                # The refresh token came from a grant that included 'openid',
+                # so the refresh must re-issue an ID Token (OIDC Core §12.2,
+                # issue #39).
+                has_id_token = "id_token" in data
+
                 if new_access:
                     self.access_token = new_access
                 if new_refresh:
@@ -904,9 +909,10 @@ class NanoIDPTestAgent:
                 return self._add_result(
                     "Refresh Token",
                     TestCategory.OAUTH,
-                    True,
-                    f"New token obtained, changed={token_changed}",
-                    {"token_changed": token_changed}
+                    has_id_token,
+                    f"New token obtained, changed={token_changed}, "
+                    f"id_token re-issued={has_id_token}",
+                    {"token_changed": token_changed, "has_id_token": has_id_token}
                 )
             error = response.json().get("error", "unknown")
             return self._add_result(

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -316,6 +316,15 @@ async def list_tools() -> list[Tool]:
                         "type": "object",
                         "description": "Additional claims to include in the token",
                     },
+                    "scope": {
+                        "type": "string",
+                        "description": (
+                            "Space-separated OAuth scopes (optional). Include "
+                            "'openid' to also receive an ID Token; the scope is "
+                            "persisted in the refresh token so refreshing "
+                            "re-issues an ID Token (OIDC Core §12.2)"
+                        ),
+                    },
                 },
                 "required": ["username"],
             },
@@ -654,14 +663,18 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             user=user,
             exp_minutes=arguments.get("expires_in_minutes", config.settings.token_expiry_minutes),
             extra_claims=arguments.get("extra_claims"),
+            scope=arguments.get("scope"),
         )
-        return {
+        result = {
             "success": True,
             "access_token": token_response["access_token"],
             "refresh_token": token_response["refresh_token"],
             "token_type": token_response["token_type"],
             "expires_in": token_response["expires_in"],
         }
+        if "id_token" in token_response:
+            result["id_token"] = token_response["id_token"]
+        return result
 
     elif name == "decode_token":
         import jwt as pyjwt

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -387,6 +387,41 @@ def token():
             )
             return abort(401, description="User not found")
 
+        # Recover the originally granted scope persisted in the refresh token
+        # so an ID Token is re-issued when 'openid' was granted (OIDC Core
+        # §12.2, issue #39). A 'scope' form parameter may narrow, but never
+        # broaden, the original grant (RFC 6749 §6). Refresh tokens minted
+        # before scope was persisted carry no scope claim and keep the old
+        # behavior: tokens are refreshed without an ID Token. The refreshed
+        # ID Token intentionally carries no nonce — that claim binds the
+        # original authentication request, not later refreshes.
+        original_scope = payload.get("scope") or ""
+        requested_scope = request.form.get("scope")
+        if requested_scope:
+            granted = set(original_scope.split())
+            rejected = [s for s in requested_scope.split() if s not in granted]
+            if rejected:
+                audit.log(
+                    event_type="token_request",
+                    endpoint="/token",
+                    method="POST",
+                    status="failed",
+                    username=username,
+                    client_id=client_id,
+                    details={
+                        "reason": "Requested scope exceeds originally granted scope",
+                        "grant_type": grant_type,
+                        "rejected_scopes": rejected,
+                    },
+                    **req_info,
+                )
+                return abort(
+                    400, description="Requested scope exceeds originally granted scope"
+                )
+            scope = requested_scope
+        else:
+            scope = original_scope or None
+
     # Password grant
     elif grant_type == "password":
         username = request.form.get("username", "").strip()

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -173,8 +173,13 @@ class TokenService:
             )
 
 
-        # Create refresh token (valid for 7 days)
+        # Create refresh token (valid for 7 days). The granted scope is
+        # persisted in its claims so the refresh_token grant can re-issue an
+        # ID Token when 'openid' was originally granted (OIDC Core §12.2,
+        # issue #39).
         refresh_extra = {"token_type": "refresh", "token_use": "refresh"}
+        if scope:
+            refresh_extra["scope"] = scope
         refresh_token = self.crypto.create_jwt(
             sub=user.username,
             issuer=settings.issuer,

--- a/tests/test_id_token_grants.py
+++ b/tests/test_id_token_grants.py
@@ -158,3 +158,86 @@ class TestClientCredentialsNoIdToken:
         )
         assert resp.status_code == 200
         assert "id_token" not in json.loads(resp.data)
+
+
+class TestRefreshGrantIdToken:
+    """The refresh_token grant re-issues an ID Token when the original scope
+    included ``openid`` (OIDC Core §12.2, issue #39).
+
+    The granted scope is persisted in the refresh token claims at issuance and
+    recovered on refresh; a ``scope`` form parameter may narrow, but never
+    broaden, the original grant (RFC 6749 §6).
+    """
+
+    def _password_grant(self, client, auth_header, scope=None):
+        data = {
+            "grant_type": "password",
+            "username": "admin",
+            "password": "admin",
+        }
+        if scope is not None:
+            data["scope"] = scope
+        resp = client.post("/token", data=data, headers=auth_header)
+        assert resp.status_code == 200
+        return json.loads(resp.data)
+
+    def _refresh(self, client, auth_header, refresh_token, scope=None):
+        data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        if scope is not None:
+            data["scope"] = scope
+        return client.post("/token", data=data, headers=auth_header)
+
+    def test_refresh_reissues_id_token_when_openid_granted(self, client, auth_header):
+        tokens = self._password_grant(client, auth_header, "openid profile")
+        resp = self._refresh(client, auth_header, tokens["refresh_token"])
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert "id_token" in data
+        claims = _decode(data["id_token"])
+        # Same contract as the original ID Token (issue #32): aud = client_id.
+        assert claims["aud"] == "demo-client"
+        assert claims["token_use"] == "id"
+        # The nonce binds the original authentication request, not refreshes.
+        assert "nonce" not in claims
+
+    def test_refresh_without_openid_has_no_id_token(self, client, auth_header):
+        tokens = self._password_grant(client, auth_header, "profile email")
+        resp = self._refresh(client, auth_header, tokens["refresh_token"])
+        assert resp.status_code == 200
+        assert "id_token" not in json.loads(resp.data)
+
+    def test_refresh_of_scopeless_grant_has_no_id_token(self, client, auth_header):
+        """Refresh tokens without a persisted scope (e.g. minted before #39)
+        keep the old behavior: tokens refresh fine, no ID Token."""
+        tokens = self._password_grant(client, auth_header)
+        resp = self._refresh(client, auth_header, tokens["refresh_token"])
+        assert resp.status_code == 200
+        assert "id_token" not in json.loads(resp.data)
+
+    def test_refresh_can_narrow_scope_dropping_openid(self, client, auth_header):
+        tokens = self._password_grant(client, auth_header, "openid profile")
+        resp = self._refresh(client, auth_header, tokens["refresh_token"], "profile")
+        assert resp.status_code == 200
+        assert "id_token" not in json.loads(resp.data)
+
+    def test_refresh_can_narrow_scope_keeping_openid(self, client, auth_header):
+        tokens = self._password_grant(client, auth_header, "openid profile")
+        resp = self._refresh(client, auth_header, tokens["refresh_token"], "openid")
+        assert resp.status_code == 200
+        assert "id_token" in json.loads(resp.data)
+
+    def test_refresh_cannot_broaden_scope(self, client, auth_header):
+        tokens = self._password_grant(client, auth_header, "profile")
+        resp = self._refresh(client, auth_header, tokens["refresh_token"], "openid profile")
+        assert resp.status_code == 400
+
+    def test_scope_survives_refresh_chains(self, client, auth_header):
+        """The refresh token returned by a refresh carries the scope forward,
+        so ID Tokens keep being re-issued across consecutive refreshes."""
+        tokens = self._password_grant(client, auth_header, "openid")
+        first = self._refresh(client, auth_header, tokens["refresh_token"])
+        assert first.status_code == 200
+        rotated = json.loads(first.data)["refresh_token"]
+        second = self._refresh(client, auth_header, rotated)
+        assert second.status_code == 200
+        assert "id_token" in json.loads(second.data)


### PR DESCRIPTION
Closes #39.

## What

Per OIDC Core §12.2, the `refresh_token` grant now returns a fresh `id_token` when the original grant included the `openid` scope.

## How

- **`services/token.py`** — `create_token()` persists the granted `scope` in the refresh token claims at issuance, so the grant survives across refreshes (including chained refreshes, since each refresh response mints a new refresh token through the same path).
- **`routes/oauth.py`** — the refresh branch recovers the persisted scope and passes it to `create_token()`. An optional `scope` form parameter may narrow, but never broaden, the original grant (RFC 6749 §6): broadening is rejected with `400` and audited. The refreshed ID Token carries no `nonce` — that claim binds the original authentication request, not later refreshes.
- **Backward compatible** — refresh tokens minted before this change carry no scope claim and keep the old behavior (tokens refresh fine, no ID Token).

## Sync (per project convention)

- MCP `generate_token` accepts an optional `scope` argument and returns `id_token` when `openid` is included.
- `examples/test_agent.py` `test_refresh_token` now asserts the re-issued ID Token (the preceding password grant already requested `openid`).

## Tests

7 new tests in `tests/test_id_token_grants.py` (`TestRefreshGrantIdToken`): re-issuance with correct `aud`/`token_use`/no-`nonce`, no ID Token without `openid`, legacy scopeless refresh tokens, narrowing (dropping/keeping `openid`), broadening rejected with 400, scope survival across refresh chains.

Full suite: **601 passed**.
