### PR TITLE
Review follow-ups (#56): refresh client binding, atomic rotation + families, implicit-plain PKCE, require_pkce persistence, honest scope — plus broken MCP entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Review follow-ups of the 2026-06-11 merge block (#56):
+  - **Refresh tokens are bound to their client**: the issuing `client_id` is
+    persisted in the refresh token claims and the refresh grant rejects any
+    other client (RFC 9700 §4.14) — which also guarantees the refreshed ID
+    Token keeps the original `aud` (OIDC Core §12.2). Tokens minted before
+    the claim existed keep working.
+  - **Rotation is atomic and revokes families on reuse**: the revocation
+    check and the claim of the consumed token now happen in one critical
+    section, so two concurrent refreshes of the same token can no longer
+    both succeed. Each grant starts a refresh-token family (`rt_family`
+    claim, stable across rotations); reusing an already-consumed token
+    revokes the whole family, including the live descendant (RFC 9700
+    §4.14.2).
+  - **PKCE `plain` can no longer slip through stricter-dev by omitting the
+    method**: per RFC 7636 §4.3 an absent `code_challenge_method` defaults
+    to `plain`; the method is now normalized before validation, and unknown
+    methods are rejected at the authorization endpoint (§4.4.1).
+  - **`require_pkce` is persisted**: it is now read from and written to
+    `settings.yaml` (oauth section), so `update_settings` → `save_config` →
+    `reload_config` no longer silently reverts it.
+  - **The token response reports the scope actually granted** (RFC 6749
+    §5.1) instead of a hardcoded `"openid"`; when no scope was involved the
+    parameter is omitted, and a narrowed refresh reports the narrowed scope.
+- The `nanoidp-mcp` stdio entrypoint crashed at startup ("a coroutine was
+  expected"): `stdio_server()` is an async context manager yielding the
+  message streams, not a coroutine. Found by the mypy baseline being
+  prepared for #55; verified with a JSON-RPC initialize handshake.
+
 ### Added
 - Optional **refresh token rotation** (#46): with `oauth.refresh_token_rotation: true`
   (default off), each refresh invalidates the consumed refresh token, so its

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -297,6 +297,7 @@ class ConfigManager:
             audience=oauth.get("audience", "default"),
             token_expiry_minutes=oauth.get("token_expiry_minutes", 60),
             refresh_token_rotation=oauth.get("refresh_token_rotation", False),
+            require_pkce=oauth.get("require_pkce", False),
             clients=clients,
             # SAML
             saml_entity_id=saml.get("entity_id", "http://localhost:8000/saml"),
@@ -504,6 +505,7 @@ class ConfigManager:
                 "audience": self.settings.audience,
                 "token_expiry_minutes": self.settings.token_expiry_minutes,
                 "refresh_token_rotation": self.settings.refresh_token_rotation,
+                "require_pkce": self.settings.require_pkce,
                 "clients": clients_data,
             },
             "saml": {

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -1014,8 +1014,19 @@ Examples:
     # Initialize config
     _ensure_config()
 
-    # Run the server
-    asyncio.run(stdio_server(server))
+    # Run the server. stdio_server() is an async context manager yielding the
+    # (read, write) streams the Server pumps messages through — the previous
+    # `asyncio.run(stdio_server(server))` crashed at startup (found by mypy,
+    # #55: "a coroutine was expected").
+    async def _serve() -> None:
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+
+    asyncio.run(_serve())
 
 
 if __name__ == "__main__":

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -500,8 +500,11 @@ def token():
         # revokes the whole family — attacker's copy and legitimate descendant
         # alike (RFC 9700 §4.14.2). This block sits after every validation
         # that may legitimately fail (binding, user, scope narrowing), so a
-        # rejected request does not consume the token; from here on, issuance
-        # is local signing and cannot fail.
+        # rejected request does not consume the token. Known edge: malformed
+        # 'exp'/'extra' form params are parsed in the grant-common code below,
+        # i.e. AFTER the claim — a client sending garbage there does lose the
+        # token; accepted tradeoff, since claiming any later would reopen the
+        # double-rotation race.
         jti = payload.get("jti")
         with _revocation_lock:
             family_revoked = bool(refresh_family) and refresh_family in _revoked_token_families

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -172,26 +172,51 @@ def authorize():
             "error_description": "PKCE code_challenge is required (require_pkce is enabled)"
         }), 400
 
-    # The 'plain' method is only acceptable when S256 is unavailable (RFC 7636
-    # §4.2); the stricter-dev profile rejects it outright (#47).
-    if (
-        code_challenge_method == "plain"
-        and config.settings.security_profile == "stricter-dev"
-    ):
-        audit.log(
-            event_type="authorization_request",
-            endpoint="/authorize",
-            method=request.method,
-            status="failed",
-            client_id=client_id,
-            details={"reason": "PKCE method 'plain' rejected by stricter-dev profile"},
-            **req_info,
-        )
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "code_challenge_method 'plain' is not allowed by the "
-                                 "stricter-dev profile; use S256"
-        }), 400
+    if code_challenge:
+        # RFC 7636 §4.3: an omitted code_challenge_method defaults to 'plain',
+        # and the verifier honors that — so the method must be normalized
+        # BEFORE validation or the stricter-dev rejection could be bypassed by
+        # simply omitting the parameter (#56). Unsupported methods are
+        # rejected at the authorization endpoint per §4.4.1.
+        effective_method = code_challenge_method or "plain"
+        if effective_method not in ("plain", "S256"):
+            audit.log(
+                event_type="authorization_request",
+                endpoint="/authorize",
+                method=request.method,
+                status="failed",
+                client_id=client_id,
+                details={"reason": f"Unsupported code_challenge_method: {effective_method}"},
+                **req_info,
+            )
+            return jsonify({
+                "error": "invalid_request",
+                "error_description": f"Unsupported code_challenge_method "
+                                     f"'{effective_method}'; use S256 or plain"
+            }), 400
+
+        # The 'plain' method is only acceptable when S256 is unavailable
+        # (RFC 7636 §4.2); the stricter-dev profile rejects it outright (#47),
+        # whether requested explicitly or via the implicit default.
+        if (
+            effective_method == "plain"
+            and config.settings.security_profile == "stricter-dev"
+        ):
+            audit.log(
+                event_type="authorization_request",
+                endpoint="/authorize",
+                method=request.method,
+                status="failed",
+                client_id=client_id,
+                details={"reason": "PKCE method 'plain' rejected by stricter-dev profile"},
+                **req_info,
+            )
+            return jsonify({
+                "error": "invalid_request",
+                "error_description": "code_challenge_method 'plain' (including the "
+                                     "implicit default when the parameter is omitted) "
+                                     "is not allowed by the stricter-dev profile; use S256"
+            }), 400
 
     error_msg = None
 
@@ -287,7 +312,7 @@ def token():
     nonce = None
     scope = None
     auth_time = None
-    rotated_refresh_jti = None
+    refresh_family = None
 
     # Reject if client identity cannot be determined at all
     if not client_id:
@@ -387,27 +412,25 @@ def token():
             )
             return abort(400, description="Invalid token type")
 
-        # Reject revoked refresh tokens — covers explicit /revoke calls and
-        # tokens consumed by rotation (issue #46)
-        if payload.get("jti") in _revoked_tokens:
+        # A refresh token may only be spent by the client it was issued to
+        # (RFC 9700 §4.14, #56). The binding claim was added in #56; tokens
+        # minted before it carry no client_id and stay usable (legacy compat).
+        bound_client = payload.get("client_id")
+        if bound_client and bound_client != client_id:
             audit.log(
                 event_type="token_request",
                 endpoint="/token",
                 method="POST",
                 status="failed",
                 client_id=client_id,
-                details={"reason": "Refresh token revoked (rotated or explicitly revoked)",
-                         "grant_type": grant_type},
+                details={
+                    "reason": "Refresh token was issued to a different client",
+                    "grant_type": grant_type,
+                    "bound_client": bound_client,
+                },
                 **req_info,
             )
-            return abort(401, description="Refresh token has been revoked")
-
-        # With rotation enabled, consuming this refresh token invalidates it:
-        # the response carries a new one, and reusing the old one must fail
-        # (OAuth 2.0 Security BCP §4.14.2, issue #46). Revocation happens after
-        # token issuance below, so a failed request leaves the token valid.
-        if config.settings.refresh_token_rotation:
-            rotated_refresh_jti = payload.get("jti")
+            return abort(401, description="Refresh token was not issued to this client")
 
         # Extract username and get user data
         username = payload.get("sub")
@@ -466,6 +489,50 @@ def token():
         # A refreshed ID Token must carry the ORIGINAL authentication time
         # (OIDC Core §12.2), persisted in the refresh token claims (#42).
         auth_time = payload.get("auth_time")
+
+        # The family id survives rotation so descendants share it (#56).
+        refresh_family = payload.get("rt_family")
+
+        # Revocation check and (with rotation) consumption of this token, as a
+        # single check-and-claim under the lock: two concurrent refreshes of
+        # the same token can no longer both pass the check and both rotate
+        # (#56). Reuse of an already-consumed token is treated as leakage and
+        # revokes the whole family — attacker's copy and legitimate descendant
+        # alike (RFC 9700 §4.14.2). This block sits after every validation
+        # that may legitimately fail (binding, user, scope narrowing), so a
+        # rejected request does not consume the token; from here on, issuance
+        # is local signing and cannot fail.
+        jti = payload.get("jti")
+        with _revocation_lock:
+            family_revoked = bool(refresh_family) and refresh_family in _revoked_token_families
+            token_revoked = jti in _revoked_tokens
+            if token_revoked or family_revoked:
+                if (
+                    config.settings.refresh_token_rotation
+                    and refresh_family
+                    and not family_revoked
+                ):
+                    _revoked_token_families.add(refresh_family)
+                reuse_detected = True
+            else:
+                reuse_detected = False
+                if config.settings.refresh_token_rotation and jti:
+                    _revoked_tokens.add(jti)
+        if reuse_detected:
+            audit.log(
+                event_type="token_request",
+                endpoint="/token",
+                method="POST",
+                status="failed",
+                username=username,
+                client_id=client_id,
+                details={
+                    "reason": "Refresh token revoked (rotated, reused, or family revoked)",
+                    "grant_type": grant_type,
+                },
+                **req_info,
+            )
+            return abort(401, description="Refresh token has been revoked")
 
     # Password grant
     elif grant_type == "password":
@@ -737,12 +804,8 @@ def token():
         scope=scope,
         client_id=client_id,
         auth_time=auth_time,
+        refresh_family=refresh_family,
     )
-
-    # Rotation: the consumed refresh token is invalidated only now that its
-    # replacement has been issued (issue #46)
-    if rotated_refresh_jti:
-        _revoked_tokens.add(rotated_refresh_jti)
 
     # Audit log
     audit.log(
@@ -765,10 +828,16 @@ def token():
     return jsonify(token_response)
 
 
-# Token blacklist for revocation (in-memory). No lock needed: only single
-# `add`/`in` operations, atomic under the GIL — there is no compound
-# check-then-act sequence to protect (unlike _device_codes above, see #43).
+# Token blacklists for revocation (in-memory). Refresh token rotation (#46)
+# introduced a check-then-claim sequence on _revoked_tokens, so compound
+# accesses in the refresh grant go through _revocation_lock (#56); the plain
+# membership tests in /userinfo,/introspect stay lock-free (single set ops,
+# atomic under the GIL). _revoked_token_families holds rt_family ids whose
+# entire rotation chain was revoked after a reuse was detected (RFC 9700
+# §4.14.2).
 _revoked_tokens: set = set()
+_revoked_token_families: set = set()
+_revocation_lock = threading.Lock()
 
 
 def _extract_bearer_token() -> str | None:

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import logging
 import threading
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -125,6 +126,7 @@ class TokenService:
         scope: Optional[str] = None,
         client_id: Optional[str] = None,
         auth_time: Optional[int] = None,
+        refresh_family: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user.
 
@@ -210,15 +212,23 @@ class TokenService:
             )
 
 
-        # Create refresh token (valid for 7 days). The granted scope and the
-        # original authentication time are persisted in its claims so the
-        # refresh_token grant can re-issue an ID Token with the same auth_time
-        # (OIDC Core §12.2, issues #39/#42).
-        refresh_extra = {"token_type": "refresh", "token_use": "refresh"}
+        # Create refresh token (valid for 7 days). Its claims persist the
+        # context needed at refresh time:
+        # - scope and auth_time, so the grant re-issues an ID Token with the
+        #   same authentication context (OIDC Core §12.2, #39/#42);
+        # - client_id, binding the token to the client it was issued to so no
+        #   other client can spend it (RFC 9700 §4.14, #56) — which also keeps
+        #   the refreshed ID Token aud identical to the original;
+        # - rt_family, a stable id across rotations: reuse of a consumed token
+        #   revokes the whole family (RFC 9700 §4.14.2, #56).
+        refresh_extra: Dict[str, Any] = {"token_type": "refresh", "token_use": "refresh"}
         if scope:
             refresh_extra["scope"] = scope
         if effective_auth_time is not None:
             refresh_extra["auth_time"] = effective_auth_time
+        if client_id:
+            refresh_extra["client_id"] = client_id
+        refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
         refresh_token = self.crypto.create_jwt(
             sub=user.username,
             issuer=settings.issuer,
@@ -234,8 +244,12 @@ class TokenService:
             "token_type": "Bearer",
             "expires_in": exp_minutes * 60,
             "refresh_token": refresh_token,
-            "scope": "openid",
         }
+        # RFC 6749 §5.1: report the scope actually granted — it may have been
+        # narrowed on refresh (§6) and was previously hardcoded to "openid"
+        # regardless of the grant (#56). Omitted when no scope was involved.
+        if scope:
+            response["scope"] = scope
 
         if id_token is not None:
             response["id_token"] = id_token

--- a/tests/test_issue_56_review.py
+++ b/tests/test_issue_56_review.py
@@ -1,0 +1,226 @@
+"""
+Tests for the five review follow-ups of the 2026-06-11 merge block (issue #56).
+
+1. Refresh tokens are bound to the client they were issued to.
+2. Rotation consumes tokens atomically; reuse revokes the whole family.
+3. stricter-dev rejects PKCE 'plain' even when the method is omitted
+   (RFC 7636 §4.3 default) and unknown methods are rejected everywhere.
+4. require_pkce survives a save/reload roundtrip.
+5. The token response reports the scope actually granted (RFC 6749 §5.1).
+"""
+
+import json
+import threading
+
+import pytest
+
+from nanoidp.config import get_config
+
+
+@pytest.fixture(autouse=True)
+def clean_revocation_state():
+    from nanoidp.routes.oauth import _revoked_token_families, _revoked_tokens
+    _revoked_tokens.clear()
+    _revoked_token_families.clear()
+    yield
+    _revoked_tokens.clear()
+    _revoked_token_families.clear()
+
+
+def _password_grant(client, headers, scope="openid"):
+    data = {"grant_type": "password", "username": "admin", "password": "admin"}
+    if scope is not None:
+        data["scope"] = scope
+    resp = client.post("/token", data=data, headers=headers)
+    assert resp.status_code == 200
+    return json.loads(resp.data)
+
+
+def _refresh(client, headers, refresh_token, scope=None):
+    data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+    if scope is not None:
+        data["scope"] = scope
+    return client.post("/token", data=data, headers=headers)
+
+
+class TestRefreshTokenClientBinding:
+    """Finding 1: a refresh token may only be spent by its issuing client."""
+
+    def test_other_client_cannot_spend_the_refresh_token(
+        self, client, auth_header, test_auth_header
+    ):
+        tokens = _password_grant(client, auth_header)  # issued to demo-client
+        resp = _refresh(client, test_auth_header, tokens["refresh_token"])
+        assert resp.status_code == 401
+        assert b"not issued to this client" in resp.data
+
+    def test_issuing_client_can_refresh_and_aud_is_preserved(self, client, auth_header):
+        import jwt as pyjwt
+
+        tokens = _password_grant(client, auth_header)
+        original_aud = pyjwt.decode(
+            tokens["id_token"], options={"verify_signature": False}
+        )["aud"]
+
+        resp = _refresh(client, auth_header, tokens["refresh_token"])
+        assert resp.status_code == 200
+        refreshed_aud = pyjwt.decode(
+            json.loads(resp.data)["id_token"], options={"verify_signature": False}
+        )["aud"]
+        # OIDC Core §12.2: the refreshed ID Token aud MUST equal the original
+        assert refreshed_aud == original_aud == "demo-client"
+
+    def test_legacy_refresh_token_without_binding_still_works(self, app, client, auth_header):
+        """Tokens minted before the client_id claim existed keep working."""
+        with app.app_context():
+            from nanoidp.services import get_crypto_service
+            settings = get_config().settings
+            legacy = get_crypto_service(settings.keys_dir).create_jwt(
+                sub="admin",
+                issuer=settings.issuer,
+                audience=settings.audience,
+                extra={"token_type": "refresh", "token_use": "refresh"},
+            )
+        resp = _refresh(client, auth_header, legacy)
+        assert resp.status_code == 200
+
+
+class TestAtomicRotationAndFamilies:
+    """Finding 2: atomic consumption + family revocation on reuse."""
+
+    @pytest.fixture(autouse=True)
+    def enable_rotation(self, app):
+        with app.app_context():
+            get_config().settings.refresh_token_rotation = True
+        yield
+
+    def test_concurrent_double_refresh_succeeds_exactly_once(self, app, auth_header):
+        tokens = _password_grant(app.test_client(), auth_header)
+        refresh_token = tokens["refresh_token"]
+
+        n = 6
+        barrier = threading.Barrier(n)
+        statuses = []
+        lock = threading.Lock()
+
+        def attempt():
+            c = app.test_client()  # one client per thread
+            barrier.wait()
+            resp = _refresh(c, auth_header, refresh_token)
+            with lock:
+                statuses.append(resp.status_code)
+
+        threads = [threading.Thread(target=attempt) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert statuses.count(200) == 1, (
+            f"{statuses.count(200)} concurrent refreshes rotated the same token; "
+            "atomic consumption requires exactly 1"
+        )
+        assert statuses.count(401) == n - 1
+
+    def test_reuse_revokes_the_whole_family(self, client, auth_header):
+        """RFC 9700 §4.14.2: reusing a consumed token must also kill the
+        legitimate descendant, not just reject the stale copy."""
+        tokens = _password_grant(client, auth_header)
+        old = tokens["refresh_token"]
+
+        rotated = json.loads(_refresh(client, auth_header, old).data)["refresh_token"]
+
+        # Attacker replays the consumed token...
+        assert _refresh(client, auth_header, old).status_code == 401
+        # ...and the live descendant is now dead too.
+        assert _refresh(client, auth_header, rotated).status_code == 401
+
+    def test_separate_grants_are_separate_families(self, client, auth_header):
+        """Reuse in one family must not affect tokens from other grants."""
+        family_a = _password_grant(client, auth_header)["refresh_token"]
+        family_b = _password_grant(client, auth_header)["refresh_token"]
+
+        _refresh(client, auth_header, family_a)               # rotate A
+        assert _refresh(client, auth_header, family_a).status_code == 401  # reuse A
+
+        assert _refresh(client, auth_header, family_b).status_code == 200  # B unaffected
+
+
+class TestImplicitPlainPkce:
+    """Finding 3: omitted code_challenge_method defaults to 'plain'."""
+
+    AUTHORIZE = {
+        "response_type": "code",
+        "client_id": "demo-client",
+        "redirect_uri": "http://localhost:9000/callback",
+    }
+
+    def test_stricter_dev_rejects_omitted_method(self, app, client):
+        with app.app_context():
+            get_config().settings.security_profile = "stricter-dev"
+        resp = client.get(
+            "/authorize",
+            query_string={**self.AUTHORIZE, "code_challenge": "x" * 43},
+        )
+        assert resp.status_code == 400
+        assert "plain" in json.loads(resp.data)["error_description"]
+
+    def test_dev_profile_still_accepts_omitted_method(self, client):
+        resp = client.get(
+            "/authorize",
+            query_string={**self.AUTHORIZE, "code_challenge": "x" * 43},
+        )
+        assert resp.status_code == 200
+
+    def test_unknown_method_rejected_in_any_profile(self, client):
+        resp = client.get(
+            "/authorize",
+            query_string={
+                **self.AUTHORIZE,
+                "code_challenge": "x" * 43,
+                "code_challenge_method": "S512",
+            },
+        )
+        assert resp.status_code == 400
+        assert "S512" in json.loads(resp.data)["error_description"]
+
+
+class TestRequirePkcePersistence:
+    """Finding 4: require_pkce must survive save() + reload."""
+
+    def test_save_reload_roundtrip(self, app, preserve_config_files):
+        with app.app_context():
+            config = get_config()
+            config.settings.require_pkce = True
+            config.settings.refresh_token_rotation = True
+            config.save()
+            config.reload()
+            assert config.settings.require_pkce is True
+            assert config.settings.refresh_token_rotation is True
+
+
+class TestHonestScopeResponse:
+    """Finding 5: the response 'scope' reflects what was actually granted."""
+
+    def test_password_grant_reports_granted_scope(self, client, auth_header):
+        data = _password_grant(client, auth_header, "openid profile")
+        assert data["scope"] == "openid profile"
+
+    def test_narrowed_refresh_reports_narrowed_scope(self, client, auth_header):
+        tokens = _password_grant(client, auth_header, "openid profile")
+        resp = _refresh(client, auth_header, tokens["refresh_token"], scope="profile")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["scope"] == "profile"
+        assert "id_token" not in data
+
+    def test_scopeless_grant_omits_scope(self, client, auth_header):
+        data = _password_grant(client, auth_header, scope=None)
+        assert "scope" not in data
+
+    def test_client_credentials_omits_scope_when_none_granted(self, client, auth_header):
+        resp = client.post(
+            "/token", data={"grant_type": "client_credentials"}, headers=auth_header
+        )
+        assert resp.status_code == 200
+        assert "scope" not in json.loads(resp.data)

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -47,7 +47,16 @@ class TestTokenCreation:
         assert "token_type" in result
         assert "expires_in" in result
         assert "refresh_token" in result
-        assert "scope" in result
+        # scope reports what was actually granted (RFC 6749 §5.1, #56):
+        # no scope requested → omitted (it used to be hardcoded to "openid")
+        assert "scope" not in result
+
+    def test_create_token_reports_granted_scope(self, token_service, basic_user, app):
+        """The response scope is the granted one, not a hardcoded value (#56)."""
+        with app.app_context():
+            result = token_service.create_token(basic_user, scope="openid profile")
+
+        assert result["scope"] == "openid profile"
 
     def test_create_token_type_is_bearer(self, token_service, basic_user, app):
         """Test that token_type is Bearer."""


### PR DESCRIPTION
Closes #56.

Addresses all five findings from the owner's review of the #50–#54 merge block, in the suggested priority order, plus a sixth bug found independently.

## 1. Refresh token ↔ client binding (finding 1)

`create_token()` persists the issuing `client_id` in the refresh token claims; the refresh grant rejects any other authenticated client with 401 (RFC 9700 §4.14). Since the binding forces the same client, the refreshed ID Token `aud` is guaranteed identical to the original (OIDC Core §12.2) — tested explicitly with two configured clients. Tokens minted before the claim existed carry no `client_id` and keep working (legacy compat, documented).

## 2. Atomic rotation + token families (finding 2)

The revocation check and the claim of the consumed token now happen in **one critical section** under a new `_revocation_lock`, placed after every validation that may legitimately fail (binding, user, scope narrowing): a rejected request doesn't consume the token, and concurrent double-refresh yields exactly one 200 — covered by a barrier test with 6 simultaneous refreshes. The stale "no lock needed" comment on `_revoked_tokens` is corrected.

Families are implemented as suggested: each grant mints an `rt_family` claim (uuid, propagated unchanged across rotations). Reuse of a consumed token revokes the entire family — the live descendant dies too (RFC 9700 §4.14.2) — while unrelated grants are unaffected (tested). The rotation feature is now legitimately "reuse detection", not just a consumed-token blacklist.

## 3. Implicit `plain` bypass in stricter-dev (finding 3)

The method is normalized **before** validation (`effective_method = code_challenge_method or "plain"`, RFC 7636 §4.3), so omitting the parameter no longer slips past the stricter-dev rejection. Unknown methods (e.g. `S512`) are now rejected at the authorization endpoint in any profile (§4.4.1).

## 4. `require_pkce` persistence (finding 4)

Loaded from and saved to the `oauth` section of `settings.yaml`, like `refresh_token_rotation`. The `update_settings` → `save_config` → `reload_config` roundtrip is tested.

## 5. Honest `scope` response (finding 5)

`create_token()` no longer hardcodes `"scope": "openid"`: it reports the actually granted scope (RFC 6749 §5.1), omits the parameter when no scope was involved, and a narrowed refresh reports the narrowed value. One legacy unit test encoded the old behavior and was updated.

## 6. (bonus) `nanoidp-mcp` crashed at startup

Found by the mypy baseline being prepared for #55: `asyncio.run(stdio_server(server))` passed an async context manager where a coroutine is expected, so the stdio entrypoint died immediately — tests never caught it because they call `_execute_tool` directly. Fixed with the canonical SDK pattern and verified with a real JSON-RPC `initialize` handshake.

## Verification

- 14 new tests in `tests/test_issue_56_review.py` covering every acceptance criterion in #56, including the concurrent and two-client cases the review noted were missing.
- Full suite: **658 passed**, ruff clean. E2E agent against a live server: **40/40**.
