### PR TITLE
mypy ratchet tranche 1: 13 modules under disallow_untyped_defs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,28 @@ warn_unused_ignores = true
 no_implicit_optional = true
 
 [[tool.mypy.overrides]]
+# Typing ratchet (#70): modules here require fully annotated defs. The list
+# only grows; when all of src/ is in, flip disallow_untyped_defs globally
+# and delete this block. Still out: config, routes.{api,oauth,saml,ui},
+# services.crypto.
+module = [
+    "nanoidp",
+    "nanoidp.__main__",
+    "nanoidp.app",
+    "nanoidp.exceptions",
+    "nanoidp.mcp_server",
+    "nanoidp.wizard",
+    "nanoidp.routes",
+    "nanoidp.services",
+    "nanoidp.services.audit",
+    "nanoidp.services.auth_code",
+    "nanoidp.services.discovery",
+    "nanoidp.services.token",
+    "nanoidp.services.yaml_writer",
+]
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
 # Only these dependencies ship no type stubs; keeping the list explicit (vs a
 # global ignore_missing_imports) means a new untyped import gets flagged
 # instead of silently ignored.

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -122,7 +122,7 @@ Default credentials:
 """)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="NanoIDP - Lightweight Identity Provider for testing OAuth2/OIDC and SAML integrations"
     )

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -6,7 +6,7 @@ import logging
 import os
 from typing import Optional
 
-from flask import Flask, jsonify
+from flask import Flask, Response, jsonify
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -102,12 +102,12 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
 
     # Context processor to inject version into all templates
     @app.context_processor
-    def inject_version():
+    def inject_version() -> dict[str, str]:
         return {"app_version": __version__}
 
     # Health check at root for backward compatibility
     @app.route("/health")
-    def health():
+    def health() -> Response:
         return jsonify({"status": "ok"})
 
     logger.info("NanoIDP initialized")
@@ -131,7 +131,7 @@ def run_app(
     debug: Optional[bool] = None,
     config_dir: Optional[str] = None,
     profile: Optional[str] = None,
-):
+) -> None:
     """Run the Flask application."""
     app = create_app(config_dir, profile=profile)
     config = get_config()

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -106,7 +106,7 @@ def _check_readonly_mode(tool_name: str) -> Tuple[bool, str]:
     return True, ""
 
 
-def _log_mcp_tool(tool_name: str, success: bool, details: Optional[dict] = None):
+def _log_mcp_tool(tool_name: str, success: bool, details: Optional[dict] = None) -> None:
     """Log MCP tool call to audit log."""
     try:
         audit = get_audit_log()
@@ -971,7 +971,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
 # Main Entry Point
 # =============================================================================
 
-def main():
+def main() -> None:
     """Run the MCP server."""
     global _readonly_mode
 

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -70,7 +70,7 @@ class AuditLog:
         ip_address: str = "unknown",
         user_agent: str = "unknown",
         details: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         """Log an audit event."""
         entry = AuditEntry(
             timestamp=datetime.now(timezone.utc),
@@ -109,7 +109,7 @@ class AuditLog:
         else:
             logger.warning(log_msg)
 
-    def _update_stats(self, event_type: str, status: str):
+    def _update_stats(self, event_type: str, status: str) -> None:
         """Update statistics counters."""
         self._stats["total_requests"] += 1
 
@@ -164,7 +164,7 @@ class AuditLog:
         with self._lock:
             return dict(self._stats)
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear the audit log."""
         with self._lock:
             self._entries.clear()

--- a/src/nanoidp/services/auth_code.py
+++ b/src/nanoidp/services/auth_code.py
@@ -38,7 +38,7 @@ class AuthCodeStore:
     Codes expire after 10 minutes (per RFC 6749).
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._codes: Dict[str, AuthorizationCode] = {}
         # Flask serves requests on multiple threads; every access to the shared
         # dict goes through this lock so consume_code stays atomic and one-time
@@ -198,7 +198,7 @@ class AuthCodeStore:
             logger.warning(f"Unknown PKCE method: {method}")
             return False
 
-    def _cleanup_expired(self):
+    def _cleanup_expired(self) -> None:
         """Remove expired authorization codes. Callers must hold ``self._lock``."""
         with self._lock:
             now = datetime.now(timezone.utc)

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class TokenService:
     """Service for generating JWT tokens."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.config = get_config()
         self.crypto = get_crypto_service(self.config.settings.keys_dir)
 

--- a/src/nanoidp/wizard.py
+++ b/src/nanoidp/wizard.py
@@ -43,7 +43,7 @@ def _confirm(message: str) -> bool:
             return False
 
 
-def _print_header(title: str):
+def _print_header(title: str) -> None:
     """Print a section header."""
     print()
     print(f"{'─' * 50}")
@@ -51,7 +51,7 @@ def _print_header(title: str):
     print(f"{'─' * 50}")
 
 
-def _print_box(lines: list[str], title: str = ""):
+def _print_box(lines: list[str], title: str = "") -> None:
     """Print text in a box."""
     width = max(len(line) for line in lines) + 4
     width = max(width, len(title) + 4)


### PR DESCRIPTION
First tranche of #70 (does not close it — tranches 2–3 remain).

- Annotates the 14 missing return types in the small-tail modules (`wizard`, `__main__`, `app`, `mcp_server`, `services/{audit,auth_code,token}`) — annotations only, no behavioral change. The only non-`None` ones: `inject_version() -> dict[str, str]` and `health() -> Response` in `app.py`.
- Adds the ratchet override in `pyproject.toml`: 13 modules (the 6 already-clean ones — `nanoidp`, `exceptions`, `routes`, `services`, `services/discovery`, `services/yaml_writer` — plus the 7 just annotated) now run with `disallow_untyped_defs = true`. Explicit module list, no wildcards, so `services.crypto` and the big route modules stay out until their tranches.

Verified: `mypy src` clean, `ruff check .` clean, 662 tests pass — and a negative probe (an unannotated def added to a ratcheted module) fails mypy as intended, confirming the override actually bites.

Remaining for #70: tranche 2 (`services/crypto`, `routes/{saml,oauth,api}` — 40 errors), tranche 3 (`config.py`, `routes/ui.py` — 41 errors).