### PR TITLE
Thread-safety for shared state (#43) + auth_time/at_hash ID Token claims (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ID Tokens now carry `auth_time` and `at_hash` (#42). `auth_time` reflects
+  when the end-user actually authenticated: the login page for the
+  authorization code flow, the `/device` verification for the device flow,
+  the request itself for the password grant — and it is preserved unchanged
+  across refreshes (OIDC Core §12.2), carried in the refresh token claims
+  like the scope (#39). `at_hash` binds the ID Token to the access token
+  issued alongside it (left half of SHA-256, base64url — §3.1.3.6).
+  Discovery `claims_supported` now also advertises `auth_time`, `nonce` and
+  `at_hash`.
+
 ### Fixed
+- Thread-safety hardening for shared in-memory state (#43): the
+  authorization code store now performs its check-then-mark sequence under a
+  lock (one-time use can no longer be defeated by concurrent redemptions),
+  device codes are claimed/transitioned atomically and pruned when expired,
+  and the lazily-created service singletons (config, token, crypto, audit,
+  auth codes) use double-checked locking so concurrent first access creates
+  exactly one instance.
 - The MCP `get_oidc_discovery` tool now returns the exact same document as the
   HTTP `/.well-known/openid-configuration` endpoint (#40). Both build it via a
   new shared helper (`services.discovery.build_discovery_document`), so the

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -561,6 +561,63 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("ID Token Audience", TestCategory.OAUTH, False, str(e))
 
+    def test_id_token_time_claims(self) -> TestResult:
+        """ID Token carries auth_time and a valid at_hash (issue #42)."""
+        try:
+            if not jwt:
+                return self._add_result(
+                    "ID Token Time Claims", TestCategory.OAUTH, False,
+                    "PyJWT not installed; cannot decode tokens"
+                )
+
+            import base64 as b64
+            import hashlib
+            import time as time_mod
+
+            before = int(time_mod.time())
+            response = self.session.post(
+                f"{self.base_url}/token",
+                data={
+                    "grant_type": "password",
+                    "username": self.username,
+                    "password": self.password,
+                    "scope": "openid",
+                },
+                timeout=5,
+            )
+            after = int(time_mod.time())
+            if response.status_code != 200:
+                return self._add_result(
+                    "ID Token Time Claims", TestCategory.OAUTH, False,
+                    f"Status: {response.status_code}"
+                )
+
+            data = response.json()
+            claims = jwt.decode(data["id_token"], options={"verify_signature": False})
+
+            auth_time = claims.get("auth_time")
+            auth_time_ok = auth_time is not None and before <= auth_time <= after
+
+            # at_hash = base64url(left half of SHA-256(access_token)), §3.1.3.6
+            digest = hashlib.sha256(data["access_token"].encode("ascii")).digest()
+            expected_at_hash = b64.urlsafe_b64encode(digest[:16]).rstrip(b"=").decode("ascii")
+            at_hash_ok = claims.get("at_hash") == expected_at_hash
+
+            ok = auth_time_ok and at_hash_ok
+            return self._add_result(
+                "ID Token Time Claims",
+                TestCategory.OAUTH,
+                ok,
+                f"auth_time valid={auth_time_ok}, at_hash valid={at_hash_ok}",
+                {
+                    "auth_time": auth_time,
+                    "at_hash": claims.get("at_hash"),
+                    "expected_at_hash": expected_at_hash,
+                },
+            )
+        except Exception as e:
+            return self._add_result("ID Token Time Claims", TestCategory.OAUTH, False, str(e))
+
     def test_id_token_audience_array(self) -> TestResult:
         """A client with additional_audiences gets an array `aud` plus `azp` (issue #32).
 
@@ -2423,6 +2480,7 @@ class NanoIDPTestAgent:
                 self.test_client_credentials,
                 self.test_authorization_code_pkce,
                 self.test_id_token_audience,
+                self.test_id_token_time_claims,
                 self.test_id_token_audience_array,
                 self.test_id_token_not_accepted_as_access_token,
                 self.test_device_flow,

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -6,6 +6,7 @@ Uses Pydantic for validation and schema enforcement.
 
 import os
 import re
+import threading
 import yaml
 import logging
 from typing import Dict, List, Optional, Any
@@ -515,13 +516,16 @@ class ConfigManager:
 
 # Global config instance
 _config: Optional[ConfigManager] = None
+_config_lock = threading.Lock()
 
 
 def get_config() -> ConfigManager:
-    """Get the global config instance."""
+    """Get the global config instance (thread-safe lazy init, issue #43)."""
     global _config
     if _config is None:
-        _config = ConfigManager()
+        with _config_lock:
+            if _config is None:
+                _config = ConfigManager()
     return _config
 
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -242,6 +242,7 @@ def token():
     client_id = body_client_id or auth_client_id
     nonce = None
     scope = None
+    auth_time = None
 
     # Reject if client identity cannot be determined at all
     if not client_id:
@@ -395,6 +396,10 @@ def token():
         else:
             scope = original_scope or None
 
+        # A refreshed ID Token must carry the ORIGINAL authentication time
+        # (OIDC Core §12.2), persisted in the refresh token claims (#42).
+        auth_time = payload.get("auth_time")
+
     # Password grant
     elif grant_type == "password":
         username = request.form.get("username", "").strip()
@@ -505,11 +510,15 @@ def token():
             )
             return abort(401, description="User not found")
 
-        if auth_code.nonce is not None: 
+        if auth_code.nonce is not None:
             nonce = auth_code.nonce
-        
+
         if auth_code.scope is not None:
             scope = auth_code.scope
+
+        # The user authenticated at the login page when the code was created,
+        # not at this token exchange — use that moment as auth_time (#42).
+        auth_time = int(auth_code.created_at.timestamp())
 
     # Client credentials grant
     elif grant_type == "client_credentials":
@@ -613,6 +622,8 @@ def token():
                 # The device flow authenticates an end-user, so honour the requested
                 # scope and emit an ID Token when 'openid' was asked for (issue #36).
                 scope = device_info.get("scope")
+                # The user authenticated at /device, not at this poll (#42).
+                auth_time = device_info.get("auth_time")
 
                 # Clean up the device code (one-time use)
                 user_code = device_info["user_code"]
@@ -658,6 +669,7 @@ def token():
         nonce=nonce,
         scope=scope,
         client_id=client_id,
+        auth_time=auth_time,
     )
 
     # Audit log
@@ -1240,6 +1252,7 @@ def device_verify():
                             # Authorization successful
                             device_info["status"] = "authorized"
                             device_info["username"] = user.username
+                            device_info["auth_time"] = int(time.time())
                             success_msg = "Device authorized successfully! You can close this window."
 
                             audit.log(

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -4,6 +4,7 @@ OAuth2/OIDC routes for token endpoint and discovery.
 
 import json
 import logging
+import threading
 from urllib.parse import urlencode, urlparse
 from flask import Blueprint, request, jsonify, abort, redirect, render_template, session, url_for
 
@@ -543,81 +544,85 @@ def token():
                 "error_description": "device_code is required"
             }), 400
 
-        # Look up device code
-        device_info = _device_codes.get(device_code)
-        if not device_info:
-            audit.log(
-                event_type="token_request",
-                endpoint="/token",
-                method="POST",
-                status="failed",
-                client_id=client_id,
-                details={"reason": "Invalid device_code", "grant_type": grant_type},
-                **req_info,
-            )
-            return jsonify({
-                "error": "invalid_grant",
-                "error_description": "Invalid device code"
-            }), 400
+        # The whole lookup-check-claim sequence runs under the device codes
+        # lock so two concurrent polls can't both claim the same authorized
+        # code (one-time use, issue #43).
+        with _device_codes_lock:
+            # Look up device code
+            device_info = _device_codes.get(device_code)
+            if not device_info:
+                audit.log(
+                    event_type="token_request",
+                    endpoint="/token",
+                    method="POST",
+                    status="failed",
+                    client_id=client_id,
+                    details={"reason": "Invalid device_code", "grant_type": grant_type},
+                    **req_info,
+                )
+                return jsonify({
+                    "error": "invalid_grant",
+                    "error_description": "Invalid device code"
+                }), 400
 
-        # Check client_id matches
-        if device_info["client_id"] != client_id:
-            return jsonify({
-                "error": "invalid_grant",
-                "error_description": "Device code was not issued to this client"
-            }), 400
+            # Check client_id matches
+            if device_info["client_id"] != client_id:
+                return jsonify({
+                    "error": "invalid_grant",
+                    "error_description": "Device code was not issued to this client"
+                }), 400
 
-        # Check expiration
-        import time as time_module
-        if time_module.time() > device_info["expires_at"]:
-            device_info["status"] = "expired"
-            return jsonify({
-                "error": "expired_token",
-                "error_description": "Device code has expired"
-            }), 400
+            # Check expiration
+            import time as time_module
+            if time_module.time() > device_info["expires_at"]:
+                device_info["status"] = "expired"
+                return jsonify({
+                    "error": "expired_token",
+                    "error_description": "Device code has expired"
+                }), 400
 
-        # Check status
-        status = device_info["status"]
-        if status == "pending":
-            # User hasn't authorized yet - tell client to slow down/retry
-            return jsonify({
-                "error": "authorization_pending",
-                "error_description": "User has not yet authorized the device"
-            }), 400
-        elif status == "denied":
-            # User denied the request
-            return jsonify({
-                "error": "access_denied",
-                "error_description": "User denied the authorization request"
-            }), 400
-        elif status == "expired":
-            return jsonify({
-                "error": "expired_token",
-                "error_description": "Device code has expired"
-            }), 400
-        elif status == "authorized":
-            # Success! Get the user and issue tokens
-            username = device_info["username"]
-            user = config.get_user(username)
-            if not user:
+            # Check status
+            status = device_info["status"]
+            if status == "pending":
+                # User hasn't authorized yet - tell client to slow down/retry
+                return jsonify({
+                    "error": "authorization_pending",
+                    "error_description": "User has not yet authorized the device"
+                }), 400
+            elif status == "denied":
+                # User denied the request
+                return jsonify({
+                    "error": "access_denied",
+                    "error_description": "User denied the authorization request"
+                }), 400
+            elif status == "expired":
+                return jsonify({
+                    "error": "expired_token",
+                    "error_description": "Device code has expired"
+                }), 400
+            elif status == "authorized":
+                # Success! Get the user and issue tokens
+                username = device_info["username"]
+                user = config.get_user(username)
+                if not user:
+                    return jsonify({
+                        "error": "server_error",
+                        "error_description": "User not found"
+                    }), 500
+
+                # The device flow authenticates an end-user, so honour the requested
+                # scope and emit an ID Token when 'openid' was asked for (issue #36).
+                scope = device_info.get("scope")
+
+                # Clean up the device code (one-time use)
+                user_code = device_info["user_code"]
+                del _device_codes[device_code]
+                del _device_codes[f"user:{user_code}"]
+            else:
                 return jsonify({
                     "error": "server_error",
-                    "error_description": "User not found"
+                    "error_description": "Unknown device code status"
                 }), 500
-
-            # The device flow authenticates an end-user, so honour the requested
-            # scope and emit an ID Token when 'openid' was asked for (issue #36).
-            scope = device_info.get("scope")
-
-            # Clean up the device code (one-time use)
-            user_code = device_info["user_code"]
-            del _device_codes[device_code]
-            del _device_codes[f"user:{user_code}"]
-        else:
-            return jsonify({
-                "error": "server_error",
-                "error_description": "Unknown device code status"
-            }), 500
 
     # Unknown grant type
     else:
@@ -676,7 +681,9 @@ def token():
     return jsonify(token_response)
 
 
-# Token blacklist for revocation (in-memory)
+# Token blacklist for revocation (in-memory). No lock needed: only single
+# `add`/`in` operations, atomic under the GIL — there is no compound
+# check-then-act sequence to protect (unlike _device_codes above, see #43).
 _revoked_tokens: set = set()
 
 
@@ -1033,8 +1040,33 @@ import secrets
 import time
 from datetime import datetime, timedelta
 
-# In-memory storage for device codes
+# In-memory storage for device codes. All compound accesses (lookup + status
+# mutation / deletion) must hold the lock: Flask serves requests on multiple
+# threads and the polling client races against the user's verification and
+# against its own retries (issue #43).
 _device_codes: dict = {}
+_device_codes_lock = threading.RLock()
+
+
+def _prune_expired_device_codes() -> None:
+    """Drop expired device codes so they don't pile up on long-running servers.
+
+    Called on each new device authorization; entries past ``expires_at`` are
+    removed together with their ``user:<code>`` index.
+    """
+    now = time.time()
+    with _device_codes_lock:
+        expired = [
+            code
+            for code, info in _device_codes.items()
+            if not code.startswith("user:") and now > info["expires_at"]
+        ]
+        for code in expired:
+            user_code = _device_codes[code].get("user_code")
+            del _device_codes[code]
+            _device_codes.pop(f"user:{user_code}", None)
+    if expired:
+        logger.debug(f"Pruned {len(expired)} expired device codes")
 
 
 def _generate_user_code() -> str:
@@ -1092,19 +1124,21 @@ def device_authorization():
     expires_in = 600
     interval = 5  # Polling interval in seconds
 
-    # Store device code info
-    _device_codes[device_code] = {
-        "user_code": user_code,
-        "client_id": client_id,
-        "scope": scope,
-        "expires_at": time.time() + expires_in,
-        "interval": interval,
-        "status": "pending",  # pending, authorized, denied, expired
-        "username": None,
-    }
+    # Store device code info (and drop stale entries while we're at it)
+    _prune_expired_device_codes()
+    with _device_codes_lock:
+        _device_codes[device_code] = {
+            "user_code": user_code,
+            "client_id": client_id,
+            "scope": scope,
+            "expires_at": time.time() + expires_in,
+            "interval": interval,
+            "status": "pending",  # pending, authorized, denied, expired
+            "username": None,
+        }
 
-    # Also index by user_code for easy lookup during verification
-    _device_codes[f"user:{user_code}"] = device_code
+        # Also index by user_code for easy lookup during verification
+        _device_codes[f"user:{user_code}"] = device_code
 
     audit.log(
         event_type="device_authorization_request",
@@ -1162,59 +1196,62 @@ def device_verify():
         if not device_code:
             error_msg = "Invalid or expired user code"
         else:
-            device_info = _device_codes.get(device_code)
-            if not device_info:
-                error_msg = "Invalid or expired user code"
-            elif device_info["status"] != "pending":
-                error_msg = "This code has already been used"
-            elif time.time() > device_info["expires_at"]:
-                device_info["status"] = "expired"
-                error_msg = "This code has expired"
-            elif action == "deny":
-                device_info["status"] = "denied"
-                success_msg = "Device authorization denied"
-                audit.log(
-                    event_type="device_verification",
-                    endpoint="/device",
-                    method="POST",
-                    status="denied",
-                    username=username,
-                    details={"user_code": user_code},
-                    **req_info,
-                )
-            else:
-                # Validate user credentials
-                if not username or not password:
-                    error_msg = "Username and password are required"
+            # check-status + transition must be atomic so two concurrent
+            # verifications can't both claim the same pending code (issue #43)
+            with _device_codes_lock:
+                device_info = _device_codes.get(device_code)
+                if not device_info:
+                    error_msg = "Invalid or expired user code"
+                elif device_info["status"] != "pending":
+                    error_msg = "This code has already been used"
+                elif time.time() > device_info["expires_at"]:
+                    device_info["status"] = "expired"
+                    error_msg = "This code has expired"
+                elif action == "deny":
+                    device_info["status"] = "denied"
+                    success_msg = "Device authorization denied"
+                    audit.log(
+                        event_type="device_verification",
+                        endpoint="/device",
+                        method="POST",
+                        status="denied",
+                        username=username,
+                        details={"user_code": user_code},
+                        **req_info,
+                    )
                 else:
-                    user = config.authenticate(username, password)
-                    if not user:
-                        error_msg = "Invalid username or password"
-                        audit.log(
-                            event_type="device_verification",
-                            endpoint="/device",
-                            method="POST",
-                            status="failed",
-                            username=username,
-                            details={"user_code": user_code, "reason": "Invalid credentials"},
-                            **req_info,
-                        )
+                    # Validate user credentials
+                    if not username or not password:
+                        error_msg = "Username and password are required"
                     else:
-                        # Authorization successful
-                        device_info["status"] = "authorized"
-                        device_info["username"] = user.username
-                        success_msg = "Device authorized successfully! You can close this window."
+                        user = config.authenticate(username, password)
+                        if not user:
+                            error_msg = "Invalid username or password"
+                            audit.log(
+                                event_type="device_verification",
+                                endpoint="/device",
+                                method="POST",
+                                status="failed",
+                                username=username,
+                                details={"user_code": user_code, "reason": "Invalid credentials"},
+                                **req_info,
+                            )
+                        else:
+                            # Authorization successful
+                            device_info["status"] = "authorized"
+                            device_info["username"] = user.username
+                            success_msg = "Device authorized successfully! You can close this window."
 
-                        audit.log(
-                            event_type="device_verification",
-                            endpoint="/device",
-                            method="POST",
-                            status="success",
-                            username=user.username,
-                            details={"user_code": user_code},
-                            **req_info,
-                        )
-                        logger.info(f"Device authorized for user '{user.username}', user_code: {user_code}")
+                            audit.log(
+                                event_type="device_verification",
+                                endpoint="/device",
+                                method="POST",
+                                status="success",
+                                username=user.username,
+                                details={"user_code": user_code},
+                                **req_info,
+                            )
+                            logger.info(f"Device authorized for user '{user.username}', user_code: {user_code}")
 
     return render_template(
         "device.html",

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -181,11 +181,14 @@ class AuditLog:
 
 # Global audit log instance
 _audit_log: Optional[AuditLog] = None
+_audit_log_lock = Lock()
 
 
 def get_audit_log() -> AuditLog:
-    """Get or create the global audit log."""
+    """Get or create the global audit log (thread-safe lazy init, #43)."""
     global _audit_log
     if _audit_log is None:
-        _audit_log = AuditLog()
+        with _audit_log_lock:
+            if _audit_log is None:
+                _audit_log = AuditLog()
     return _audit_log

--- a/src/nanoidp/services/auth_code.py
+++ b/src/nanoidp/services/auth_code.py
@@ -7,6 +7,7 @@ import hashlib
 import base64
 import secrets
 import logging
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
@@ -39,6 +40,11 @@ class AuthCodeStore:
 
     def __init__(self):
         self._codes: Dict[str, AuthorizationCode] = {}
+        # Flask serves requests on multiple threads; every access to the shared
+        # dict goes through this lock so consume_code stays atomic and one-time
+        # use can't be defeated by two concurrent redemptions (issue #43).
+        # RLock because create_code calls _cleanup_expired while holding it.
+        self._lock = threading.RLock()
 
     def create_code(
         self,
@@ -67,9 +73,6 @@ class AuthCodeStore:
         Returns:
             The generated authorization code
         """
-        # Clean up expired codes
-        self._cleanup_expired()
-
         # Generate a secure random code
         code = secrets.token_urlsafe(32)
 
@@ -85,7 +88,10 @@ class AuthCodeStore:
             state=state,
         )
 
-        self._codes[code] = auth_code
+        with self._lock:
+            # Clean up expired codes
+            self._cleanup_expired()
+            self._codes[code] = auth_code
 
         # Verbose logging controlled by settings (late import to avoid circular dependency)
         try:
@@ -120,47 +126,51 @@ class AuthCodeStore:
         Returns:
             The AuthorizationCode if valid, None otherwise
         """
-        auth_code = self._codes.get(code)
+        # The whole check-then-mark sequence runs under the lock so two
+        # concurrent redemptions of the same code can't both pass the
+        # one-time-use check (issue #43).
+        with self._lock:
+            auth_code = self._codes.get(code)
 
-        if not auth_code:
-            logger.warning(f"Authorization code not found: {code[:8]}...")
-            return None
-
-        # Check if code is expired
-        if datetime.now(timezone.utc) > auth_code.expires_at:
-            logger.warning(f"Authorization code expired: {code[:8]}...")
-            del self._codes[code]
-            return None
-
-        # Check if code was already used (one-time use per RFC 6749)
-        if auth_code.used:
-            logger.warning(f"Authorization code already used: {code[:8]}...")
-            # Revoke all tokens issued with this code (security measure)
-            del self._codes[code]
-            return None
-
-        # Validate client_id
-        if auth_code.client_id != client_id:
-            logger.warning(f"Client ID mismatch for code {code[:8]}...")
-            return None
-
-        # Validate redirect_uri
-        if auth_code.redirect_uri != redirect_uri:
-            logger.warning(f"Redirect URI mismatch for code {code[:8]}...")
-            return None
-
-        # Validate PKCE if code_challenge was provided during authorization
-        if auth_code.code_challenge:
-            if not code_verifier:
-                logger.warning(f"PKCE code_verifier required but not provided for code {code[:8]}...")
+            if not auth_code:
+                logger.warning(f"Authorization code not found: {code[:8]}...")
                 return None
 
-            if not self._verify_pkce(code_verifier, auth_code.code_challenge, auth_code.code_challenge_method):
-                logger.warning(f"PKCE verification failed for code {code[:8]}...")
+            # Check if code is expired
+            if datetime.now(timezone.utc) > auth_code.expires_at:
+                logger.warning(f"Authorization code expired: {code[:8]}...")
+                del self._codes[code]
                 return None
 
-        # Mark as used
-        auth_code.used = True
+            # Check if code was already used (one-time use per RFC 6749)
+            if auth_code.used:
+                logger.warning(f"Authorization code already used: {code[:8]}...")
+                # Revoke all tokens issued with this code (security measure)
+                del self._codes[code]
+                return None
+
+            # Validate client_id
+            if auth_code.client_id != client_id:
+                logger.warning(f"Client ID mismatch for code {code[:8]}...")
+                return None
+
+            # Validate redirect_uri
+            if auth_code.redirect_uri != redirect_uri:
+                logger.warning(f"Redirect URI mismatch for code {code[:8]}...")
+                return None
+
+            # Validate PKCE if code_challenge was provided during authorization
+            if auth_code.code_challenge:
+                if not code_verifier:
+                    logger.warning(f"PKCE code_verifier required but not provided for code {code[:8]}...")
+                    return None
+
+                if not self._verify_pkce(code_verifier, auth_code.code_challenge, auth_code.code_challenge_method):
+                    logger.warning(f"PKCE verification failed for code {code[:8]}...")
+                    return None
+
+            # Mark as used
+            auth_code.used = True
 
         logger.debug(f"Authorization code consumed for user '{auth_code.username}'")
         return auth_code
@@ -189,26 +199,31 @@ class AuthCodeStore:
             return False
 
     def _cleanup_expired(self):
-        """Remove expired authorization codes."""
-        now = datetime.now(timezone.utc)
-        expired = [code for code, auth in self._codes.items() if now > auth.expires_at]
-        for code in expired:
-            del self._codes[code]
+        """Remove expired authorization codes. Callers must hold ``self._lock``."""
+        with self._lock:
+            now = datetime.now(timezone.utc)
+            expired = [code for code, auth in self._codes.items() if now > auth.expires_at]
+            for code in expired:
+                del self._codes[code]
         if expired:
             logger.debug(f"Cleaned up {len(expired)} expired authorization codes")
 
     def get_code_info(self, code: str) -> Optional[AuthorizationCode]:
         """Get info about a code without consuming it (for debugging)."""
-        return self._codes.get(code)
+        with self._lock:
+            return self._codes.get(code)
 
 
 # Global instance
 _auth_code_store: Optional[AuthCodeStore] = None
+_auth_code_store_lock = threading.Lock()
 
 
 def get_auth_code_store() -> AuthCodeStore:
-    """Get or create the global authorization code store."""
+    """Get or create the global authorization code store (thread-safe, #43)."""
     global _auth_code_store
     if _auth_code_store is None:
-        _auth_code_store = AuthCodeStore()
+        with _auth_code_store_lock:
+            if _auth_code_store is None:
+                _auth_code_store = AuthCodeStore()
     return _auth_code_store

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -9,6 +9,7 @@ Supports:
 
 import json
 import shutil
+import threading
 import uuid
 import base64
 import logging
@@ -449,13 +450,16 @@ class CryptoService:
 
 # Global crypto service instance
 _crypto_service: Optional[CryptoService] = None
+_crypto_service_lock = threading.Lock()
 
 
 def get_crypto_service(keys_dir: str = "./keys") -> CryptoService:
-    """Get or create the global crypto service."""
+    """Get or create the global crypto service (thread-safe lazy init, #43)."""
     global _crypto_service
     if _crypto_service is None:
-        _crypto_service = CryptoService(keys_dir)
+        with _crypto_service_lock:
+            if _crypto_service is None:
+                _crypto_service = CryptoService(keys_dir)
     return _crypto_service
 
 

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -42,6 +42,7 @@ def build_discovery_document(settings: Settings) -> Dict[str, Any]:
         "scopes_supported": ["openid", "profile", "email", "offline_access"],
         "claims_supported": [
             "sub", "iss", "aud", "azp", "exp", "iat", "nbf",
+            "auth_time", "nonce", "at_hash",
             "email", "email_verified", "preferred_username",
             "roles", "tenant", "identity_class", "entitlements",
             "source_acl", "attributes", "authorities"

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -2,8 +2,11 @@
 Token service for generating JWT tokens with authorities.
 """
 
+import base64
+import hashlib
 import logging
 import threading
+from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
 
 from ..config import User, Settings, get_config
@@ -103,6 +106,16 @@ class TokenService:
             return aud[0], None
         return aud, client_id
 
+    @staticmethod
+    def _compute_at_hash(access_token: str) -> str:
+        """Compute the OIDC ``at_hash`` claim for an access token.
+
+        Per OIDC Core §3.1.3.6 (with RS256): base64url of the left half of
+        the SHA-256 hash of the ASCII access token, without padding.
+        """
+        digest = hashlib.sha256(access_token.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest[: len(digest) // 2]).rstrip(b"=").decode("ascii")
+
     def create_token(
         self,
         user: User,
@@ -111,8 +124,16 @@ class TokenService:
         nonce: Optional[str] = None,
         scope: Optional[str] = None,
         client_id: Optional[str] = None,
+        auth_time: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Create a JWT token for a user."""
+        """Create a JWT token for a user.
+
+        ``auth_time`` is the Unix timestamp of the original end-user
+        authentication (issue #42): callers pass it when they know it (auth
+        code creation time, device authorization time, value preserved from a
+        refresh token); when omitted it defaults to "now", which is correct
+        for grants that authenticate the user in the same request (password).
+        """
         settings = self.config.settings
 
         if exp_minutes is None:
@@ -159,9 +180,24 @@ class TokenService:
         )
         
         id_token = None
+        effective_auth_time = None
         if scope and "openid" in scope.split():
+            # auth_time is REQUIRED on re-authentication checks (OIDC Core
+            # §2): when the caller didn't supply the original authentication
+            # time, the user authenticated within this very request.
+            effective_auth_time = (
+                auth_time
+                if auth_time is not None
+                else int(datetime.now(timezone.utc).timestamp())
+            )
             id_aud, azp = self._resolve_id_token_audience(client_id)
-            id_extra = {"token_use": "id"}
+            id_extra = {
+                "token_use": "id",
+                "auth_time": effective_auth_time,
+                # at_hash lets clients that validate it bind this ID Token to
+                # the access token issued alongside (OIDC Core §3.1.3.6).
+                "at_hash": self._compute_at_hash(token),
+            }
             if azp:
                 id_extra["azp"] = azp
             id_token = self.crypto.create_jwt(
@@ -174,13 +210,15 @@ class TokenService:
             )
 
 
-        # Create refresh token (valid for 7 days). The granted scope is
-        # persisted in its claims so the refresh_token grant can re-issue an
-        # ID Token when 'openid' was originally granted (OIDC Core §12.2,
-        # issue #39).
+        # Create refresh token (valid for 7 days). The granted scope and the
+        # original authentication time are persisted in its claims so the
+        # refresh_token grant can re-issue an ID Token with the same auth_time
+        # (OIDC Core §12.2, issues #39/#42).
         refresh_extra = {"token_type": "refresh", "token_use": "refresh"}
         if scope:
             refresh_extra["scope"] = scope
+        if effective_auth_time is not None:
+            refresh_extra["auth_time"] = effective_auth_time
         refresh_token = self.crypto.create_jwt(
             sub=user.username,
             issuer=settings.issuer,

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -3,6 +3,7 @@ Token service for generating JWT tokens with authorities.
 """
 
 import logging
+import threading
 from typing import Dict, List, Any, Optional
 
 from ..config import User, Settings, get_config
@@ -206,11 +207,14 @@ class TokenService:
 
 # Global token service instance
 _token_service: Optional[TokenService] = None
+_token_service_lock = threading.Lock()
 
 
 def get_token_service() -> TokenService:
-    """Get or create the global token service."""
+    """Get or create the global token service (thread-safe lazy init, #43)."""
     global _token_service
     if _token_service is None:
-        _token_service = TokenService()
+        with _token_service_lock:
+            if _token_service is None:
+                _token_service = TokenService()
     return _token_service

--- a/tests/test_id_token_time_claims.py
+++ b/tests/test_id_token_time_claims.py
@@ -1,0 +1,98 @@
+"""
+Tests for the ``auth_time`` and ``at_hash`` ID Token claims (issue #42).
+
+``auth_time`` must reflect when the end-user actually authenticated:
+- password grant: the token request itself;
+- authorization_code: when the code was created (the login page);
+- refresh_token: preserved unchanged from the original authentication
+  (OIDC Core §12.2), carried in the refresh token claims like scope (#39).
+
+``at_hash`` binds the ID Token to the access token issued alongside it:
+base64url(left half of SHA-256(access_token)), per OIDC Core §3.1.3.6.
+Both claims belong to the ID Token only — never to the access token.
+"""
+
+import base64
+import hashlib
+import json
+import time
+
+import jwt as pyjwt
+
+
+def _decode(token: str) -> dict:
+    return pyjwt.decode(token, options={"verify_signature": False})
+
+
+def _password_grant(client, auth_header, scope="openid"):
+    resp = client.post(
+        "/token",
+        data={
+            "grant_type": "password",
+            "username": "admin",
+            "password": "admin",
+            "scope": scope,
+        },
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    return json.loads(resp.data)
+
+
+def _expected_at_hash(access_token: str) -> str:
+    digest = hashlib.sha256(access_token.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest[:16]).rstrip(b"=").decode("ascii")
+
+
+class TestAuthTime:
+    def test_password_grant_auth_time_is_now(self, client, auth_header):
+        before = int(time.time())
+        data = _password_grant(client, auth_header)
+        after = int(time.time())
+        claims = _decode(data["id_token"])
+        assert before <= claims["auth_time"] <= after
+
+    def test_refresh_preserves_original_auth_time(self, client, auth_header):
+        data = _password_grant(client, auth_header)
+        original = _decode(data["id_token"])["auth_time"]
+
+        time.sleep(1.1)  # ensure "now" has moved past the original auth_time
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": data["refresh_token"],
+            },
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+        refreshed = _decode(json.loads(resp.data)["id_token"])
+        assert refreshed["auth_time"] == original
+        assert refreshed["iat"] > original
+
+    def test_access_token_has_no_auth_time(self, client, auth_header):
+        data = _password_grant(client, auth_header)
+        assert "auth_time" not in _decode(data["access_token"])
+
+
+class TestAtHash:
+    def test_at_hash_binds_id_token_to_access_token(self, client, auth_header):
+        data = _password_grant(client, auth_header)
+        claims = _decode(data["id_token"])
+        assert claims["at_hash"] == _expected_at_hash(data["access_token"])
+
+    def test_at_hash_changes_with_the_access_token(self, client, auth_header):
+        first = _password_grant(client, auth_header)
+        second = _password_grant(client, auth_header)
+        assert _decode(first["id_token"])["at_hash"] != _decode(second["id_token"])["at_hash"]
+
+    def test_access_token_has_no_at_hash(self, client, auth_header):
+        data = _password_grant(client, auth_header)
+        assert "at_hash" not in _decode(data["access_token"])
+
+
+class TestDiscoveryAdvertisesTimeClaims:
+    def test_claims_supported_lists_new_claims(self, client):
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        for claim in ("auth_time", "nonce", "at_hash"):
+            assert claim in doc["claims_supported"]

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,131 @@
+"""
+Concurrency tests for shared in-memory state (issue #43).
+
+Flask serves requests on multiple threads, so the authorization code store,
+the lazily-created service singletons and the device code dict must tolerate
+concurrent access. These tests use barriers to force the racy interleavings:
+without the locks they fail reliably, with them they must always pass.
+"""
+
+import threading
+
+import nanoidp.config as config_module
+import nanoidp.services.crypto as crypto_module
+import nanoidp.services.token as token_module
+from nanoidp.services.auth_code import AuthCodeStore
+
+
+def _run_threads(n, target):
+    threads = [threading.Thread(target=target) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+class TestAuthCodeStoreConcurrency:
+    """One-time use must hold under concurrent redemption (RFC 6749 §4.1.2)."""
+
+    def test_concurrent_consume_succeeds_exactly_once(self):
+        store = AuthCodeStore()
+        code = store.create_code(
+            client_id="demo-client",
+            redirect_uri="http://localhost:9000/callback",
+            username="admin",
+        )
+
+        n = 8
+        barrier = threading.Barrier(n)
+        results = []
+        results_lock = threading.Lock()
+
+        def consume():
+            barrier.wait()  # maximize the overlap between redemptions
+            outcome = store.consume_code(
+                code=code,
+                client_id="demo-client",
+                redirect_uri="http://localhost:9000/callback",
+            )
+            with results_lock:
+                results.append(outcome)
+
+        _run_threads(n, consume)
+
+        successes = [r for r in results if r is not None]
+        assert len(results) == n
+        assert len(successes) == 1, (
+            f"{len(successes)} concurrent redemptions of the same code succeeded; "
+            "one-time use requires exactly 1"
+        )
+
+    def test_concurrent_create_does_not_lose_codes(self):
+        store = AuthCodeStore()
+        n = 16
+        barrier = threading.Barrier(n)
+        codes = []
+        codes_lock = threading.Lock()
+
+        def create():
+            barrier.wait()
+            code = store.create_code(
+                client_id="demo-client",
+                redirect_uri="http://localhost:9000/callback",
+                username="admin",
+            )
+            with codes_lock:
+                codes.append(code)
+
+        _run_threads(n, create)
+
+        assert len(set(codes)) == n
+        for code in codes:
+            assert store.get_code_info(code) is not None
+
+
+class TestSingletonConcurrency:
+    """Lazy singletons must be constructed exactly once under concurrent
+    first access. A slow __init__ forces the check-then-set race window."""
+
+    def _assert_single_instance(self, module, attr, getter, monkeypatch):
+        instances = []
+
+        class SlowInit:
+            def __init__(self, *args, **kwargs):
+                import time
+                time.sleep(0.05)  # widen the race window
+                instances.append(self)
+
+        monkeypatch.setattr(module, attr, SlowInit)
+        n = 8
+        barrier = threading.Barrier(n)
+        seen = []
+        seen_lock = threading.Lock()
+
+        def get():
+            barrier.wait()
+            obj = getter()
+            with seen_lock:
+                seen.append(obj)
+
+        _run_threads(n, get)
+
+        assert len(instances) == 1, f"{attr} was constructed {len(instances)} times"
+        assert all(obj is seen[0] for obj in seen)
+
+    def test_get_config_creates_one_instance(self, monkeypatch):
+        config_module._config = None
+        self._assert_single_instance(
+            config_module, "ConfigManager", config_module.get_config, monkeypatch
+        )
+
+    def test_get_token_service_creates_one_instance(self, monkeypatch):
+        token_module._token_service = None
+        self._assert_single_instance(
+            token_module, "TokenService", token_module.get_token_service, monkeypatch
+        )
+
+    def test_get_crypto_service_creates_one_instance(self, monkeypatch):
+        crypto_module._crypto_service = None
+        self._assert_single_instance(
+            crypto_module, "CryptoService", crypto_module.get_crypto_service, monkeypatch
+        )


### PR DESCRIPTION
Closes #43, closes #42.

Two commits, one per issue — bundled in a single PR because #42's refresh handling builds on the same refresh-token-claims mechanism and adjacent code regions touched here.

## Commit 1 — thread-safety (#43)

Flask serves requests on multiple threads; the shared in-memory structures had unsynchronized check-then-act sequences:

- **`AuthCodeStore`** — create/consume/cleanup now run under an `RLock`; `consume_code` is atomic, so two concurrent redemptions of the same code can no longer both pass the one-time-use check (RFC 6749 §4.1.2).
- **Lazy singletons** (`get_config`, `get_token_service`, `get_crypto_service`, `get_audit_log`, `get_auth_code_store`) — double-checked locking; concurrent first access constructs exactly one instance.
- **`_device_codes`** — the poll's lookup+claim, the `pending→authorized/denied` transition in `/device`, and creation are atomic under a shared `RLock`; expired codes are pruned on each new device authorization (they used to accumulate forever).
- **`_revoked_tokens`** — documented why no lock is needed (single set ops, atomic under the GIL, no compound sequence).

New `tests/test_thread_safety.py` forces the racy interleavings with barriers and slow-init stubs: without the locks these tests fail reliably.

## Commit 2 — auth_time and at_hash (#42)

- **`auth_time`** reflects the real authentication moment per grant: auth code creation time (the login page) for the code flow, `/device` verification time for the device flow, the request itself for the password grant. On refresh it is preserved unchanged per OIDC Core §12.2, persisted in the refresh token claims alongside the scope from #39.
- **`at_hash`** = base64url(left half of SHA-256(access_token)) per §3.1.3.6, binding the ID Token to its access token.
- Both claims are on the ID Token only, never on access tokens. Discovery `claims_supported` now advertises `auth_time`, `nonce`, `at_hash` — via the shared helper from #40, so HTTP and MCP stay aligned automatically.

## Verification

- Full suite: **618 passed** (5 new concurrency tests, 7 new claim tests).
- E2E against a live server: **40/40** — including the new "ID Token Time Claims" agent test.
