### PR TITLE
fix: validate exp/extra before the grant dispatch — rotation never consumes a token on a rejected request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expected"): `stdio_server()` is an async context manager yielding the
   message streams, not a coroutine. Found by the mypy baseline being
   prepared for #55; verified with a JSON-RPC initialize handshake.
+- The token endpoint validates `exp` and `extra` before the grant dispatch:
+  with rotation enabled, a malformed value can no longer consume the refresh
+  token without delivering its replacement (the last tradeoff noted in the
+  #56 review), and a non-numeric `exp` now returns a proper 400 instead of
+  an unhandled `ValueError` (500).
 
 ### Added
 - Optional **refresh token rotation** (#46): with `oauth.refresh_token_rotation: true`

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -365,6 +365,42 @@ def token():
         )
         return abort(401, description="Invalid client credentials")
 
+    # Validate the grant-independent 'exp' and 'extra' params BEFORE the grant
+    # dispatch: the rotation branch atomically consumes the refresh token at
+    # the end of its validations, so nothing after it may reject the request
+    # (#56 review follow-up). This also turns a non-numeric 'exp' into a
+    # proper 400 instead of an unhandled ValueError (500).
+    try:
+        exp_minutes = int(request.form.get("exp", config.settings.token_expiry_minutes))
+    except (TypeError, ValueError):
+        audit.log(
+            event_type="token_request",
+            endpoint="/token",
+            method="POST",
+            status="failed",
+            client_id=client_id,
+            details={"reason": "Invalid 'exp' parameter", "grant_type": grant_type},
+            **req_info,
+        )
+        return abort(400, description="'exp' must be an integer number of minutes")
+
+    extra_claims = None
+    extra_raw = request.form.get("extra")
+    if extra_raw:
+        try:
+            extra_claims = json.loads(extra_raw)
+        except json.JSONDecodeError:
+            audit.log(
+                event_type="token_request",
+                endpoint="/token",
+                method="POST",
+                status="failed",
+                client_id=client_id,
+                details={"reason": "Invalid JSON in 'extra'", "grant_type": grant_type},
+                **req_info,
+            )
+            return abort(400, description="Invalid JSON in 'extra'")
+
     # Refresh token grant
     if grant_type == "refresh_token":
         refresh_token = request.form.get("refresh_token", "")
@@ -499,12 +535,10 @@ def token():
         # (#56). Reuse of an already-consumed token is treated as leakage and
         # revokes the whole family — attacker's copy and legitimate descendant
         # alike (RFC 9700 §4.14.2). This block sits after every validation
-        # that may legitimately fail (binding, user, scope narrowing), so a
-        # rejected request does not consume the token. Known edge: malformed
-        # 'exp'/'extra' form params are parsed in the grant-common code below,
-        # i.e. AFTER the claim — a client sending garbage there does lose the
-        # token; accepted tradeoff, since claiming any later would reopen the
-        # double-rotation race.
+        # that may reject the request (binding, user, scope narrowing — and
+        # the grant-independent 'exp'/'extra' params, validated before the
+        # grant dispatch), so a rejected request never consumes the token:
+        # from here on, issuance is local signing and cannot fail.
         jti = payload.get("jti")
         with _revocation_lock:
             family_revoked = bool(refresh_family) and refresh_family in _revoked_token_families
@@ -785,19 +819,8 @@ def token():
         )
         return abort(400, description=f"Unsupported grant_type: {grant_type}")
 
-    # Get expiration from request or use default
-    exp_minutes = int(request.form.get("exp", config.settings.token_expiry_minutes))
-
-    # Parse extra claims if provided
-    extra_claims = None
-    extra_raw = request.form.get("extra")
-    if extra_raw:
-        try:
-            extra_claims = json.loads(extra_raw)
-        except json.JSONDecodeError:
-            return abort(400, description="Invalid JSON in 'extra'")
-
-    # Create token
+    # Create token ('exp' and 'extra' were validated before the grant dispatch
+    # so the rotation claim above is the last thing that can reject)
     token_service = get_token_service()
     token_response = token_service.create_token(
         user=user,

--- a/tests/test_issue_56_review.py
+++ b/tests/test_issue_56_review.py
@@ -94,6 +94,43 @@ class TestAtomicRotationAndFamilies:
             get_config().settings.refresh_token_rotation = True
         yield
 
+    def test_malformed_extra_does_not_consume_the_token(self, client, auth_header):
+        """'exp'/'extra' are validated before the grant dispatch, so a 400
+        there never burns the refresh token (post-#56 review note)."""
+        tokens = _password_grant(client, auth_header)
+
+        bad = client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": tokens["refresh_token"],
+                "extra": "{not-json",
+            },
+            headers=auth_header,
+        )
+        assert bad.status_code == 400
+
+        retry = _refresh(client, auth_header, tokens["refresh_token"])
+        assert retry.status_code == 200
+
+    def test_non_numeric_exp_is_a_400_and_does_not_consume(self, client, auth_header):
+        """A non-numeric 'exp' used to raise an unhandled ValueError (500)."""
+        tokens = _password_grant(client, auth_header)
+
+        bad = client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": tokens["refresh_token"],
+                "exp": "abc",
+            },
+            headers=auth_header,
+        )
+        assert bad.status_code == 400
+
+        retry = _refresh(client, auth_header, tokens["refresh_token"])
+        assert retry.status_code == 200
+
     def test_concurrent_double_refresh_succeeds_exactly_once(self, app, auth_header):
         tokens = _password_grant(app.test_client(), auth_header)
         refresh_token = tokens["refresh_token"]


### PR DESCRIPTION
Follow-up to the #56 review's last note (the declared `exp`/`extra` tradeoff) — as suggested there, the tradeoff is not necessary.

## What

`exp` and `extra` are grant-independent, so they are now parsed and validated **before** the grant dispatch. The rotation branch's atomic claim is therefore the last operation that can reject a request: a 400 on any parameter leaves the refresh token valid, with no race reopened (the claim still happens before issuance).

Bonus found while moving the code: a non-numeric `exp` (`exp=abc`) previously raised an unhandled `ValueError` → **500**, consuming the token along the way under rotation. It now returns a proper 400 with an audit entry, consistent with `extra`.

The now-obsolete "known edge" comment in the rotation block is replaced with the accurate invariant.

## Verification

- 2 new tests: malformed `extra` and non-numeric `exp` each return 400 *and* the refresh token still works afterwards (rotation enabled).
- Full suite: **660 passed**, ruff clean.

Independent of #58 (mypy) — only `routes/oauth.py`, tests and changelog; mergeable in either order.
