### PR TITLE
ci: enforce coverage threshold and fail on Codecov upload errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,11 +42,12 @@ jobs:
       - name: Run tests with coverage
         if: matrix.python-version == '3.12'
         run: |
-          pytest tests/ --cov=nanoidp --cov-report=xml --cov-report=term-missing
+          # Threshold ratchets upward only (#71); measured 73% when introduced.
+          pytest tests/ --cov=nanoidp --cov-report=xml --cov-report=term-missing --cov-fail-under=70
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,4 @@ jobs:
         if: matrix.python-version == '3.12'
         run: |
           # Threshold ratchets upward only (#71); measured 73% when introduced.
-          pytest tests/ --cov=nanoidp --cov-report=xml --cov-report=term-missing --cov-fail-under=70
-
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: true
+          pytest tests/ --cov=nanoidp --cov-report=term-missing --cov-fail-under=70


### PR DESCRIPTION
Closes #71 — first execution PR of the [CI quality gates](https://github.com/cdelmonte-zg/nanoidp/milestone/4) milestone.

- `--cov-fail-under=70` on the 3.12 coverage step. Measured today: 72.88% across 662 tests, so the gate has ~3 points of headroom against flakiness while still catching real regressions. Per the issue, the threshold only ratchets upward (a comment in the workflow says so); #72 (covering `wizard.py`, currently 0%) is the natural next bump.
- ~~`fail_ci_if_error: true` on the Codecov upload~~ → **the Codecov upload step is removed.** Turning the flag on surfaced that the upload has failed on every run since inception ("Token required - not valid tokenless upload"): the repo has no `CODECOV_TOKEN` secret, no `codecov.yml`, no badge — Codecov was never set up, and `fail_ci_if_error: false` hid that. A step that pretends to publish coverage nowhere is exactly what #71 exists to stop. Coverage enforcement now lives entirely in CI; if dashboards are ever wanted, re-add the action with a real token. (Details in the PR comment.)

Verified locally: the full suite passes the gate (`Required test coverage of 70% reached`).