### PR TITLE
feat: type-check src/ with mypy in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           ruff check .
 
+      - name: Type-check with mypy
+        run: |
+          mypy src
+
       - name: Run tests
         run: |
           pytest tests/ -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CI now type-checks `src/` with **mypy** (#55), with a documented
+  gradual-adoption baseline in `pyproject.toml` (`check_untyped_defs`,
+  `no_implicit_optional`, missing-stub imports ignored). All 40 baseline
+  errors were fixed: implicit-`Optional` parameter defaults, heterogeneous
+  dicts annotated `Dict[str, Any]`, `check_client` accepts `Optional`
+  credentials and fails closed, RSA key narrowing in cert generation,
+  signxml certificate passed as PEM string, and `_get_c14n_algorithm`
+  raises instead of returning `None` when signxml is missing. The baseline
+  also surfaced the broken `nanoidp-mcp` entrypoint fixed in #57.
+
 ### Fixed
 - Review follow-ups of the 2026-06-11 merge block (#56):
   - **Refresh tokens are bound to their client**: the issuing `client_id` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "black>=25.12.0",
     "ruff>=0.1.0",
+    "mypy>=1.8.0",
+    "types-PyYAML",
 ]
 
 [project.scripts]
@@ -102,6 +104,18 @@ select = [
 ignore = [
     "E501",  # line too long (handled by black)
 ]
+
+[tool.mypy]
+# Gradual-adoption baseline (#55): catch real type errors in src/ without
+# demanding full annotation coverage yet. Tighten over time (e.g. enable
+# disallow_untyped_defs per module) as annotations improve.
+python_version = "3.10"
+files = ["src"]
+ignore_missing_imports = true  # lxml, signxml, mcp, flask_limiter lack stubs
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -4,6 +4,7 @@ Flask application factory for NanoIDP.
 
 import logging
 import os
+from typing import Optional
 
 from flask import Flask, jsonify
 from flask_cors import CORS
@@ -16,10 +17,10 @@ from .routes import api_bp, oauth_bp, saml_bp, ui_bp
 from .services import init_crypto_service
 
 # Global limiter instance (initialized in create_app)
-limiter = None
+limiter: Optional[Limiter] = None
 
 
-def create_app(config_dir: str = None, profile: str = None) -> Flask:
+def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) -> Flask:
     """Create and configure the Flask application."""
     global limiter
 
@@ -119,17 +120,17 @@ def create_app(config_dir: str = None, profile: str = None) -> Flask:
     return app
 
 
-def get_limiter() -> Limiter:
-    """Get the global limiter instance."""
+def get_limiter() -> Optional[Limiter]:
+    """Get the global limiter instance (None before create_app runs)."""
     return limiter
 
 
 def run_app(
-    host: str = None,
-    port: int = None,
-    debug: bool = None,
-    config_dir: str = None,
-    profile: str = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    debug: Optional[bool] = None,
+    config_dir: Optional[str] = None,
+    profile: Optional[str] = None,
 ):
     """Run the Flask application."""
     app = create_app(config_dir, profile=profile)

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -425,8 +425,14 @@ class ConfigManager:
         import bcrypt
         return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
-    def check_client(self, client_id: str, client_secret: str) -> bool:
-        """Check client credentials."""
+    def check_client(self, client_id: Optional[str], client_secret: Optional[str]) -> bool:
+        """Check client credentials.
+
+        Accepts ``None`` (Flask's ``request.authorization`` fields are
+        Optional) and fails closed: missing credentials never match.
+        """
+        if client_id is None or client_secret is None:
+            return False
         for client in self.settings.clients:
             if client.client_id == client_id and client.client_secret == client_secret:
                 return True
@@ -456,7 +462,7 @@ class ConfigManager:
 
         users_data = {}
         for username, user in self.users.items():
-            user_dict = {
+            user_dict: Dict[str, Any] = {
                 "password": user.password,
                 "email": user.email,
                 "roles": user.roles,
@@ -486,7 +492,7 @@ class ConfigManager:
 
         clients_data = []
         for client in self.settings.clients:
-            client_entry = {
+            client_entry: Dict[str, Any] = {
                 "client_id": client.client_id,
                 "client_secret": client.client_secret,
                 "description": client.description,

--- a/src/nanoidp/exceptions.py
+++ b/src/nanoidp/exceptions.py
@@ -3,6 +3,8 @@ Typed exceptions for NanoIDP.
 Provides clear, specific error handling across the application.
 """
 
+from typing import Optional
+
 
 class NanoIDPError(Exception):
     """Base exception for all NanoIDP errors."""
@@ -143,7 +145,7 @@ class ConfigFileNotFoundError(ConfigurationError):
 class InvalidConfigurationError(ConfigurationError):
     """Raised when configuration is invalid."""
 
-    def __init__(self, message: str, field: str = None):
+    def __init__(self, message: str, field: Optional[str] = None):
         super().__init__(message, "INVALID_CONFIGURATION")
         self.field = field
 

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -18,7 +18,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import jwt as pyjwt
 from mcp.server import Server
@@ -106,7 +106,7 @@ def _check_readonly_mode(tool_name: str) -> Tuple[bool, str]:
     return True, ""
 
 
-def _log_mcp_tool(tool_name: str, success: bool, details: dict = None):
+def _log_mcp_tool(tool_name: str, success: bool, details: Optional[dict] = None):
     """Log MCP tool call to audit log."""
     try:
         audit = get_audit_log()

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -8,6 +8,7 @@ import uuid
 import zlib
 from base64 import b64decode, b64encode
 from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
 
 from flask import Blueprint, Response, abort, render_template, request, session
 from lxml import etree
@@ -51,7 +52,9 @@ def _get_c14n_algorithm(config_value: str) -> "CanonicalizationMethod":
         CanonicalizationMethod enum value
     """
     if not SIGNXML_AVAILABLE:
-        return None
+        # All callers are inside `if ... SIGNXML_AVAILABLE` guards; raising
+        # here (instead of returning None) keeps the return type honest.
+        raise RuntimeError("signxml is not available; cannot sign SAML XML")
 
     if config_value == "c14n":
         return CanonicalizationMethod.CANONICAL_XML_1_0
@@ -142,7 +145,7 @@ def _build_saml_response(
     audience: str,
     name_id: str,
     attributes: dict,
-    in_response_to: str = None,
+    in_response_to: Optional[str] = None,
     sign: bool = True,
 ):
     """Build a SAML Response XML."""
@@ -262,7 +265,9 @@ def _build_saml_response(
             c14n_algorithm=c14n_algo,
         )
         signed = signer.sign(
-            assertion, key=crypto.priv_pem, cert=cert_pem, reference_uri=assertion_id
+            # signxml's typed API takes the certificate as a PEM string
+            assertion, key=crypto.priv_pem, cert=cert_pem.decode("ascii"),
+            reference_uri=assertion_id
         )
         resp.remove(assertion)
         resp.append(signed)
@@ -611,7 +616,7 @@ def _sign_attribute_query_response(response_xml: str, sign: bool = True) -> str:
             c14n_algorithm=c14n_algo,
         )
 
-        signed_root = signer.sign(root, key=crypto.priv_pem, cert=cert_pem)
+        signed_root = signer.sign(root, key=crypto.priv_pem, cert=cert_pem.decode("ascii"))
         return etree.tostring(signed_root, encoding="unicode", pretty_print=True)
 
     except Exception as e:
@@ -672,7 +677,7 @@ def attribute_query():
 
         if user:
             # Build attributes from user config
-            attributes = {
+            attributes: Dict[str, Any] = {
                 "email": user.email or f"{user_id}@example.com",
             }
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -91,7 +91,8 @@ def login():
         method="POST",
         status="success",
         username=username,
-        **req_info,
+        ip_address=req_info["ip_address"],
+        user_agent=req_info["user_agent"],
     )
 
     return redirect(url_for("ui.index"))

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -142,6 +142,8 @@ class CryptoService:
 
     def _load_external_keys(self):
         """Load external PEM keys instead of generating new ones."""
+        if self._external_private_key is None or self._external_public_key is None:
+            raise ValueError("External key paths not configured")
         logger.info(f"Loading external keys from {self._external_private_key}")
 
         priv_path = Path(self._external_private_key)
@@ -218,6 +220,13 @@ class CryptoService:
 
         private_key = serialization.load_pem_private_key(self.priv_pem, password=None)
         public_key = serialization.load_pem_public_key(self.pub_pem)
+        # The loaders return a union over every supported key algorithm, but
+        # nanoidp keys are always RSA — and CertificateBuilder rejects e.g. DH
+        # keys, so narrow before use.
+        if not isinstance(private_key, rsa.RSAPrivateKey) or not isinstance(
+            public_key, rsa.RSAPublicKey
+        ):
+            raise ValueError("Certificate generation requires RSA keys")
 
         subject = issuer = x509.Name(
             [

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -142,7 +142,7 @@ class TokenService:
             exp_minutes = settings.token_expiry_minutes
 
         # Build extra claims
-        extra = {}
+        extra: Dict[str, Any] = {}
 
         # Add core user attributes
         if user.identity_class:

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -94,7 +94,7 @@ class YamlWriter:
         if is_new and user.username in data.get("users", {}):
             raise ValueError(f"User '{user.username}' already exists")
 
-        user_data = {
+        user_data: Dict[str, Any] = {
             "password": user.password,
             "email": user.email,
         }
@@ -181,7 +181,7 @@ class YamlWriter:
         if is_new and existing_idx is not None:
             raise ValueError(f"Client '{client.client_id}' already exists")
 
-        client_data = {
+        client_data: Dict[str, Any] = {
             "client_id": client.client_id,
             "client_secret": client.client_secret,
             "description": client.description,


### PR DESCRIPTION
Closes #55.

## What

- **mypy in CI**: new `mypy src` step in the tests workflow (after ruff), `mypy>=1.8.0` + `types-PyYAML` in dev dependencies.
- **Baseline config** in `pyproject.toml` `[tool.mypy]`, documented as gradual-adoption: `check_untyped_defs`, `no_implicit_optional`, `warn_redundant_casts`, `warn_unused_ignores`; `ignore_missing_imports` because lxml/signxml/mcp/flask_limiter ship no stubs. Tightening (e.g. per-module `disallow_untyped_defs`) can come later.
- **All 40 baseline errors fixed** — annotations and narrowing only, no intended behavior change:
  - implicit-`Optional` parameter defaults (app.py, exceptions.py, saml.py, mcp_server.py)
  - heterogeneous dicts annotated `Dict[str, Any]` where mypy inferred too-narrow value types from the first assignment (config.py, yaml_writer.py, token.py, saml.py)
  - `check_client()` accepts `Optional` credentials and fails closed — Flask's `request.authorization` fields are Optional at all 4 call sites
  - cert generation narrows loaded PEM keys to RSA before `CertificateBuilder` (the loaders return a union including key types the builder rejects); `_load_external_keys` raises clearly when paths are unconfigured
  - signxml's typed `sign()` takes the certificate as a PEM **string**: decoded at both call sites (SAML e2e signing verified live)
  - `_get_c14n_algorithm` raises instead of returning `None` when signxml is missing (all callers are `SIGNXML_AVAILABLE`-guarded), keeping the declared return type honest
  - the UI login audit call passes `ip_address`/`user_agent` explicitly instead of `**req_info`, so the kwargs can't be confused with the `details` parameter

Worth noting: this baseline is what surfaced the broken `nanoidp-mcp` stdio entrypoint fixed in #57 — the check already paid for itself.

## Verification

- `mypy src`: clean on 19 source files; ruff clean.
- Full suite: **658 passed**.
- E2E agent against a live server: **40/40** (includes the SAML signing paths touched by the cert decode change).
