### PR TITLE
fix: semantic validation of exp/extra; explicit mypy stub-ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,11 +111,22 @@ ignore = [
 # disallow_untyped_defs per module) as annotations improve.
 python_version = "3.10"
 files = ["src"]
-ignore_missing_imports = true  # lxml, signxml, mcp, flask_limiter lack stubs
 check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 no_implicit_optional = true
+
+[[tool.mypy.overrides]]
+# Only these dependencies ship no type stubs; keeping the list explicit (vs a
+# global ignore_missing_imports) means a new untyped import gets flagged
+# instead of silently ignored.
+module = [
+    "lxml.*",
+    "signxml.*",
+    "flask_cors.*",
+    "flask_limiter.*",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -368,8 +368,10 @@ def token():
     # Validate the grant-independent 'exp' and 'extra' params BEFORE the grant
     # dispatch: the rotation branch atomically consumes the refresh token at
     # the end of its validations, so nothing after it may reject the request
-    # (#56 review follow-up). This also turns a non-numeric 'exp' into a
-    # proper 400 instead of an unhandled ValueError (500).
+    # (#56 review follow-up). Validation is semantic, not just syntactic:
+    # json.loads("42") succeeds but extra.update(42) raises later, and a huge
+    # 'exp' passes int() but overflows the timedelta arithmetic — both would
+    # be 500s after the token was consumed.
     try:
         exp_minutes = int(request.form.get("exp", config.settings.token_expiry_minutes))
     except (TypeError, ValueError):
@@ -383,12 +385,24 @@ def token():
             **req_info,
         )
         return abort(400, description="'exp' must be an integer number of minutes")
+    # Same bounds the Settings model enforces for token_expiry_minutes
+    if not 1 <= exp_minutes <= 1440:
+        audit.log(
+            event_type="token_request",
+            endpoint="/token",
+            method="POST",
+            status="failed",
+            client_id=client_id,
+            details={"reason": "'exp' out of range", "grant_type": grant_type},
+            **req_info,
+        )
+        return abort(400, description="'exp' must be between 1 and 1440 minutes")
 
     extra_claims = None
     extra_raw = request.form.get("extra")
     if extra_raw:
         try:
-            extra_claims = json.loads(extra_raw)
+            parsed_extra = json.loads(extra_raw)
         except json.JSONDecodeError:
             audit.log(
                 event_type="token_request",
@@ -400,6 +414,19 @@ def token():
                 **req_info,
             )
             return abort(400, description="Invalid JSON in 'extra'")
+        # Any JSON scalar/array parses fine but is not a claims mapping
+        if not isinstance(parsed_extra, dict):
+            audit.log(
+                event_type="token_request",
+                endpoint="/token",
+                method="POST",
+                status="failed",
+                client_id=client_id,
+                details={"reason": "'extra' is not a JSON object", "grant_type": grant_type},
+                **req_info,
+            )
+            return abort(400, description="'extra' must be a JSON object")
+        extra_claims = parsed_extra
 
     # Refresh token grant
     if grant_type == "refresh_token":

--- a/tests/test_issue_56_review.py
+++ b/tests/test_issue_56_review.py
@@ -131,6 +131,49 @@ class TestAtomicRotationAndFamilies:
         retry = _refresh(client, auth_header, tokens["refresh_token"])
         assert retry.status_code == 200
 
+    def test_non_object_extra_is_a_400_and_does_not_consume(self, client, auth_header):
+        """json.loads('42') succeeds, but extra.update(42) would be a 500
+        AFTER the claim — 'extra' must be a JSON object (second review)."""
+        tokens = _password_grant(client, auth_header)
+
+        for bad_extra in ("42", '"hello"', "[1, 2]"):
+            resp = client.post(
+                "/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": tokens["refresh_token"],
+                    "extra": bad_extra,
+                },
+                headers=auth_header,
+            )
+            assert resp.status_code == 400, f"extra={bad_extra!r}"
+            assert b"JSON object" in resp.data
+
+        retry = _refresh(client, auth_header, tokens["refresh_token"])
+        assert retry.status_code == 200
+
+    def test_out_of_range_exp_is_a_400_and_does_not_consume(self, client, auth_header):
+        """A huge 'exp' passes int() but overflows the timedelta arithmetic
+        after the claim; the HTTP param now enforces the same 1..1440 bounds
+        as the Settings model (second review)."""
+        tokens = _password_grant(client, auth_header)
+
+        for bad_exp in ("0", "-5", "2000", "9" * 30):
+            resp = client.post(
+                "/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": tokens["refresh_token"],
+                    "exp": bad_exp,
+                },
+                headers=auth_header,
+            )
+            assert resp.status_code == 400, f"exp={bad_exp!r}"
+            assert b"between 1 and 1440" in resp.data
+
+        retry = _refresh(client, auth_header, tokens["refresh_token"])
+        assert retry.status_code == 200
+
     def test_concurrent_double_refresh_succeeds_exactly_once(self, app, auth_header):
         tokens = _password_grant(app.test_client(), auth_header)
         refresh_token = tokens["refresh_token"]


### PR DESCRIPTION
Follow-up to the second review of `f14eecb`/`3a04fee` — both findings addressed.

## 1. `exp`/`extra`: semantic, not just syntactic validation

The review was right: two cases still rejected **after** the rotation claim consumed the refresh token:

- `extra=42` (any JSON scalar or array): `json.loads` succeeds, `extra.update(42)` raises `TypeError` → 500. Now: `'extra' must be a JSON object` → 400.
- astronomical `exp`: Python ints don't overflow in `int()`, but the `timedelta` arithmetic does (`OverflowError` → 500). Now the HTTP param enforces the same `1..1440` bounds the `Settings` model already imposes on `token_expiry_minutes` → 400.

With these, "the rotation claim is the last operation that can reject" finally holds. New tests cover `extra` as scalar/string/array and `exp` ∈ {0, -5, 2000, 10³⁰}, each asserting 400 **and** that the refresh token remains usable under rotation.

## 2. mypy: explicit stub-ignore list

`ignore_missing_imports` is no longer global: a `[[tool.mypy.overrides]]` block lists exactly the dependencies that ship no stubs — `lxml`, `signxml`, `flask_cors`, `flask_limiter` — so a future untyped import gets flagged instead of silently ignored. Side discovery: `mcp` ships `py.typed` and never needed the flag; the global setting was hiding that.

## Verification

Full suite **662 passed**, ruff clean, `mypy src` clean.

Note: I had started preparing the 2.2.0 release when this review arrived — the release PR will follow stacked on this one, so the tag ships with this fix included.
