### PR TITLE
fix: single source of truth for OIDC discovery, honest response_types, full MCP docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The MCP `get_oidc_discovery` tool now returns the exact same document as the
+  HTTP `/.well-known/openid-configuration` endpoint (#40). Both build it via a
+  new shared helper (`services.discovery.build_discovery_document`), so the
+  MCP tool now advertises `claims_supported` (including `azp`),
+  `response_types_supported`, `id_token_signing_alg_values_supported`,
+  `code_challenge_methods_supported` and the endpoint auth methods — and the
+  two documents can no longer drift apart.
+- Discovery no longer advertises the `token` response type (#41): the implicit
+  flow was never implemented (`/authorize` only accepts `response_type=code`)
+  and is deprecated by the OAuth 2.0 Security BCP, so advertising it misled
+  clients. `response_types_supported` is now `["code"]`.
+
+### Documentation
+- The MCP tools table in the README now lists all 19 tools (#44): it was
+  missing `create_client`, `update_client`, `delete_client`, `update_user`,
+  `update_settings` and `save_config`. (`docs/MCP_WORKFLOW.md` was already
+  complete.)
+
 ### Added
 - The **refresh_token** grant now re-issues an ID Token when the original grant
   included the `openid` scope (OIDC Core §12.2, #39). The granted scope is

--- a/README.md
+++ b/README.md
@@ -531,15 +531,21 @@ NanoIDP includes an MCP server for integration with Claude Code and other MCP-co
 | `list_users` | List all configured users |
 | `get_user` | Get details of a specific user |
 | `create_user` | Create a new user |
+| `update_user` | Update an existing user (password, email, roles, …) |
 | `delete_user` | Delete a user |
-| `generate_token` | Generate OAuth2 access token for a user |
+| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token) |
 | `decode_token` | Decode JWT token (without verification) |
 | `verify_token` | Verify JWT token signature and expiration |
 | `list_clients` | List OAuth clients |
 | `get_client` | Get client details |
+| `create_client` | Create a new OAuth client |
+| `update_client` | Update an existing OAuth client |
+| `delete_client` | Delete an OAuth client |
 | `get_settings` | Get current IdP settings |
+| `update_settings` | Update IdP settings |
+| `save_config` | Persist the current configuration to the YAML files |
 | `reload_config` | Reload configuration from files |
-| `get_oidc_discovery` | Get OIDC discovery document |
+| `get_oidc_discovery` | Get OIDC discovery document (same document as `/.well-known/openid-configuration`) |
 | `get_jwks` | Get JSON Web Key Set |
 
 ### Claude Code CLI Configuration

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -26,7 +26,13 @@ from mcp.server.stdio import stdio_server
 from mcp.types import Tool, TextContent
 
 from .config import ConfigManager, User, OAuthClient, init_config, get_config
-from .services import init_crypto_service, get_crypto_service, get_token_service, get_audit_log
+from .services import (
+    init_crypto_service,
+    get_crypto_service,
+    get_token_service,
+    get_audit_log,
+    build_discovery_document,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -828,26 +834,9 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
 
     # Discovery
     elif name == "get_oidc_discovery":
-        settings = config.settings
-        return {
-            "issuer": settings.issuer,
-            "authorization_endpoint": f"{settings.issuer}/authorize",
-            "token_endpoint": f"{settings.issuer}/token",
-            "userinfo_endpoint": f"{settings.issuer}/userinfo",
-            "introspection_endpoint": f"{settings.issuer}/introspect",
-            "revocation_endpoint": f"{settings.issuer}/revoke",
-            "end_session_endpoint": f"{settings.issuer}/logout",
-            "device_authorization_endpoint": f"{settings.issuer}/device_authorization",
-            "jwks_uri": f"{settings.issuer}/.well-known/jwks.json",
-            "grant_types_supported": [
-                "authorization_code",
-                "client_credentials",
-                "password",
-                "refresh_token",
-                "urn:ietf:params:oauth:grant-type:device_code",
-            ],
-            "scopes_supported": ["openid", "profile", "email", "offline_access"],
-        }
+        # Shared with the HTTP /.well-known/openid-configuration endpoint so
+        # the two documents can never drift apart (issue #40).
+        return build_discovery_document(config.settings)
 
     elif name == "get_jwks":
         crypto = get_crypto_service(config.settings.keys_dir)

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -8,7 +8,13 @@ from urllib.parse import urlencode, urlparse
 from flask import Blueprint, request, jsonify, abort, redirect, render_template, session, url_for
 
 from ..config import get_config, User
-from ..services import get_token_service, get_crypto_service, get_audit_log, get_auth_code_store
+from ..services import (
+    get_token_service,
+    get_crypto_service,
+    get_audit_log,
+    get_auth_code_store,
+    build_discovery_document,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,41 +35,7 @@ def _get_request_info():
 def oidc_config():
     """OIDC Discovery endpoint."""
     config = get_config()
-    settings = config.settings
-
-    return jsonify(
-        {
-            "issuer": settings.issuer,
-            "authorization_endpoint": f"{settings.issuer}/authorize",
-            "token_endpoint": f"{settings.issuer}/token",
-            "userinfo_endpoint": f"{settings.issuer}/userinfo",
-            "introspection_endpoint": f"{settings.issuer}/introspect",
-            "revocation_endpoint": f"{settings.issuer}/revoke",
-            "end_session_endpoint": f"{settings.issuer}/logout",
-            "device_authorization_endpoint": f"{settings.issuer}/device_authorization",
-            "jwks_uri": f"{settings.issuer}/.well-known/jwks.json",
-            "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
-            "introspection_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
-            "revocation_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
-            "response_types_supported": ["code", "token"],
-            "id_token_signing_alg_values_supported": ["RS256"],
-            "scopes_supported": ["openid", "profile", "email", "offline_access"],
-            "claims_supported": [
-                "sub", "iss", "aud", "azp", "exp", "iat", "nbf",
-                "email", "email_verified", "preferred_username",
-                "roles", "tenant", "identity_class", "entitlements",
-                "source_acl", "attributes", "authorities"
-            ],
-            "grant_types_supported": [
-                "authorization_code",
-                "client_credentials",
-                "password",
-                "refresh_token",
-                "urn:ietf:params:oauth:grant-type:device_code",
-            ],
-            "code_challenge_methods_supported": ["plain", "S256"],
-        }
-    )
+    return jsonify(build_discovery_document(config.settings))
 
 
 @oauth_bp.route("/.well-known/jwks.json")

--- a/src/nanoidp/services/__init__.py
+++ b/src/nanoidp/services/__init__.py
@@ -5,8 +5,10 @@ from .token import TokenService, get_token_service
 from .audit import AuditLog, get_audit_log
 from .yaml_writer import YamlWriter, get_yaml_writer
 from .auth_code import AuthCodeStore, AuthorizationCode, get_auth_code_store
+from .discovery import build_discovery_document
 
 __all__ = [
+    "build_discovery_document",
     "CryptoService",
     "get_crypto_service",
     "init_crypto_service",

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -1,0 +1,57 @@
+"""
+Single source of truth for the OIDC discovery document.
+
+Both the HTTP endpoint (``/.well-known/openid-configuration``) and the MCP
+``get_oidc_discovery`` tool build their response here, so the two can never
+drift apart (issue #40 — the MCP tool used to return an abbreviated dict that
+omitted ``claims_supported``/``azp`` and the auth-method metadata).
+"""
+
+from typing import Any, Dict
+
+from ..config import Settings
+
+
+def build_discovery_document(settings: Settings) -> Dict[str, Any]:
+    """Build the OIDC discovery metadata for the given settings.
+
+    Every value advertised here must reflect what the endpoints actually
+    implement — the document is a contract, and for a dev IdP a misleading
+    entry is worse than a missing feature (see issue #41: ``token`` was
+    advertised in ``response_types_supported`` while ``/authorize`` only
+    accepts ``code``).
+    """
+    issuer = settings.issuer
+    return {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/authorize",
+        "token_endpoint": f"{issuer}/token",
+        "userinfo_endpoint": f"{issuer}/userinfo",
+        "introspection_endpoint": f"{issuer}/introspect",
+        "revocation_endpoint": f"{issuer}/revoke",
+        "end_session_endpoint": f"{issuer}/logout",
+        "device_authorization_endpoint": f"{issuer}/device_authorization",
+        "jwks_uri": f"{issuer}/.well-known/jwks.json",
+        "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+        "introspection_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+        "revocation_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+        # Only the authorization code flow is implemented; the implicit flow is
+        # deprecated by the OAuth 2.0 Security BCP and intentionally absent.
+        "response_types_supported": ["code"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "scopes_supported": ["openid", "profile", "email", "offline_access"],
+        "claims_supported": [
+            "sub", "iss", "aud", "azp", "exp", "iat", "nbf",
+            "email", "email_verified", "preferred_username",
+            "roles", "tenant", "identity_class", "entitlements",
+            "source_acl", "attributes", "authorities"
+        ],
+        "grant_types_supported": [
+            "authorization_code",
+            "client_credentials",
+            "password",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ],
+        "code_challenge_methods_supported": ["plain", "S256"],
+    }

--- a/tests/test_discovery_parity.py
+++ b/tests/test_discovery_parity.py
@@ -1,0 +1,63 @@
+"""
+Tests for the shared OIDC discovery document (issues #40 and #41).
+
+The HTTP ``/.well-known/openid-configuration`` endpoint and the MCP
+``get_oidc_discovery`` tool both build their response via
+``services.discovery.build_discovery_document``, so the two documents must be
+identical — the MCP tool used to return an abbreviated dict that omitted
+``claims_supported``/``azp`` and the auth-method metadata (#40).
+
+The document must also only advertise what the endpoints implement: the
+implicit flow was never supported, so ``response_types_supported`` must not
+list ``token`` (#41).
+"""
+
+import json
+
+import pytest
+
+from nanoidp.config import get_config
+from nanoidp.mcp_server import _execute_tool
+
+
+class TestDiscoveryParity:
+    """MCP and HTTP discovery come from one helper and can't drift (#40)."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_discovery_matches_http_document(self, client):
+        http_doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        mcp_doc = await _execute_tool("get_oidc_discovery", {}, get_config())
+        assert mcp_doc == http_doc
+
+    @pytest.mark.asyncio
+    async def test_mcp_discovery_advertises_azp(self):
+        doc = await _execute_tool("get_oidc_discovery", {}, get_config())
+        assert "azp" in doc["claims_supported"]
+
+    @pytest.mark.asyncio
+    async def test_mcp_discovery_advertises_pkce_and_auth_methods(self):
+        doc = await _execute_tool("get_oidc_discovery", {}, get_config())
+        assert doc["code_challenge_methods_supported"] == ["plain", "S256"]
+        assert "client_secret_basic" in doc["token_endpoint_auth_methods_supported"]
+        assert "RS256" in doc["id_token_signing_alg_values_supported"]
+
+
+class TestResponseTypesHonest:
+    """Discovery only advertises response types /authorize accepts (#41)."""
+
+    def test_response_types_supported_is_code_only(self, client):
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        assert doc["response_types_supported"] == ["code"]
+
+    def test_authorize_rejects_token_response_type(self, client):
+        resp = client.get(
+            "/authorize",
+            query_string={
+                "response_type": "token",
+                "client_id": "demo-client",
+                "redirect_uri": "http://localhost:9000/callback",
+            },
+        )
+        data = json.loads(resp.data)
+        assert resp.status_code == 400
+        assert data["error"] == "unsupported_response_type"


### PR DESCRIPTION
Closes #40, closes #41, closes #44.

## What

Three discovery/MCP-metadata issues fixed together, since they touch the same surface.

### #40 — MCP discovery parity
New shared helper `services/discovery.py::build_discovery_document()` is now the single source of truth for the discovery document. Both the HTTP `/.well-known/openid-configuration` route and the MCP `get_oidc_discovery` tool call it, so the MCP tool now advertises everything the HTTP document does — `claims_supported` (including `azp`, per the #37 contract), `response_types_supported`, `id_token_signing_alg_values_supported`, `code_challenge_methods_supported`, and the endpoint auth methods — and the two documents can never drift again.

### #41 — honest response_types
`response_types_supported` no longer lists `token`: `/authorize` only accepts `response_type=code`, and the implicit flow is deprecated by the OAuth 2.0 Security BCP, so advertising it just misled clients. Resolved by removing the advertisement rather than implementing the flow, as recommended in the issue.

### #44 — complete MCP tools docs
The README tools table now lists all 19 tools (was 13: `create_user`→ok but `update_user`, `create_client`, `update_client`, `delete_client`, `update_settings`, `save_config` were missing). Note: the issue also flagged `docs/MCP_WORKFLOW.md`, but that table was already complete — only the README needed fixing.

## Tests

- New `tests/test_discovery_parity.py`: MCP output == HTTP output (field-for-field via `_execute_tool`), `azp`/PKCE/auth-methods advertised over MCP, `response_types_supported == ["code"]`, and `/authorize` returning `unsupported_response_type` (400) for `response_type=token`.
- Full suite: **606 passed**.
- E2E: `examples/test_agent.py` against a live server — **39/39 passed** (includes the discovery `azp` check and the #39 refresh ID Token assertion).
