### PR TITLE
docs: vision refinements — scope the promises to what nanoidp can keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Features
 
-- **OAuth2 / OIDC** - Full OAuth2 implementation with Authorization Code, Password, Client Credentials, Refresh Token, and Device Authorization grants
+- **OAuth2 / OIDC** - OAuth2/OIDC support for development and integration testing: Authorization Code, Password, Client Credentials, Refresh Token, and Device Authorization grants
 - **PKCE Support** - Proof Key for Code Exchange (RFC 7636) with S256 and plain methods
 - **Token Management** - Introspection (RFC 7662) and Revocation (RFC 7009) endpoints
 - **OIDC Logout** - End Session endpoint for RP-initiated logout

--- a/VISION.md
+++ b/VISION.md
@@ -8,18 +8,23 @@ spec-honest OAuth2/OIDC and SAML 2.0 counterpart to integrate against,
 without standing up Keycloak or wiring a cloud tenant: `pip install`, two
 YAML files, go.
 
-The product is **confidence**: if your client works against nanoidp, the
-tokens, claims and flows it relied on are the ones the RFCs describe.
+The product is **confidence**: the behaviors nanoidp advertises and
+implements are grounded in the relevant specifications, so clients can
+test against them without depending on accidental or invented semantics.
 
 ## Principles
 
 These are the criteria every change is judged by. They have been applied
 implicitly throughout the project's history; this writes them down.
 
-1. **A dev tool, not a production IdP.** Tradeoffs are weighed by asking
-   *"would this mislead someone testing against it?"* — never *"would this
-   survive an attack?"*. Convenience that doesn't distort spec behavior is
-   welcome; hardening that costs convenience must be optional.
+1. **A dev tool, not a production IdP.** Tradeoffs are primarily weighed
+   by asking *"would this mislead someone testing against it?"*, rather
+   than *"is this hardened enough to operate as a production identity
+   provider?"*. Security behaviors (PKCE, rotation, client binding) are
+   first-class precisely because clients need to test them; what nanoidp
+   does not promise is production-grade operation. Convenience that
+   doesn't distort spec behavior is welcome; hardening that costs
+   convenience must be optional.
 2. **Metadata never lies.** Discovery and documentation advertise exactly
    what the endpoints implement — a missing feature is acceptable, a
    pretended one is not (see #41: `response_type=token` was advertised but
@@ -28,11 +33,15 @@ implicitly throughout the project's history; this writes them down.
    security profiles (`stricter-dev`) and explicit settings (`require_pkce`,
    `refresh_token_rotation`); the out-of-the-box experience favors getting
    a first token in under a minute.
-4. **MCP/HTTP parity.** Every capability exposed over HTTP is reachable by
-   agents over MCP, built from a single source of truth so the two surfaces
-   cannot drift (see #40: the shared discovery builder).
-5. **Features ship whole.** A feature lands together with its MCP exposure,
-   its `examples/test_agent.py` e2e coverage and its docs — in the same PR.
+4. **MCP/HTTP parity.** Every administrative and testing capability that
+   is meaningful to agents is exposed through MCP, with shared builders
+   and models wherever possible so equivalent surfaces cannot drift (see
+   #40: the shared discovery builder). Protocol surfaces themselves —
+   authorization redirects, SAML SSO, UserInfo — are exercised over HTTP,
+   as a real client would.
+5. **Features ship whole.** A feature lands together with its MCP exposure
+   (where applicable), its `examples/test_agent.py` e2e coverage and its
+   docs — in the same PR.
 6. **RFC-citable behavior.** Token and protocol behaviors reference the
    spec paragraph that justifies them, in code comments and changelog
    entries alike. When a reviewer disagrees, the RFC arbitrates.


### PR DESCRIPTION
Applies the four wording fixes from the VISION.md review:

1. **Central promise** — no longer readable as "compatibility with nanoidp implies standards conformance"; confidence is tied to the behaviors nanoidp *advertises and implements* (reviewer's wording, verbatim).
2. **Principle 1** — drops the absolute "never 'would this survive an attack?'": security behaviors (PKCE, rotation, client binding) are first-class precisely because clients need to test them; what nanoidp doesn't promise is production-grade *operation*.
3. **MCP/HTTP parity** — scoped to administrative/testing capabilities meaningful to agents, with shared builders so equivalent surfaces can't drift; protocol surfaces (authorization redirects, SAML SSO, UserInfo) are exercised over HTTP as a real client would. "Features ship whole" gains *where applicable* on MCP exposure.
4. **README contradiction** — "Full OAuth2 implementation" replaced with "OAuth2/OIDC support for development and integration testing" + the same accurate grant list; "Full" undermined both the spec-completeness non-goal and "metadata never lies". (No other "Full <protocol>" claims found in README or docs/.)

The OAuth 2.1 "draft" wording stays as-is per the review (draft-ietf-oauth-v2-1-15, IESG submission expected Dec 2026).

Doc-only change.
