### PR TITLE
feat: refresh token rotation, PKCE enforcement, MCP audit/key tools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Lint with ruff
+        run: |
+          ruff check .
+
       - name: Run tests
         run: |
           pytest tests/ -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Optional **refresh token rotation** (#46): with `oauth.refresh_token_rotation: true`
+  (default off), each refresh invalidates the consumed refresh token, so its
+  reuse fails with 401 — lets clients test rotation and reuse-detection
+  handling (OAuth 2.0 Security BCP §4.14.2). Revocation happens only after the
+  replacement is issued, and explicitly revoked refresh tokens are now also
+  rejected by the refresh grant.
+- **PKCE enforcement** (#47): new `require_pkce` setting (enabled by the
+  `stricter-dev` profile) rejects `/authorize` requests without a
+  `code_challenge`; `stricter-dev` also rejects `code_challenge_method=plain`
+  and discovery only advertises `S256` there. Default profile unchanged.
+- **MCP audit & key tools** (#48): `get_audit_log`, `get_audit_stats`,
+  `clear_audit_log`, `get_keys_info` and `rotate_keys` mirror the HTTP API,
+  so agent workflows can inspect what the IdP recorded and exercise JWKS
+  refresh handling. `clear_audit_log`/`rotate_keys` count as mutating tools
+  (admin secret / readonly rules apply). MCP `get_settings`/`update_settings`
+  now expose `refresh_token_rotation` and `require_pkce`.
+
+### Changed
+- CI now runs `ruff check .` before the tests (#45), and the codebase is
+  lint-clean: 153 findings fixed (#49) — deprecated `datetime.utcnow()`
+  replaced (removes 80 DeprecationWarnings), unused imports/variables
+  dropped, imports sorted and moved to module level, `Optional[...]` type
+  hints in the crypto service, `verify_jwt` accepts an array audience,
+  exceptions re-raised with `from e`.
 - ID Tokens now carry `auth_time` and `at_hash` (#42). `auth_time` reflects
   when the end-user actually authenticated: the login page for the
   authorization code flow, the `/device` verification for the device flow,

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ oauth:
   issuer: "http://localhost:8000"
   audience: "my-app"            # access token "aud" (resource audience, RFC 9068)
   token_expiry_minutes: 60
+  refresh_token_rotation: false # true: each refresh invalidates the used refresh token
   clients:
     - client_id: "demo-client"
       client_secret: "demo-secret"
@@ -547,6 +548,11 @@ NanoIDP includes an MCP server for integration with Claude Code and other MCP-co
 | `reload_config` | Reload configuration from files |
 | `get_oidc_discovery` | Get OIDC discovery document (same document as `/.well-known/openid-configuration`) |
 | `get_jwks` | Get JSON Web Key Set |
+| `get_audit_log` | Get audit log entries (filter by limit, event type, username) |
+| `get_audit_stats` | Get audit statistics |
+| `clear_audit_log` | Clear the audit log |
+| `get_keys_info` | Get signing key info (active kid, previous keys) |
+| `rotate_keys` | Rotate signing keys (old key stays valid for verification) |
 
 ### Claude Code CLI Configuration
 

--- a/docs/MCP_WORKFLOW.md
+++ b/docs/MCP_WORKFLOW.md
@@ -183,6 +183,9 @@ Prompt: "I need to test role-based access. Create a user 'role-test' with
 | `reload_config` | Reload from files | "Reload nanoidp config" |
 | `get_oidc_discovery` | Get OIDC discovery | "Get OIDC discovery" |
 | `get_jwks` | Get JWKS | "Get the JWKS from nanoidp" |
+| `get_audit_log` | Get audit entries | "Show the last 20 audit entries" |
+| `get_audit_stats` | Get audit statistics | "Show audit stats" |
+| `get_keys_info` | Get signing key info | "Which signing key is active?" |
 
 ### Mutating Tools (disabled in `--readonly` mode)
 
@@ -197,6 +200,8 @@ Prompt: "I need to test role-based access. Create a user 'role-test' with
 | `generate_token` | Generate JWT | "Generate token for 'admin'" |
 | `update_settings` | Update settings | "Set token expiry to 30 minutes" |
 | `save_config` | Save to YAML | "Save nanoidp config to files" |
+| `clear_audit_log` | Clear the audit log | "Clear the nanoidp audit log" |
+| `rotate_keys` | Rotate signing keys | "Rotate the signing keys" |
 
 ---
 

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -46,17 +46,17 @@ Uso:
     python test_agent.py --verbose
 """
 
-import sys
-import json
-import time
 import base64
 import hashlib
+import json
 import secrets
+import sys
+import time
 import xml.etree.ElementTree as ET
-from typing import Optional, Dict, Any, List, Tuple
 from dataclasses import dataclass, field
-from urllib.parse import urlencode, parse_qs, urlparse
 from enum import Enum
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
 
 try:
     import requests
@@ -719,7 +719,6 @@ class NanoIDPTestAgent:
                 device_code = data.get("device_code")
                 user_code = data.get("user_code")
                 verification_uri = data.get("verification_uri")
-                interval = data.get("interval", 5)
 
                 self._log(f"Device code: {device_code[:20]}...")
                 self._log(f"User code: {user_code}")
@@ -906,7 +905,6 @@ class NanoIDPTestAgent:
                 data = response.json()
                 sub = data.get("sub", "?")
                 email = data.get("email", "?")
-                roles = data.get("roles", [])
                 tenant = data.get("tenant", "?")
                 return self._add_result(
                     "UserInfo",
@@ -1173,7 +1171,7 @@ class NanoIDPTestAgent:
             session = requests.Session()
 
             # Login to get a session
-            login_response = session.post(
+            session.post(
                 f"{self.base_url}/login",
                 data={"username": self.username, "password": self.password},
                 allow_redirects=False,
@@ -1277,7 +1275,7 @@ class NanoIDPTestAgent:
             session = requests.Session()
 
             # Login to get a session
-            login_response = session.post(
+            session.post(
                 f"{self.base_url}/login",
                 data={"username": self.username, "password": self.password},
                 allow_redirects=False,
@@ -1678,7 +1676,7 @@ class NanoIDPTestAgent:
         try:
             # First, authenticate via session
             session = requests.Session()
-            login_response = session.post(
+            session.post(
                 f"{self.base_url}/login",
                 data={"username": self.username, "password": self.password},
                 allow_redirects=False,
@@ -2091,7 +2089,6 @@ class NanoIDPTestAgent:
 
             before_data = before.json()
             old_kid = before_data.get("active_kid", before_data.get("current_kid"))
-            old_previous = before_data.get("previous_kids", [])
 
             # Perform rotation
             response = self.session.post(
@@ -2100,9 +2097,6 @@ class NanoIDPTestAgent:
             )
 
             if response.status_code == 200:
-                data = response.json()
-                new_kid = data.get("new_kid", data.get("active_kid"))
-
                 # Verify key actually changed
                 after = self.session.get(f"{self.base_url}/api/keys/info", timeout=5)
                 if after.status_code == 200:
@@ -2118,7 +2112,6 @@ class NanoIDPTestAgent:
                     jwks = self.session.get(f"{self.base_url}/.well-known/jwks.json", timeout=5)
                     jwks_kids = [k.get("kid") for k in jwks.json().get("keys", [])] if jwks.status_code == 200 else []
                     new_in_jwks = current_kid in jwks_kids
-                    old_in_jwks = old_kid in jwks_kids
 
                     return self._add_result(
                         "Key Rotation",
@@ -2523,7 +2516,7 @@ class NanoIDPTestAgent:
         ]
 
         # Run tests by group
-        for category, title, tests in test_groups:
+        for _category, title, tests in test_groups:
             print(f"\n{'─' * 70}")
             print(f"  {title}")
             print(f"{'─' * 70}\n")
@@ -2557,7 +2550,7 @@ class NanoIDPTestAgent:
             print("\n  [SUCCESS] All tests passed!")
         else:
             failed = [r.name for r in self.suite.results if not r.success]
-            print(f"\n  [WARNING] Failed tests:")
+            print("\n  [WARNING] Failed tests:")
             for name in failed:
                 print(f"    - {name}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ target-version = ["py310", "py311", "py312"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -9,8 +9,8 @@ Usage:
 """
 
 import argparse
-import sys
 import os
+import sys
 
 from nanoidp import __version__
 

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -4,15 +4,16 @@ Flask application factory for NanoIDP.
 
 import logging
 import os
-from flask import Flask
+
+from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
 from . import __version__
-from .config import init_config, get_config
+from .config import get_config, init_config
+from .routes import api_bp, oauth_bp, saml_bp, ui_bp
 from .services import init_crypto_service
-from .routes import oauth_bp, saml_bp, ui_bp, api_bp
 
 # Global limiter instance (initialized in create_app)
 limiter = None
@@ -104,10 +105,9 @@ def create_app(config_dir: str = None, profile: str = None) -> Flask:
     # Health check at root for backward compatibility
     @app.route("/health")
     def health():
-        from flask import jsonify
         return jsonify({"status": "ok"})
 
-    logger.info(f"NanoIDP initialized")
+    logger.info("NanoIDP initialized")
     logger.info(f"  - Security profile: {settings.security_profile}")
     logger.info(f"  - Password hashing: {'bcrypt' if settings.password_hashing else 'plaintext'}")
     logger.info(f"  - Issuer: {settings.issuer}")

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -32,6 +32,8 @@ def create_app(config_dir: str = None, profile: str = None) -> Flask:
         settings.security_profile = "stricter-dev"
         settings.rate_limit_enabled = True
         settings.password_hashing = True
+        # PKCE required and 'plain' rejected in stricter-dev (#47)
+        settings.require_pkce = True
         # Block debug mode in stricter-dev
         settings.debug = False
 

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -4,14 +4,15 @@ Loads settings and users from YAML files.
 Uses Pydantic for validation and schema enforcement.
 """
 
+import logging
 import os
 import re
 import threading
-import yaml
-import logging
-from typing import Dict, List, Optional, Any
 from pathlib import Path
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from typing import Any, Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 logger = logging.getLogger(__name__)
 

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -131,6 +131,11 @@ class Settings(BaseModel):
     issuer: str = Field(default="http://localhost:8000", description="OAuth issuer URL")
     audience: str = Field(default="default", min_length=1, description="OAuth audience")
     token_expiry_minutes: int = Field(default=60, gt=0, le=1440, description="Token expiry in minutes")
+    refresh_token_rotation: bool = Field(
+        default=False,
+        description="Rotate refresh tokens: each refresh invalidates the consumed "
+        "refresh token, so its reuse fails (lets clients test rotation handling, #46)",
+    )
     clients: List[OAuthClient] = Field(default_factory=list, description="OAuth clients")
 
     # SAML
@@ -172,6 +177,11 @@ class Settings(BaseModel):
     rate_limit_enabled: bool = Field(default=False, description="Enable rate limiting")
     rate_limit_token_endpoint: str = Field(default="10/minute", description="Rate limit for /token endpoint")
     password_hashing: bool = Field(default=False, description="Use bcrypt for password hashing")
+    require_pkce: bool = Field(
+        default=False,
+        description="Reject /authorize requests without a PKCE code_challenge "
+        "(enabled by the stricter-dev profile, #47)",
+    )
 
     # Key management
     external_private_key: Optional[str] = Field(default=None, description="Path to external private PEM key")
@@ -286,6 +296,7 @@ class ConfigManager:
             issuer=oauth.get("issuer", "http://localhost:8000"),
             audience=oauth.get("audience", "default"),
             token_expiry_minutes=oauth.get("token_expiry_minutes", 60),
+            refresh_token_rotation=oauth.get("refresh_token_rotation", False),
             clients=clients,
             # SAML
             saml_entity_id=saml.get("entity_id", "http://localhost:8000/saml"),
@@ -492,6 +503,7 @@ class ConfigManager:
                 "issuer": self.settings.issuer,
                 "audience": self.settings.audience,
                 "token_expiry_minutes": self.settings.token_expiry_minutes,
+                "refresh_token_rotation": self.settings.refresh_token_rotation,
                 "clients": clients_data,
             },
             "saml": {

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -18,20 +18,20 @@ import asyncio
 import json
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Any, Tuple
 
+import jwt as pyjwt
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool, TextContent
+from mcp.types import TextContent, Tool
 
-from .config import ConfigManager, User, OAuthClient, init_config, get_config
+from .config import ConfigManager, OAuthClient, User, init_config
 from .services import (
-    init_crypto_service,
+    build_discovery_document,
+    get_audit_log,
     get_crypto_service,
     get_token_service,
-    get_audit_log,
-    build_discovery_document,
+    init_crypto_service,
 )
 
 logger = logging.getLogger(__name__)
@@ -683,7 +683,6 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         return result
 
     elif name == "decode_token":
-        import jwt as pyjwt
         token = arguments["token"]
         try:
             payload = pyjwt.decode(token, options={"verify_signature": False})

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -56,6 +56,8 @@ MUTATING_TOOLS = {
     "generate_token",
     "update_settings",
     "save_config",
+    "clear_audit_log",
+    "rotate_keys",
 }
 
 
@@ -511,6 +513,14 @@ async def list_tools() -> list[Tool]:
                         "type": "boolean",
                         "description": "Include usernames/client_ids in log messages (dev convenience)",
                     },
+                    "refresh_token_rotation": {
+                        "type": "boolean",
+                        "description": "Rotate refresh tokens: each refresh invalidates the consumed refresh token (#46)",
+                    },
+                    "require_pkce": {
+                        "type": "boolean",
+                        "description": "Reject /authorize requests without a PKCE code_challenge (#47)",
+                    },
                 },
                 "required": [],
             },
@@ -538,6 +548,68 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="get_jwks",
             description="Get JSON Web Key Set for token verification",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+
+        # Audit log (mirrors /api/audit*, issue #48)
+        Tool(
+            name="get_audit_log",
+            description="Get audit log entries (what the IdP recorded: token requests, logins, SAML flows)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum entries to return (default: 100)",
+                    },
+                    "event_type": {
+                        "type": "string",
+                        "description": "Filter by event type (e.g. token_request, authorization_request)",
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Filter by username",
+                    },
+                },
+                "required": [],
+            },
+        ),
+        Tool(
+            name="get_audit_stats",
+            description="Get audit log statistics (event counts by type/status)",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="clear_audit_log",
+            description="Clear the audit log",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+
+        # Key management (mirrors /api/keys*, issue #48)
+        Tool(
+            name="get_keys_info",
+            description="Get information about the signing keys (active kid, previous keys)",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="rotate_keys",
+            description="Rotate the signing keys: the active key moves to 'previous' (still valid for verification) and a new active key is generated — useful to test clients' JWKS refresh handling",
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -766,6 +838,8 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             "issuer": settings.issuer,
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
+            "refresh_token_rotation": settings.refresh_token_rotation,
+            "require_pkce": settings.require_pkce,
             "jwt_algorithm": settings.jwt_algorithm,
             "saml": {
                 "entity_id": settings.saml_entity_id,
@@ -809,6 +883,12 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         if "verbose_logging" in arguments:
             settings.verbose_logging = arguments["verbose_logging"]
             updated.append("verbose_logging")
+        if "refresh_token_rotation" in arguments:
+            settings.refresh_token_rotation = arguments["refresh_token_rotation"]
+            updated.append("refresh_token_rotation")
+        if "require_pkce" in arguments:
+            settings.require_pkce = arguments["require_pkce"]
+            updated.append("require_pkce")
 
         return {
             "success": True,
@@ -817,6 +897,8 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
                 "issuer": settings.issuer,
                 "audience": settings.audience,
                 "token_expiry_minutes": settings.token_expiry_minutes,
+                "refresh_token_rotation": settings.refresh_token_rotation,
+                "require_pkce": settings.require_pkce,
                 "saml_sign_responses": settings.saml_sign_responses,
                 "saml_c14n_algorithm": settings.saml_c14n_algorithm,
                 "strict_saml_binding": settings.strict_saml_binding,
@@ -840,6 +922,46 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
     elif name == "get_jwks":
         crypto = get_crypto_service(config.settings.keys_dir)
         return crypto.get_jwks()
+
+    # Audit log (mirrors /api/audit*, issue #48)
+    elif name == "get_audit_log":
+        audit = get_audit_log()
+        entries = audit.get_entries(
+            limit=arguments.get("limit", 100),
+            event_type=arguments.get("event_type"),
+            username=arguments.get("username"),
+        )
+        return {"entries": entries, "count": len(entries)}
+
+    elif name == "get_audit_stats":
+        return get_audit_log().get_stats()
+
+    elif name == "clear_audit_log":
+        get_audit_log().clear()
+        return {"success": True, "message": "Audit log cleared"}
+
+    # Key management (mirrors /api/keys*, issue #48)
+    elif name == "get_keys_info":
+        crypto = get_crypto_service(config.settings.keys_dir)
+        return {
+            "active_kid": crypto.kid,
+            "previous_keys_count": len(crypto.previous_keys),
+            "previous_kids": [k.kid for k in crypto.previous_keys],
+            "max_previous_keys": crypto.max_previous_keys,
+        }
+
+    elif name == "rotate_keys":
+        crypto = get_crypto_service(config.settings.keys_dir)
+        result = crypto.rotate_keys()
+        get_audit_log().log(
+            event_type="key_rotation",
+            endpoint="mcp:rotate_keys",
+            method="MCP",
+            username="mcp",
+            status="success",
+            details={"old_kid": result["old_kid"], "new_kid": result["new_kid"]},
+        )
+        return {"success": True, **result}
 
     else:
         return {"error": f"Unknown tool: {name}"}

--- a/src/nanoidp/routes/__init__.py
+++ b/src/nanoidp/routes/__init__.py
@@ -1,8 +1,8 @@
 """Routes module for NanoIDP."""
 
+from .api import api_bp
 from .oauth import oauth_bp
 from .saml import saml_bp
 from .ui import ui_bp
-from .api import api_bp
 
 __all__ = ["oauth_bp", "saml_bp", "ui_bp", "api_bp"]

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -3,6 +3,7 @@ REST API routes for management and monitoring.
 """
 
 import logging
+
 from flask import Blueprint, jsonify, request
 
 from ..config import get_config

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -153,6 +153,46 @@ def authorize():
             "error_description": "Invalid redirect_uri"
         }), 400
 
+    # PKCE enforcement (issue #47). With require_pkce enabled (on by default in
+    # the stricter-dev profile) an authorization request without a
+    # code_challenge is rejected, so developers can verify their client
+    # actually sends PKCE (mandatory in OAuth 2.1).
+    if config.settings.require_pkce and not code_challenge:
+        audit.log(
+            event_type="authorization_request",
+            endpoint="/authorize",
+            method=request.method,
+            status="failed",
+            client_id=client_id,
+            details={"reason": "PKCE code_challenge required (require_pkce enabled)"},
+            **req_info,
+        )
+        return jsonify({
+            "error": "invalid_request",
+            "error_description": "PKCE code_challenge is required (require_pkce is enabled)"
+        }), 400
+
+    # The 'plain' method is only acceptable when S256 is unavailable (RFC 7636
+    # §4.2); the stricter-dev profile rejects it outright (#47).
+    if (
+        code_challenge_method == "plain"
+        and config.settings.security_profile == "stricter-dev"
+    ):
+        audit.log(
+            event_type="authorization_request",
+            endpoint="/authorize",
+            method=request.method,
+            status="failed",
+            client_id=client_id,
+            details={"reason": "PKCE method 'plain' rejected by stricter-dev profile"},
+            **req_info,
+        )
+        return jsonify({
+            "error": "invalid_request",
+            "error_description": "code_challenge_method 'plain' is not allowed by the "
+                                 "stricter-dev profile; use S256"
+        }), 400
+
     error_msg = None
 
     # Handle POST (login form submission)
@@ -247,6 +287,7 @@ def token():
     nonce = None
     scope = None
     auth_time = None
+    rotated_refresh_jti = None
 
     # Reject if client identity cannot be determined at all
     if not client_id:
@@ -345,6 +386,28 @@ def token():
                 **req_info,
             )
             return abort(400, description="Invalid token type")
+
+        # Reject revoked refresh tokens — covers explicit /revoke calls and
+        # tokens consumed by rotation (issue #46)
+        if payload.get("jti") in _revoked_tokens:
+            audit.log(
+                event_type="token_request",
+                endpoint="/token",
+                method="POST",
+                status="failed",
+                client_id=client_id,
+                details={"reason": "Refresh token revoked (rotated or explicitly revoked)",
+                         "grant_type": grant_type},
+                **req_info,
+            )
+            return abort(401, description="Refresh token has been revoked")
+
+        # With rotation enabled, consuming this refresh token invalidates it:
+        # the response carries a new one, and reusing the old one must fail
+        # (OAuth 2.0 Security BCP §4.14.2, issue #46). Revocation happens after
+        # token issuance below, so a failed request leaves the token valid.
+        if config.settings.refresh_token_rotation:
+            rotated_refresh_jti = payload.get("jti")
 
         # Extract username and get user data
         username = payload.get("sub")
@@ -675,6 +738,11 @@ def token():
         client_id=client_id,
         auth_time=auth_time,
     )
+
+    # Rotation: the consumed refresh token is invalidated only now that its
+    # replacement has been issued (issue #46)
+    if rotated_refresh_jti:
+        _revoked_tokens.add(rotated_refresh_jti)
 
     # Audit log
     audit.log(

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -4,17 +4,21 @@ OAuth2/OIDC routes for token endpoint and discovery.
 
 import json
 import logging
+import secrets
 import threading
+import time
 from urllib.parse import urlencode, urlparse
-from flask import Blueprint, request, jsonify, abort, redirect, render_template, session, url_for
 
-from ..config import get_config, User
+import jwt as pyjwt
+from flask import Blueprint, abort, jsonify, redirect, render_template, request, session
+
+from ..config import User, get_config
 from ..services import (
-    get_token_service,
-    get_crypto_service,
+    build_discovery_document,
     get_audit_log,
     get_auth_code_store,
-    build_discovery_document,
+    get_crypto_service,
+    get_token_service,
 )
 
 logger = logging.getLogger(__name__)
@@ -826,9 +830,8 @@ def introspect():
     if not token:
         return jsonify({"active": False})
 
-    token_type_hint = request.form.get("token_type_hint", "access_token")
-
-    # Try to verify the token
+    # Try to verify the token (token_type_hint is intentionally ignored: with a
+    # single signing key there is nothing to disambiguate, per RFC 7662 §2.1)
     crypto = get_crypto_service(config.settings.keys_dir)
     try:
         payload = crypto.verify_jwt(token, config.settings.audience)
@@ -932,10 +935,8 @@ def revoke():
         return "", 200
 
     # Try to decode the token to get its JTI
-    crypto = get_crypto_service(config.settings.keys_dir)
     try:
         # Decode without verification to get the JTI
-        import jwt as pyjwt
         payload = pyjwt.decode(token, options={"verify_signature": False})
         jti = payload.get("jti")
 
@@ -984,7 +985,6 @@ def end_session():
     - state: CSRF protection state (optional)
     - client_id: Client identifier (optional, required if no id_token_hint)
     """
-    config = get_config()
     audit = get_audit_log()
     req_info = _get_request_info()
 
@@ -1000,9 +1000,7 @@ def end_session():
 
     # If id_token_hint is provided, extract user info
     if id_token_hint:
-        crypto = get_crypto_service(config.settings.keys_dir)
         try:
-            import jwt as pyjwt
             payload = pyjwt.decode(id_token_hint, options={"verify_signature": False})
             username = payload.get("sub")
 
@@ -1047,10 +1045,6 @@ def end_session():
 # ============================================================================
 # Device Authorization Grant (RFC 8628)
 # ============================================================================
-
-import secrets
-import time
-from datetime import datetime, timedelta
 
 # In-memory storage for device codes. All compound accesses (lookup + status
 # mutation / deletion) must hold the lock: Flask serves requests on multiple

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -3,14 +3,17 @@ SAML routes for SSO and metadata.
 """
 
 import html
+import logging
 import uuid
 import zlib
-import logging
-from base64 import b64encode, b64decode
+from base64 import b64decode, b64encode
 from datetime import datetime, timedelta, timezone
-from flask import Blueprint, request, abort, session, redirect, url_for, Response, render_template
 
+from flask import Blueprint, Response, abort, render_template, request, session
 from lxml import etree
+
+from ..config import get_config
+from ..services import get_audit_log, get_crypto_service
 
 # Create secure XML parser (XXE protection without deprecated defusedxml.lxml)
 _secure_parser = etree.XMLParser(
@@ -25,12 +28,9 @@ def secure_fromstring(xml_bytes: bytes) -> etree._Element:
     """Parse XML securely, preventing XXE attacks."""
     return etree.fromstring(xml_bytes, parser=_secure_parser)
 
-from ..config import get_config
-from ..services import get_crypto_service, get_audit_log
-
 # Try to import signxml for SAML signing
 try:
-    from signxml import XMLSigner, methods, CanonicalizationMethod
+    from signxml import CanonicalizationMethod, XMLSigner, methods
     SIGNXML_AVAILABLE = True
 except ImportError:
     SIGNXML_AVAILABLE = False

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -2,15 +2,16 @@
 Web UI routes for the NanoIDP dashboard.
 """
 
+import csv
+import json
 import logging
 import secrets
-from flask import Blueprint, render_template, request, session, redirect, url_for, flash, Response
-import json
-import csv
 from io import StringIO
 
-from ..config import get_config, User, OAuthClient
-from ..services import get_audit_log, get_yaml_writer, get_token_service
+from flask import Blueprint, Response, flash, redirect, render_template, request, session, url_for
+
+from ..config import OAuthClient, User, get_config
+from ..services import get_audit_log, get_token_service, get_yaml_writer
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +165,7 @@ def user_create():
         attr_keys = request.form.getlist("attr_key[]")
         attr_values = request.form.getlist("attr_value[]")
         attributes = {}
-        for key, value in zip(attr_keys, attr_values):
+        for key, value in zip(attr_keys, attr_values, strict=False):
             key = key.strip()
             value = value.strip()
             if key and value:
@@ -252,7 +253,7 @@ def user_edit(username: str):
         attr_keys = request.form.getlist("attr_key[]")
         attr_values = request.form.getlist("attr_value[]")
         attributes = {}
-        for key, value in zip(attr_keys, attr_values):
+        for key, value in zip(attr_keys, attr_values, strict=False):
             key = key.strip()
             value = value.strip()
             if key and value:
@@ -528,8 +529,8 @@ def settings():
 def keys():
     """Keys and certificates management page."""
     import os
-    from pathlib import Path
     from datetime import datetime
+    from pathlib import Path
     config = get_config()
     from ..services import get_crypto_service
 
@@ -637,7 +638,7 @@ def claims():
         # Custom attribute prefixes
         custom_keys = request.form.getlist("custom_prefix_key[]")
         custom_values = request.form.getlist("custom_prefix_value[]")
-        for key, value in zip(custom_keys, custom_values):
+        for key, value in zip(custom_keys, custom_values, strict=False):
             key = key.strip()
             value = value.strip()
             if key and value:

--- a/src/nanoidp/services/__init__.py
+++ b/src/nanoidp/services/__init__.py
@@ -1,11 +1,11 @@
 """Services module for NanoIDP."""
 
-from .crypto import CryptoService, get_crypto_service, init_crypto_service
-from .token import TokenService, get_token_service
 from .audit import AuditLog, get_audit_log
-from .yaml_writer import YamlWriter, get_yaml_writer
 from .auth_code import AuthCodeStore, AuthorizationCode, get_auth_code_store
+from .crypto import CryptoService, get_crypto_service, init_crypto_service
 from .discovery import build_discovery_document
+from .token import TokenService, get_token_service
+from .yaml_writer import YamlWriter, get_yaml_writer
 
 __all__ = [
     "build_discovery_document",

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -3,11 +3,11 @@ Audit logging service for tracking IDP operations.
 """
 
 import logging
-from datetime import datetime, timezone
-from typing import Optional, List, Dict, Any
-from dataclasses import dataclass, field
 from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from threading import Lock
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/nanoidp/services/auth_code.py
+++ b/src/nanoidp/services/auth_code.py
@@ -3,10 +3,10 @@ Authorization Code service with PKCE support.
 Manages authorization codes for OAuth2 Authorization Code Flow.
 """
 
-import hashlib
 import base64
-import secrets
+import hashlib
 import logging
+import secrets
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -7,30 +7,28 @@ Supports:
 - Key rotation with multiple keys in JWKS
 """
 
+import base64
 import json
-import shutil
+import logging
 import threading
 import uuid
-import base64
-import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any, List, Union
-
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization, hashes
-from cryptography.hazmat.primitives.serialization import (
-    Encoding,
-    PrivateFormat,
-    NoEncryption,
-    PublicFormat,
-)
-from cryptography.hazmat.backends import default_backend
-from cryptography import x509
-from cryptography.x509.oid import NameOID
+from typing import Any, Dict, List, Optional, Union
 
 import jwt
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+from cryptography.x509.oid import NameOID
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +162,7 @@ class CryptoService:
             serialization.load_pem_private_key(self.priv_pem, password=None)
             serialization.load_pem_public_key(self.pub_pem)
         except Exception as e:
-            raise ValueError(f"Invalid PEM key format: {e}")
+            raise ValueError(f"Invalid PEM key format: {e}") from e
 
         self.kid = self._external_key_id or uuid.uuid4().hex
         logger.info(f"Loaded external keys with KID: {self.kid}")
@@ -235,8 +233,8 @@ class CryptoService:
             .issuer_name(issuer)
             .public_key(public_key)
             .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.utcnow() - timedelta(days=1))
-            .not_valid_after(datetime.utcnow() + timedelta(days=3650))
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=None),
                 critical=True,
@@ -295,9 +293,9 @@ class CryptoService:
         sub: str,
         issuer: str,
         audience: Union[str, List[str]],
-        roles: list = None,
-        tenant: str = None,
-        extra: dict = None,
+        roles: Optional[List[str]] = None,
+        tenant: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
         exp_minutes: int = 60,
         nonce: Optional[str] = None
     ) -> str:
@@ -321,13 +319,18 @@ class CryptoService:
             payload.update(extra)
         if nonce is not None:
             payload["nonce"] = nonce
-            
+
         headers = {"kid": self.kid, "alg": "RS256", "typ": "JWT"}
         token = jwt.encode(payload, self.priv_pem, algorithm="RS256", headers=headers)
         return token
 
-    def verify_jwt(self, token: str, audience: str) -> Dict[str, Any]:
-        """Verify and decode a JWT token."""
+    def verify_jwt(self, token: str, audience: Union[str, List[str]]) -> Dict[str, Any]:
+        """Verify and decode a JWT token.
+
+        ``audience`` accepts a list as well as a string (PyJWT semantics:
+        the token is valid if its ``aud`` matches any of the values), so ID
+        Tokens carrying an array ``aud`` can be verified too.
+        """
         try:
             # Use public key for verification
             payload = jwt.decode(
@@ -338,10 +341,10 @@ class CryptoService:
                 options={"verify_signature": True},
             )
             return payload
-        except jwt.ExpiredSignatureError:
-            raise ValueError("Token has expired")
+        except jwt.ExpiredSignatureError as e:
+            raise ValueError("Token has expired") from e
         except jwt.InvalidTokenError as e:
-            raise ValueError(f"Invalid token: {str(e)}")
+            raise ValueError(f"Invalid token: {str(e)}") from e
 
     def get_certificate_base64(self) -> str:
         """Get the certificate in base64 format (without headers)."""

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -54,5 +54,11 @@ def build_discovery_document(settings: Settings) -> Dict[str, Any]:
             "refresh_token",
             "urn:ietf:params:oauth:grant-type:device_code",
         ],
-        "code_challenge_methods_supported": ["plain", "S256"],
+        # stricter-dev rejects 'plain' at /authorize, so don't advertise it
+        # there (#47)
+        "code_challenge_methods_supported": (
+            ["S256"]
+            if settings.security_profile == "stricter-dev"
+            else ["plain", "S256"]
+        ),
     }

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -7,9 +7,9 @@ import hashlib
 import logging
 import threading
 from datetime import datetime, timezone
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
 
-from ..config import User, Settings, get_config
+from ..config import User, get_config
 from .crypto import get_crypto_service
 
 logger = logging.getLogger(__name__)
@@ -178,7 +178,7 @@ class TokenService:
             extra=extra,
             exp_minutes=exp_minutes,
         )
-        
+
         id_token = None
         effective_auth_time = None
         if scope and "openid" in scope.split():

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -3,16 +3,16 @@ YAML configuration writer service.
 Provides atomic write operations for YAML configuration files.
 """
 
-import os
-import yaml
-import shutil
 import logging
+import os
+import shutil
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Any, Optional
-from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-from ..config import User, OAuthClient, get_config
+import yaml
+
+from ..config import OAuthClient, User, get_config
 
 logger = logging.getLogger(__name__)
 

--- a/src/nanoidp/wizard.py
+++ b/src/nanoidp/wizard.py
@@ -3,9 +3,8 @@ Interactive text-based configuration wizard.
 No external dependencies required.
 """
 
-import os
-import sys
 import getpass
+import os
 
 
 def _prompt(message: str, default: str = "") -> str:
@@ -26,8 +25,11 @@ def _prompt_password(message: str, default: str = "") -> str:
             return result if result else default
         else:
             return getpass.getpass(f"  {message}: ")
-    except Exception:
-        # Fallback to regular input if getpass fails
+    except Exception as e:
+        # getpass can fail on terminals without echo control (e.g. some IDE
+        # consoles or non-tty stdin); fall back to visible input rather than
+        # aborting the wizard.
+        print(f"  (hidden input unavailable: {e}; falling back to visible input)")
         return _prompt(message, default)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,14 @@ Pytest configuration and shared fixtures for NanoIDP tests.
 """
 
 import base64
-import pytest
-from typing import Generator
 
-from nanoidp.app import create_app
-from nanoidp.config import ConfigManager, User, OAuthClient, Settings
-import nanoidp.services.crypto as crypto_module
+import pytest
+
 import nanoidp.config as config_module
+import nanoidp.services.crypto as crypto_module
 import nanoidp.services.token as token_module
+from nanoidp.app import create_app
+from nanoidp.config import OAuthClient, User
 
 
 @pytest.fixture(autouse=True)
@@ -138,8 +138,8 @@ def pkce_verifier():
 @pytest.fixture
 def pkce_challenge_s256(pkce_verifier):
     """Generate a PKCE code challenge using S256 method."""
-    import hashlib
     import base64
+    import hashlib
     digest = hashlib.sha256(pkce_verifier.encode('ascii')).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b'=').decode('ascii')
 

--- a/tests/test_auth_code.py
+++ b/tests/test_auth_code.py
@@ -3,15 +3,13 @@ Unit tests for the Authorization Code service.
 Tests PKCE verification, code creation, and code consumption.
 """
 
-import pytest
-import hashlib
 import base64
+import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
 
 from nanoidp.services.auth_code import (
     AuthCodeStore,
-    AuthorizationCode,
     get_auth_code_store,
 )
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,5 @@
 """Basic tests for NanoIDP."""
 
-import pytest
 
 
 def test_import():

--- a/tests/test_claims_mapping.py
+++ b/tests/test_claims_mapping.py
@@ -6,7 +6,7 @@ according to README documentation and user configuration.
 """
 
 import json
-import pytest
+
 import jwt as pyjwt
 
 
@@ -211,8 +211,8 @@ class TestAuthorityPrefixConfiguration:
 
     def test_build_authorities_with_default_prefixes(self):
         """Test authority building with default prefix configuration."""
-        from nanoidp.services.token import TokenService
         from nanoidp.config import User
+        from nanoidp.services.token import TokenService
 
         user = User(
             username="testuser",
@@ -267,8 +267,8 @@ class TestEmptyAndMissingFields:
 
     def test_user_with_empty_roles_generates_valid_token(self):
         """Test that users with empty roles still generate valid tokens."""
-        from nanoidp.services.token import TokenService
         from nanoidp.config import User
+        from nanoidp.services.token import TokenService
 
         user = User(
             username="minimaluser",
@@ -287,8 +287,8 @@ class TestEmptyAndMissingFields:
 
     def test_user_with_none_identity_class(self):
         """Test that users with None identity_class don't add spurious authorities."""
-        from nanoidp.services.token import TokenService
         from nanoidp.config import User
+        from nanoidp.services.token import TokenService
 
         user = User(
             username="noidentity",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,9 +7,9 @@ import pytest
 
 from nanoidp.config import (
     ConfigManager,
-    User,
     OAuthClient,
     Settings,
+    User,
     get_config,
 )
 

--- a/tests/test_device_flow_complete.py
+++ b/tests/test_device_flow_complete.py
@@ -11,8 +11,8 @@ Tests cover:
 
 import json
 import time
+
 import pytest
-from unittest.mock import patch
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,38 +5,38 @@ Unit tests for NanoIDP typed exceptions.
 import pytest
 
 from nanoidp.exceptions import (
-    # Base
-    NanoIDPError,
+    # Auth Code
+    AuthCodeError,
     # Authentication
     AuthenticationError,
-    InvalidCredentialsError,
-    UserNotFoundError,
     # Client
     ClientError,
     ClientNotFoundError,
-    InvalidClientCredentialsError,
-    # Token
-    TokenError,
-    InvalidTokenError,
-    ExpiredTokenError,
-    RevokedTokenError,
-    # Auth Code
-    AuthCodeError,
-    InvalidAuthCodeError,
-    ExpiredAuthCodeError,
-    PKCEValidationError,
+    ConfigFileNotFoundError,
     # Configuration
     ConfigurationError,
-    ConfigFileNotFoundError,
-    InvalidConfigurationError,
+    ExpiredAuthCodeError,
+    ExpiredTokenError,
     # Grant
     GrantError,
-    UnsupportedGrantTypeError,
+    InvalidAuthCodeError,
+    InvalidClientCredentialsError,
+    InvalidConfigurationError,
+    InvalidCredentialsError,
     InvalidGrantError,
+    InvalidSAMLRequestError,
+    InvalidTokenError,
+    # Base
+    NanoIDPError,
+    PKCEValidationError,
+    RevokedTokenError,
     # SAML
     SAMLError,
-    InvalidSAMLRequestError,
     SAMLSignatureError,
+    # Token
+    TokenError,
+    UnsupportedGrantTypeError,
+    UserNotFoundError,
 )
 
 

--- a/tests/test_expand_env_vars.py
+++ b/tests/test_expand_env_vars.py
@@ -10,11 +10,8 @@ Covers:
   - Integration: ConfigManager picks up substitutions from the environment
 """
 
-import os
-import pytest
 
 from nanoidp.config import _expand_env_vars
-
 
 # ---------------------------------------------------------------------------
 # Basic string substitution

--- a/tests/test_key_management.py
+++ b/tests/test_key_management.py
@@ -7,23 +7,21 @@ Tests cover:
 - Key rotation
 """
 
-import os
 import tempfile
-import pytest
 from pathlib import Path
 
+import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
-    PrivateFormat,
     NoEncryption,
+    PrivateFormat,
     PublicFormat,
 )
 
-from nanoidp.services.crypto import CryptoService, init_crypto_service, get_crypto_service
-import nanoidp.services.crypto as crypto_module
 import nanoidp.config as config_module
+import nanoidp.services.crypto as crypto_module
+from nanoidp.services.crypto import CryptoService
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -416,11 +414,6 @@ class TestKeyRotationAPI:
 
     def test_jwks_endpoint_returns_multiple_keys_after_rotation(self, client):
         """Test that JWKS includes previous keys after rotation."""
-        # Get initial JWKS and the active key
-        response1 = client.get("/.well-known/jwks.json")
-        initial_jwks = response1.get_json()
-        initial_kids = {key["kid"] for key in initial_jwks["keys"]}
-
         # Rotate keys
         rotate_response = client.post("/api/keys/rotate")
         rotate_data = rotate_response.get_json()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,8 +8,8 @@ Tests cover:
 """
 
 import json
+
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
 
 
 class TestMCPGetSettings:
@@ -161,13 +161,6 @@ class TestMCPToolSchema:
         # Read the MCP server module to verify schema
         from nanoidp import mcp_server
 
-        # Get the list_tools function and check schema
-        # The schema should include verbose_logging
-        expected_schema_property = {
-            "type": "boolean",
-            "description": "Include usernames/client_ids in log messages (dev convenience)",
-        }
-
         # Verify the module has the expected structure
         assert hasattr(mcp_server, 'server')
         assert hasattr(mcp_server, 'MUTATING_TOOLS')
@@ -179,10 +172,9 @@ class TestMCPReadonlyMode:
 
     def test_readonly_mode_blocks_update_settings(self):
         """Test that readonly mode blocks update_settings calls."""
-        from nanoidp.mcp_server import _check_readonly_mode, MUTATING_TOOLS
-
         # Simulate readonly mode enabled
         import nanoidp.mcp_server as mcp_module
+        from nanoidp.mcp_server import _check_readonly_mode
         original_readonly = mcp_module._readonly_mode
 
         try:
@@ -207,6 +199,7 @@ class TestMCPAdminSecret:
     def test_update_settings_requires_admin_secret_when_configured(self):
         """Test that update_settings requires admin_secret when env var is set."""
         import os
+
         from nanoidp.mcp_server import _check_admin_secret
 
         original_secret = os.environ.get("NANOIDP_MCP_ADMIN_SECRET")
@@ -241,6 +234,7 @@ class TestMCPAdminSecret:
     def test_get_settings_does_not_require_admin_secret(self):
         """Test that get_settings works without admin_secret."""
         import os
+
         from nanoidp.mcp_server import _check_admin_secret
 
         original_secret = os.environ.get("NANOIDP_MCP_ADMIN_SECRET")

--- a/tests/test_mcp_audit_keys.py
+++ b/tests/test_mcp_audit_keys.py
@@ -1,0 +1,87 @@
+"""
+Tests for the MCP audit log and key management tools (issue #48).
+
+They mirror the HTTP API (/api/audit*, /api/keys*) so agent-driven test
+workflows can inspect what the IdP recorded and rotate keys to exercise a
+client's JWKS refresh handling.
+"""
+
+import pytest
+
+from nanoidp.config import get_config
+from nanoidp.mcp_server import MUTATING_TOOLS, _execute_tool
+from nanoidp.services import get_audit_log
+
+
+class TestAuditTools:
+    @pytest.mark.asyncio
+    async def test_get_audit_log_returns_logged_entries(self, app):
+        with app.app_context():
+            get_audit_log().log(
+                event_type="token_request",
+                endpoint="/token",
+                method="POST",
+                status="success",
+                username="admin",
+            )
+            result = await _execute_tool("get_audit_log", {}, get_config())
+        assert result["count"] >= 1
+        assert any(e["event_type"] == "token_request" for e in result["entries"])
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_filters(self, app):
+        with app.app_context():
+            audit = get_audit_log()
+            audit.log(event_type="a_event", endpoint="/a", method="GET", status="success")
+            audit.log(event_type="b_event", endpoint="/b", method="GET", status="success")
+            result = await _execute_tool(
+                "get_audit_log", {"event_type": "a_event"}, get_config()
+            )
+        assert result["count"] == 1
+        assert result["entries"][0]["event_type"] == "a_event"
+
+    @pytest.mark.asyncio
+    async def test_stats_and_clear(self, app):
+        with app.app_context():
+            config = get_config()
+            get_audit_log().log(
+                event_type="x", endpoint="/x", method="GET", status="success"
+            )
+            stats = await _execute_tool("get_audit_stats", {}, config)
+            assert stats  # non-empty after logging
+
+            cleared = await _execute_tool("clear_audit_log", {}, config)
+            assert cleared["success"] is True
+            after = await _execute_tool("get_audit_log", {}, config)
+        assert after["count"] == 0
+
+
+class TestKeyTools:
+    @pytest.mark.asyncio
+    async def test_get_keys_info(self, app):
+        with app.app_context():
+            info = await _execute_tool("get_keys_info", {}, get_config())
+        assert info["active_kid"]
+        assert "previous_kids" in info
+
+    @pytest.mark.asyncio
+    async def test_rotate_keys_changes_active_and_preserves_old(self, app):
+        with app.app_context():
+            config = get_config()
+            before = await _execute_tool("get_keys_info", {}, config)
+            result = await _execute_tool("rotate_keys", {}, config)
+            after = await _execute_tool("get_keys_info", {}, config)
+
+        assert result["success"] is True
+        assert after["active_kid"] != before["active_kid"]
+        # The old key remains available for verification (JWKS keeps it)
+        assert before["active_kid"] in after["previous_kids"]
+
+
+class TestToolClassification:
+    def test_mutating_tools_membership(self):
+        assert "clear_audit_log" in MUTATING_TOOLS
+        assert "rotate_keys" in MUTATING_TOOLS
+        assert "get_audit_log" not in MUTATING_TOOLS
+        assert "get_audit_stats" not in MUTATING_TOOLS
+        assert "get_keys_info" not in MUTATING_TOOLS

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -9,14 +9,15 @@ Tests cover:
 
 import json
 import os
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 # Import MCP security functions
 from nanoidp.mcp_server import (
+    MUTATING_TOOLS,
     _check_admin_secret,
     _log_mcp_tool,
-    MUTATING_TOOLS,
 )
 
 
@@ -228,8 +229,8 @@ class TestMCPReadonlyMode:
 
     def test_check_readonly_mode_disabled_allows_all(self):
         """Test that readonly mode disabled allows all tools."""
-        from nanoidp.mcp_server import _check_readonly_mode
         import nanoidp.mcp_server as mcp
+        from nanoidp.mcp_server import _check_readonly_mode
 
         # Ensure readonly mode is off
         original_value = mcp._readonly_mode
@@ -247,8 +248,8 @@ class TestMCPReadonlyMode:
 
     def test_check_readonly_mode_blocks_mutating_tools(self):
         """Test that readonly mode blocks mutating tools."""
-        from nanoidp.mcp_server import _check_readonly_mode
         import nanoidp.mcp_server as mcp
+        from nanoidp.mcp_server import _check_readonly_mode
 
         original_value = mcp._readonly_mode
         mcp._readonly_mode = True
@@ -263,8 +264,8 @@ class TestMCPReadonlyMode:
 
     def test_check_readonly_mode_allows_read_only_tools(self):
         """Test that readonly mode allows read-only tools."""
-        from nanoidp.mcp_server import _check_readonly_mode
         import nanoidp.mcp_server as mcp
+        from nanoidp.mcp_server import _check_readonly_mode
 
         original_value = mcp._readonly_mode
         mcp._readonly_mode = True
@@ -285,8 +286,8 @@ class TestMCPReadonlyMode:
     @pytest.mark.parametrize("tool_name", list(MUTATING_TOOLS))
     def test_all_mutating_tools_blocked_in_readonly(self, tool_name):
         """Test that all mutating tools are blocked in readonly mode."""
-        from nanoidp.mcp_server import _check_readonly_mode
         import nanoidp.mcp_server as mcp
+        from nanoidp.mcp_server import _check_readonly_mode
 
         original_value = mcp._readonly_mode
         mcp._readonly_mode = True

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -307,8 +307,9 @@ class TestMCPSecurityDocumentation:
         """Test that we have the expected number of mutating tools."""
         # From README: create_user, update_user, delete_user,
         #              create_client, update_client, delete_client,
-        #              generate_token, update_settings, save_config
-        expected_count = 9
+        #              generate_token, update_settings, save_config,
+        #              clear_audit_log, rotate_keys (#48)
+        expected_count = 11
         assert len(MUTATING_TOOLS) == expected_count
 
     def test_mcp_server_has_security_docstring(self):

--- a/tests/test_new_endpoints.py
+++ b/tests/test_new_endpoints.py
@@ -3,9 +3,7 @@ Integration tests for new endpoints: OIDC Logout and Device Authorization Grant.
 Tests end session endpoint and RFC 8628 device flow.
 """
 
-import pytest
 import json
-import time
 
 
 class TestOIDCLogout:

--- a/tests/test_oauth_errors.py
+++ b/tests/test_oauth_errors.py
@@ -7,9 +7,8 @@ Verifies that error responses follow RFC 6749 format:
 - error_uri: Optional URI with more information
 """
 
-import json
 import base64
-import pytest
+import json
 
 
 class TestInvalidGrantError:

--- a/tests/test_oauth_flows.py
+++ b/tests/test_oauth_flows.py
@@ -3,11 +3,8 @@ Integration tests for OAuth2 flows.
 Tests complete authorization code flow, password grant, client credentials, and refresh token.
 """
 
-import pytest
-import json
-import hashlib
 import base64
-import secrets
+import json
 
 
 class TestAuthorizationCodeFlow:

--- a/tests/test_oidc_endpoints.py
+++ b/tests/test_oidc_endpoints.py
@@ -3,9 +3,7 @@ Integration tests for OIDC endpoints.
 Tests discovery, JWKS, userinfo, introspection, and revocation.
 """
 
-import pytest
 import json
-import jwt as pyjwt
 
 
 class TestOIDCDiscovery:

--- a/tests/test_pkce_enforcement.py
+++ b/tests/test_pkce_enforcement.py
@@ -1,0 +1,91 @@
+"""
+Tests for PKCE enforcement (issue #47).
+
+``require_pkce`` (off by default, enabled by the stricter-dev profile)
+rejects /authorize requests without a ``code_challenge``. The stricter-dev
+profile also rejects ``code_challenge_method=plain`` (RFC 7636 §4.2 reserves
+it for when S256 is unavailable) and stops advertising it in discovery.
+"""
+
+import json
+
+import pytest
+
+from nanoidp.config import get_config
+
+AUTHORIZE_PARAMS = {
+    "response_type": "code",
+    "client_id": "demo-client",
+    "redirect_uri": "http://localhost:9000/callback",
+}
+
+
+def _authorize(client, **extra):
+    return client.get("/authorize", query_string={**AUTHORIZE_PARAMS, **extra})
+
+
+class TestDefaultBehaviorUnchanged:
+    def test_default_require_pkce_is_off(self, app):
+        with app.app_context():
+            assert get_config().settings.require_pkce is False
+
+    def test_authorize_without_pkce_is_accepted(self, client):
+        resp = _authorize(client)
+        assert resp.status_code == 200  # login page renders
+
+    def test_plain_method_accepted_in_dev(self, client):
+        resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="plain")
+        assert resp.status_code == 200
+
+    def test_discovery_advertises_both_methods_in_dev(self, client):
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        assert doc["code_challenge_methods_supported"] == ["plain", "S256"]
+
+
+class TestRequirePkce:
+    @pytest.fixture(autouse=True)
+    def enable(self, app):
+        with app.app_context():
+            get_config().settings.require_pkce = True
+        yield
+
+    def test_authorize_without_code_challenge_rejected(self, client):
+        resp = _authorize(client)
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data["error"] == "invalid_request"
+        assert "code_challenge" in data["error_description"]
+
+    def test_authorize_with_code_challenge_accepted(self, client):
+        resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="S256")
+        assert resp.status_code == 200
+
+
+class TestStricterDevProfile:
+    @pytest.fixture(autouse=True)
+    def stricter(self, app):
+        with app.app_context():
+            settings = get_config().settings
+            settings.security_profile = "stricter-dev"
+            settings.require_pkce = True
+        yield
+
+    def test_plain_method_rejected(self, client):
+        resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="plain")
+        assert resp.status_code == 400
+        assert "plain" in json.loads(resp.data)["error_description"]
+
+    def test_s256_method_accepted(self, client):
+        resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="S256")
+        assert resp.status_code == 200
+
+    def test_discovery_advertises_s256_only(self, client):
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        assert doc["code_challenge_methods_supported"] == ["S256"]
+
+
+class TestProfileWiring:
+    def test_create_app_stricter_dev_enables_require_pkce(self):
+        from nanoidp.app import create_app
+        create_app(profile="stricter-dev")
+        assert get_config().settings.require_pkce is True

--- a/tests/test_refresh_rotation.py
+++ b/tests/test_refresh_rotation.py
@@ -1,0 +1,105 @@
+"""
+Tests for optional refresh token rotation (issue #46).
+
+Off by default: the same refresh token can be reused indefinitely (old
+behavior). When ``oauth.refresh_token_rotation`` is enabled, each refresh
+invalidates the consumed refresh token (its jti joins the revocation list),
+so reuse fails with 401 — letting clients test rotation and reuse-detection
+handling (OAuth 2.0 Security BCP §4.14.2).
+"""
+
+import json
+
+import pytest
+
+from nanoidp.config import get_config
+
+
+@pytest.fixture(autouse=True)
+def clean_revoked_tokens():
+    """The revocation list is module-global; keep tests isolated."""
+    from nanoidp.routes.oauth import _revoked_tokens
+    _revoked_tokens.clear()
+    yield
+    _revoked_tokens.clear()
+
+
+def _password_grant(client, auth_header):
+    resp = client.post(
+        "/token",
+        data={
+            "grant_type": "password",
+            "username": "admin",
+            "password": "admin",
+            "scope": "openid",
+        },
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    return json.loads(resp.data)
+
+
+def _refresh(client, auth_header, refresh_token):
+    return client.post(
+        "/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+        headers=auth_header,
+    )
+
+
+class TestRotationDisabled:
+    def test_default_is_off(self, app):
+        with app.app_context():
+            assert get_config().settings.refresh_token_rotation is False
+
+    def test_refresh_token_is_reusable(self, client, auth_header):
+        tokens = _password_grant(client, auth_header)
+        first = _refresh(client, auth_header, tokens["refresh_token"])
+        second = _refresh(client, auth_header, tokens["refresh_token"])
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+
+class TestRotationEnabled:
+    @pytest.fixture(autouse=True)
+    def enable_rotation(self, app):
+        with app.app_context():
+            get_config().settings.refresh_token_rotation = True
+        yield
+
+    def test_reuse_of_rotated_token_fails(self, client, auth_header):
+        tokens = _password_grant(client, auth_header)
+        first = _refresh(client, auth_header, tokens["refresh_token"])
+        assert first.status_code == 200
+
+        reuse = _refresh(client, auth_header, tokens["refresh_token"])
+        assert reuse.status_code == 401
+
+    def test_rotated_replacement_works(self, client, auth_header):
+        tokens = _password_grant(client, auth_header)
+        first = _refresh(client, auth_header, tokens["refresh_token"])
+        rotated = json.loads(first.data)["refresh_token"]
+
+        second = _refresh(client, auth_header, rotated)
+        assert second.status_code == 200
+        # The rotated chain still re-issues ID Tokens (scope persisted, #39)
+        assert "id_token" in json.loads(second.data)
+
+    def test_failed_refresh_does_not_consume_the_token(self, client, auth_header):
+        """Revocation happens only after successful issuance: a rejected
+        request (e.g. broadened scope, RFC 6749 §6) must leave the refresh
+        token valid."""
+        tokens = _password_grant(client, auth_header)
+        broadened = client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": tokens["refresh_token"],
+                "scope": "openid profile email something-never-granted",
+            },
+            headers=auth_header,
+        )
+        assert broadened.status_code == 400
+
+        retry = _refresh(client, auth_header, tokens["refresh_token"])
+        assert retry.status_code == 200

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -11,9 +11,9 @@ Tests cover:
 
 import base64
 import zlib
+
 import pytest
 from lxml import etree
-from unittest.mock import patch
 
 SAML_NS = {
     "md": "urn:oasis:names:tc:SAML:2.0:metadata",
@@ -520,7 +520,7 @@ class TestSAMLSigningConfiguration:
         root = etree.fromstring(xml)
         # If signxml is available, signature should be present
         try:
-            from signxml import XMLSigner
+            from signxml import XMLSigner  # noqa: F401 -- availability probe
             signature = root.find(".//ds:Signature", SAML_NS)
             assert signature is not None, "Signed response should contain Signature element"
         except ImportError:
@@ -626,7 +626,7 @@ class TestSAMLSigningConfiguration:
         from nanoidp.routes.saml import _build_saml_response
 
         try:
-            from signxml import XMLSigner
+            from signxml import XMLSigner  # noqa: F401 -- availability probe
         except ImportError:
             pytest.skip("signxml not available")
 
@@ -652,7 +652,7 @@ class TestSAMLSigningConfiguration:
         incompatible_c14n = "http://www.w3.org/2006/12/xml-c14n11"
 
         assert c14n_algo != incompatible_c14n, \
-            f"Default should be Exclusive C14N, not C14N 1.1"
+            "Default should be Exclusive C14N, not C14N 1.1"
         assert c14n_algo == expected_c14n, \
             f"Expected Exclusive C14N algorithm, got: {c14n_algo}"
 
@@ -661,7 +661,7 @@ class TestSAMLSigningConfiguration:
         from nanoidp.routes.saml import _build_saml_response
 
         try:
-            from signxml import XMLSigner
+            from signxml import XMLSigner  # noqa: F401 -- availability probe
         except ImportError:
             pytest.skip("signxml not available")
 
@@ -686,7 +686,7 @@ class TestSAMLSigningConfiguration:
             algo = transform.get("Algorithm")
             if "c14n" in algo.lower():
                 assert algo != incompatible_c14n, \
-                    f"Transform should use Exclusive C14N by default, not C14N 1.1"
+                    "Transform should use Exclusive C14N by default, not C14N 1.1"
                 assert algo == expected_c14n, \
                     f"Expected Exclusive C14N in Transform, got: {algo}"
 
@@ -696,7 +696,7 @@ class TestSAMLSigningConfiguration:
         from nanoidp.routes.saml import _build_saml_response
 
         try:
-            from signxml import XMLSigner
+            from signxml import XMLSigner  # noqa: F401 -- availability probe
         except ImportError:
             pytest.skip("signxml not available")
 
@@ -735,7 +735,7 @@ class TestSAMLSigningConfiguration:
         from nanoidp.routes.saml import _build_saml_response
 
         try:
-            from signxml import XMLSigner
+            from signxml import XMLSigner  # noqa: F401 -- availability probe
         except ImportError:
             pytest.skip("signxml not available")
 

--- a/tests/test_security_edge_cases.py
+++ b/tests/test_security_edge_cases.py
@@ -10,14 +10,11 @@ Tests cover:
 """
 
 import json
-import time
-import pytest
-import jwt as pyjwt
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 
-from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt as pyjwt
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 
 class TestTokenExpiration:
@@ -37,12 +34,12 @@ class TestTokenExpiration:
         data = json.loads(response.data)
         token = data['access_token']
 
-        # Decode and verify it's valid first
-        payload = pyjwt.decode(token, options={"verify_signature": False})
+        # Decode to verify it's well-formed first (raises if not)
+        pyjwt.decode(token, options={"verify_signature": False})
 
         # Create a token that's already expired by manipulating the payload
-        from nanoidp.services import get_crypto_service
         from nanoidp.config import get_config
+        from nanoidp.services import get_crypto_service
 
         config = get_config()
         crypto = get_crypto_service(config.settings.keys_dir)
@@ -71,8 +68,8 @@ class TestTokenExpiration:
 
     def test_expired_token_inactive_in_introspection(self, client, auth_header):
         """Test that expired tokens show as inactive in introspection."""
-        from nanoidp.services import get_crypto_service
         from nanoidp.config import get_config
+        from nanoidp.services import get_crypto_service
 
         config = get_config()
         crypto = get_crypto_service(config.settings.keys_dir)
@@ -105,8 +102,8 @@ class TestTokenExpiration:
 
     def test_token_near_expiration_still_valid(self, client, auth_header):
         """Test that tokens near expiration are still valid."""
-        from nanoidp.services import get_crypto_service
         from nanoidp.config import get_config
+        from nanoidp.services import get_crypto_service
 
         config = get_config()
         crypto = get_crypto_service(config.settings.keys_dir)
@@ -140,8 +137,8 @@ class TestAudienceMismatch:
 
     def test_token_with_wrong_audience_rejected(self, client, auth_header):
         """Test that tokens with wrong audience are rejected."""
-        from nanoidp.services import get_crypto_service
         from nanoidp.config import get_config
+        from nanoidp.services import get_crypto_service
 
         config = get_config()
         crypto = get_crypto_service(config.settings.keys_dir)
@@ -209,8 +206,8 @@ class TestIssuerMismatch:
         NanoIDP does not validate the issuer claim - it trusts any token
         signed with its key. This test documents this behavior.
         """
-        from nanoidp.services import get_crypto_service
         from nanoidp.config import get_config
+        from nanoidp.services import get_crypto_service
 
         config = get_config()
         crypto = get_crypto_service(config.settings.keys_dir)

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -9,10 +9,8 @@ Tests cover:
 - Verbose logging setting
 """
 
-import json
 import base64
-import pytest
-from unittest.mock import patch, MagicMock
+import json
 
 
 class TestXXEProtection:
@@ -222,7 +220,6 @@ class TestSecureXMLParser:
 
     def test_secure_parser_configured(self):
         """Test that secure XML parser has correct settings."""
-        from nanoidp.routes.saml import _secure_parser
 
         # Verify parser is configured to block XXE attacks
         # resolve_entities=False prevents entity expansion
@@ -230,8 +227,9 @@ class TestSecureXMLParser:
 
     def test_secure_parser_blocks_entities(self):
         """Test that secure parser blocks external entity expansion."""
-        from nanoidp.routes.saml import secure_fromstring
         from lxml.etree import XMLSyntaxError
+
+        from nanoidp.routes.saml import secure_fromstring
 
         xxe_xml = b"""<?xml version="1.0"?>
 <!DOCTYPE foo [

--- a/tests/test_security_profiles.py
+++ b/tests/test_security_profiles.py
@@ -8,8 +8,8 @@ Tests cover:
 - Security profile switching
 """
 
-import pytest
 import bcrypt
+import pytest
 
 from nanoidp.config import ConfigManager, Settings, User
 
@@ -195,14 +195,14 @@ class TestRateLimiting:
     def test_rate_limiter_exists_in_app(self):
         """Test that rate limiter is configured in app."""
         from nanoidp.app import create_app, get_limiter
-        app = create_app(profile="stricter-dev")
+        create_app(profile="stricter-dev")
         limiter = get_limiter()
         assert limiter is not None
 
     def test_rate_limiter_disabled_in_dev(self):
         """Test that rate limiter is effectively disabled in dev profile."""
         from nanoidp.app import create_app, get_limiter
-        app = create_app(profile="dev")
+        create_app(profile="dev")
         limiter = get_limiter()
         # Limiter exists but is disabled
         assert limiter is not None
@@ -216,7 +216,7 @@ class TestProfileOverrides:
         from nanoidp.app import create_app
         from nanoidp.config import get_config
 
-        app = create_app(profile="stricter-dev")
+        create_app(profile="stricter-dev")
         config = get_config()
 
         assert config.settings.password_hashing is True
@@ -226,7 +226,7 @@ class TestProfileOverrides:
         from nanoidp.app import create_app
         from nanoidp.config import get_config
 
-        app = create_app(profile="stricter-dev")
+        create_app(profile="stricter-dev")
         config = get_config()
 
         assert config.settings.rate_limit_enabled is True
@@ -236,7 +236,7 @@ class TestProfileOverrides:
         from nanoidp.app import create_app
         from nanoidp.config import get_config
 
-        app = create_app(profile="stricter-dev")
+        create_app(profile="stricter-dev")
         config = get_config()
 
         assert config.settings.debug is False

--- a/tests/test_token_lifecycle.py
+++ b/tests/test_token_lifecycle.py
@@ -3,10 +3,10 @@ Integration tests for complete token lifecycle.
 Tests end-to-end journeys including token issuance, usage, refresh, and revocation.
 """
 
-import pytest
 import json
-import jwt as pyjwt
 import time
+
+import jwt as pyjwt
 
 
 class TestCompleteAuthorizationCodeJourney:
@@ -45,7 +45,6 @@ class TestCompleteAuthorizationCodeJourney:
         assert response.status_code == 200
         tokens = json.loads(response.data)
         access_token = tokens['access_token']
-        refresh_token = tokens['refresh_token']
 
         # 5. Use access token to get userinfo
         response = client.get('/userinfo', headers={
@@ -274,7 +273,6 @@ class TestTokenValidation:
 
     def test_token_timestamps_are_valid(self, client, auth_header):
         """Test that token timestamps are properly set."""
-        import time
 
         before = int(time.time())
 

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -3,12 +3,12 @@ Unit tests for the Token Service.
 Tests JWT token creation, authorities building, and token validation.
 """
 
-import pytest
-import jwt as pyjwt
-from datetime import datetime, timezone
 
-from nanoidp.services.token import TokenService, get_token_service
+import jwt as pyjwt
+import pytest
+
 from nanoidp.config import User
+from nanoidp.services.token import TokenService, get_token_service
 
 
 class TestTokenCreation:


### PR DESCRIPTION
Closes #46, closes #47, closes #48.

> **Stacked on #53** — merge #53 first; this PR's diff then shrinks to its own commit.

## #46 — Refresh token rotation (opt-in)

With `oauth.refresh_token_rotation: true` (default **off**, current behavior unchanged), each refresh invalidates the consumed refresh token by adding its `jti` to the revocation list — reusing it fails with 401, letting clients test rotation and reuse-detection handling (OAuth 2.0 Security BCP §4.14.2). Details:

- Revocation happens **after** the replacement is issued: a rejected refresh (e.g. scope broadening) leaves the token valid.
- The refresh grant now also rejects tokens revoked via `/revoke` (previously only access-token endpoints checked the list).
- Rotated chains keep re-issuing ID Tokens (scope/auth_time persist per #39/#42).

## #47 — PKCE enforcement

New `require_pkce` setting (default off; **enabled by the stricter-dev profile**): `/authorize` without a `code_challenge` is rejected with `invalid_request`, so developers can verify their client actually sends PKCE (mandatory in OAuth 2.1). stricter-dev additionally rejects `code_challenge_method=plain` (RFC 7636 §4.2) and discovery advertises only `S256` there — via the shared helper from #40, so HTTP and MCP stay aligned.

## #48 — MCP audit & key tools

Five new tools mirroring the HTTP API: `get_audit_log` (with limit/event_type/username filters), `get_audit_stats`, `clear_audit_log`, `get_keys_info`, `rotate_keys` — the last one is handy to verify a client re-fetches JWKS after rotation. `clear_audit_log` and `rotate_keys` are registered as mutating (admin-secret and `--readonly` rules apply). `get_settings`/`update_settings` expose the two new settings; README and `docs/MCP_WORKFLOW.md` tables now list all 24 tools.

## Verification

- 21 new tests (`test_refresh_rotation.py`, `test_pkce_enforcement.py`, `test_mcp_audit_keys.py`); full suite **643 passed**, ruff clean.
- E2E agent against a live server: **40/40**.
