### PR TITLE
mypy ratchet tranche 2: crypto and the api/oauth/saml routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,7 @@ no_implicit_optional = true
 [[tool.mypy.overrides]]
 # Typing ratchet (#70): modules here require fully annotated defs. The list
 # only grows; when all of src/ is in, flip disallow_untyped_defs globally
-# and delete this block. Still out: config, routes.{api,oauth,saml,ui},
-# services.crypto.
+# and delete this block. Still out: config, routes.ui.
 module = [
     "nanoidp",
     "nanoidp.__main__",
@@ -129,9 +128,13 @@ module = [
     "nanoidp.mcp_server",
     "nanoidp.wizard",
     "nanoidp.routes",
+    "nanoidp.routes.api",
+    "nanoidp.routes.oauth",
+    "nanoidp.routes.saml",
     "nanoidp.services",
     "nanoidp.services.audit",
     "nanoidp.services.auth_code",
+    "nanoidp.services.crypto",
     "nanoidp.services.discovery",
     "nanoidp.services.token",
     "nanoidp.services.yaml_writer",

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -5,6 +5,7 @@ REST API routes for management and monitoring.
 import logging
 
 from flask import Blueprint, jsonify, request
+from flask.typing import ResponseReturnValue
 
 from ..config import get_config
 from ..services import get_audit_log, get_token_service
@@ -15,13 +16,13 @@ api_bp = Blueprint("api", __name__, url_prefix="/api")
 
 
 @api_bp.route("/health")
-def health():
+def health() -> ResponseReturnValue:
     """Health check endpoint."""
     return jsonify({"status": "ok"})
 
 
 @api_bp.route("/users")
-def list_users():
+def list_users() -> ResponseReturnValue:
     """List all configured users (without passwords)."""
     config = get_config()
     users = []
@@ -39,7 +40,7 @@ def list_users():
 
 
 @api_bp.route("/users/<username>")
-def get_user(username: str):
+def get_user(username: str) -> ResponseReturnValue:
     """Get details for a specific user."""
     config = get_config()
     user = config.get_user(username)
@@ -63,7 +64,7 @@ def get_user(username: str):
 
 
 @api_bp.route("/users/<username>/token", methods=["POST"])
-def generate_token(username: str):
+def generate_token(username: str) -> ResponseReturnValue:
     """Generate a token for a user (for testing)."""
     config = get_config()
     user = config.get_user(username)
@@ -79,7 +80,7 @@ def generate_token(username: str):
 
 
 @api_bp.route("/audit")
-def get_audit():
+def get_audit() -> ResponseReturnValue:
     """Get audit log entries."""
     audit = get_audit_log()
 
@@ -96,14 +97,14 @@ def get_audit():
 
 
 @api_bp.route("/audit/stats")
-def get_audit_stats():
+def get_audit_stats() -> ResponseReturnValue:
     """Get audit statistics."""
     audit = get_audit_log()
     return jsonify(audit.get_stats())
 
 
 @api_bp.route("/audit/clear", methods=["POST"])
-def clear_audit():
+def clear_audit() -> ResponseReturnValue:
     """Clear the audit log."""
     audit = get_audit_log()
     audit.clear()
@@ -111,7 +112,7 @@ def clear_audit():
 
 
 @api_bp.route("/config")
-def get_configuration():
+def get_configuration() -> ResponseReturnValue:
     """Get current configuration (excluding secrets)."""
     config = get_config()
     settings = config.settings
@@ -144,7 +145,7 @@ def get_configuration():
 
 
 @api_bp.route("/config/reload", methods=["POST"])
-def reload_config():
+def reload_config() -> ResponseReturnValue:
     """Reload configuration from files."""
     config = get_config()
     config.reload()
@@ -155,7 +156,7 @@ def reload_config():
 
 
 @api_bp.route("/keys/rotate", methods=["POST"])
-def rotate_keys():
+def rotate_keys() -> ResponseReturnValue:
     """Rotate cryptographic keys.
 
     Moves the current active key to 'previous' keys (kept for token validation)
@@ -191,7 +192,7 @@ def rotate_keys():
 
 
 @api_bp.route("/keys/info")
-def keys_info():
+def keys_info() -> ResponseReturnValue:
     """Get information about current cryptographic keys."""
     from ..services import get_crypto_service
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -7,10 +7,12 @@ import logging
 import secrets
 import threading
 import time
+from typing import TypedDict
 from urllib.parse import urlencode, urlparse
 
 import jwt as pyjwt
 from flask import Blueprint, abort, jsonify, redirect, render_template, request, session
+from flask.typing import ResponseReturnValue
 
 from ..config import User, get_config
 from ..services import (
@@ -26,7 +28,12 @@ logger = logging.getLogger(__name__)
 oauth_bp = Blueprint("oauth", __name__)
 
 
-def _get_request_info():
+class _RequestInfo(TypedDict):
+    ip_address: str
+    user_agent: str
+
+
+def _get_request_info() -> _RequestInfo:
     """Get request info for audit logging."""
     return {
         "ip_address": request.remote_addr or "unknown",
@@ -37,14 +44,14 @@ def _get_request_info():
 
 
 @oauth_bp.route("/.well-known/openid-configuration")
-def oidc_config():
+def oidc_config() -> ResponseReturnValue:
     """OIDC Discovery endpoint."""
     config = get_config()
     return jsonify(build_discovery_document(config.settings))
 
 
 @oauth_bp.route("/.well-known/jwks.json")
-def jwks():
+def jwks() -> ResponseReturnValue:
     """JWKS endpoint for JWT verification.
 
     Returns all keys including previous keys for rotation support.
@@ -55,7 +62,7 @@ def jwks():
 
 
 @oauth_bp.route("/authorize", methods=["GET", "POST"])
-def authorize():
+def authorize() -> ResponseReturnValue:
     """
     OAuth2 Authorization endpoint.
     Supports Authorization Code Flow with optional PKCE.
@@ -298,7 +305,7 @@ def authorize():
 
 
 @oauth_bp.route("/token", methods=["POST"])
-def token():
+def token() -> ResponseReturnValue:
     """OAuth2 token endpoint."""
     config = get_config()
     audit = get_audit_log()
@@ -902,7 +909,7 @@ def _extract_bearer_token() -> str | None:
 
 
 @oauth_bp.route("/userinfo", methods=["GET", "POST"])
-def userinfo():
+def userinfo() -> ResponseReturnValue:
     """
     OIDC UserInfo endpoint.
     Returns claims about the authenticated user.
@@ -989,7 +996,7 @@ def userinfo():
 
 
 @oauth_bp.route("/introspect", methods=["POST"])
-def introspect():
+def introspect() -> ResponseReturnValue:
     """
     Token Introspection endpoint (RFC 7662).
     Allows resource servers to validate tokens.
@@ -1092,7 +1099,7 @@ def introspect():
 
 
 @oauth_bp.route("/revoke", methods=["POST"])
-def revoke():
+def revoke() -> ResponseReturnValue:
     """
     Token Revocation endpoint (RFC 7009).
     Allows clients to revoke tokens.
@@ -1164,7 +1171,7 @@ def revoke():
 
 @oauth_bp.route("/logout", methods=["GET", "POST"])
 @oauth_bp.route("/end_session", methods=["GET", "POST"])
-def end_session():
+def end_session() -> ResponseReturnValue:
     """
     OIDC End Session / Logout endpoint.
     Allows clients to initiate logout.
@@ -1280,7 +1287,7 @@ def _generate_device_code() -> str:
 
 @oauth_bp.route("/device_authorization", methods=["POST"])
 @oauth_bp.route("/device/code", methods=["POST"])
-def device_authorization():
+def device_authorization() -> ResponseReturnValue:
     """
     Device Authorization endpoint (RFC 8628).
     Initiates the device flow by returning device_code and user_code.
@@ -1363,7 +1370,7 @@ def device_authorization():
 
 
 @oauth_bp.route("/device", methods=["GET", "POST"])
-def device_verify():
+def device_verify() -> ResponseReturnValue:
     """
     Device verification endpoint.
     Users enter their user_code here to authorize the device.

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -8,9 +8,10 @@ import uuid
 import zlib
 from base64 import b64decode, b64encode
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypedDict
 
 from flask import Blueprint, Response, abort, render_template, request, session
+from flask.typing import ResponseReturnValue
 from lxml import etree
 
 from ..config import get_config
@@ -66,7 +67,12 @@ def _get_c14n_algorithm(config_value: str) -> "CanonicalizationMethod":
 saml_bp = Blueprint("saml", __name__, url_prefix="/saml")
 
 
-def _get_request_info():
+class _RequestInfo(TypedDict):
+    ip_address: str
+    user_agent: str
+
+
+def _get_request_info() -> _RequestInfo:
     """Get request info for audit logging."""
     return {
         "ip_address": request.remote_addr or "unknown",
@@ -74,7 +80,9 @@ def _get_request_info():
     }
 
 
-def _parse_saml_request(saml_request_b64: str, http_verb: str, strict: bool = False):
+def _parse_saml_request(
+    saml_request_b64: str, http_verb: str, strict: bool = False
+) -> Optional[Dict[str, Optional[str]]]:
     """Parse a SAMLRequest to extract ID, ACS URL, and Issuer.
 
     Args:
@@ -147,14 +155,14 @@ def _build_saml_response(
     attributes: dict,
     in_response_to: Optional[str] = None,
     sign: bool = True,
-):
+) -> bytes:
     """Build a SAML Response XML."""
     config = get_config()
     crypto = get_crypto_service(config.settings.keys_dir)
 
     now = datetime.now(timezone.utc)
 
-    def iso(dt):
+    def iso(dt: datetime) -> str:
         return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     response_id = f"_{uuid.uuid4().hex}"
@@ -277,7 +285,7 @@ def _build_saml_response(
 
 
 @saml_bp.route("/metadata")
-def metadata():
+def metadata() -> ResponseReturnValue:
     """SAML IdP Metadata endpoint."""
     config = get_config()
     crypto = get_crypto_service(config.settings.keys_dir)
@@ -325,7 +333,7 @@ def metadata():
 
 
 @saml_bp.route("/cert.pem")
-def cert():
+def cert() -> ResponseReturnValue:
     """Download the IdP certificate."""
     config = get_config()
     crypto = get_crypto_service(config.settings.keys_dir)
@@ -333,7 +341,7 @@ def cert():
 
 
 @saml_bp.route("/sso", methods=["GET", "POST"])
-def sso():
+def sso() -> ResponseReturnValue:
     """SAML SSO endpoint.
 
     Handles both SP-initiated SSO flows:
@@ -436,10 +444,8 @@ def sso():
     )
 
     # Determine ACS URL
-    if saml_info and saml_info.get("acs_url"):
-        acs_url = saml_info["acs_url"]
-    else:
-        acs_url = config.settings.default_acs_url
+    requested_acs = saml_info.get("acs_url") if saml_info else None
+    acs_url = requested_acs or config.settings.default_acs_url
 
     in_response_to = saml_info.get("id") if saml_info else None
 
@@ -504,7 +510,7 @@ def _build_attribute_query_response(user_id: str, attributes: dict, request_id: 
     """
     now = datetime.now(timezone.utc)
 
-    def iso(dt):
+    def iso(dt: datetime) -> str:
         return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     SAML2_NS = "urn:oasis:names:tc:SAML:2.0:assertion"
@@ -625,7 +631,7 @@ def _sign_attribute_query_response(response_xml: str, sign: bool = True) -> str:
 
 
 @saml_bp.route("/attribute-query", methods=["POST"])
-def attribute_query():
+def attribute_query() -> ResponseReturnValue:
     """
     SAML 2.0 AttributeQuery endpoint (Backend-to-Backend).
 

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -73,7 +73,7 @@ class CryptoService:
 
         self._ensure_keys()
 
-    def _ensure_keys(self):
+    def _ensure_keys(self) -> None:
         """Ensure RSA keys and certificate exist."""
         self.keys_dir.mkdir(parents=True, exist_ok=True)
 
@@ -140,7 +140,7 @@ class CryptoService:
         with open(cert_path, "rb") as f:
             self.cert_pem = f.read()
 
-    def _load_external_keys(self):
+    def _load_external_keys(self) -> None:
         """Load external PEM keys instead of generating new ones."""
         if self._external_private_key is None or self._external_public_key is None:
             raise ValueError("External key paths not configured")
@@ -175,7 +175,7 @@ class CryptoService:
         with open(cert_path, "rb") as f:
             self.cert_pem = f.read()
 
-    def _load_previous_keys(self, keys_meta_path: Path):
+    def _load_previous_keys(self, keys_meta_path: Path) -> None:
         """Load previous keys from metadata file."""
         if not keys_meta_path.exists():
             return
@@ -201,7 +201,7 @@ class CryptoService:
         except Exception as e:
             logger.warning(f"Failed to load previous keys: {e}")
 
-    def _save_keys_metadata(self):
+    def _save_keys_metadata(self) -> None:
         """Save keys metadata to file."""
         keys_meta_path = self.keys_dir / "keys.json"
         metadata = {
@@ -214,7 +214,7 @@ class CryptoService:
         with open(keys_meta_path, "w") as f:
             json.dump(metadata, f, indent=2)
 
-    def _generate_certificate(self, cert_path: Path):
+    def _generate_certificate(self, cert_path: Path) -> None:
         """Generate a self-signed X.509 certificate."""
         logger.info("Generating self-signed certificate...")
 
@@ -455,7 +455,7 @@ class CryptoService:
             "rotated_at": datetime.now(timezone.utc).isoformat(),
         }
 
-    def regenerate_keys(self):
+    def regenerate_keys(self) -> Dict[str, Any]:
         """Regenerate RSA keys and certificate (legacy method, calls rotate_keys)."""
         return self.rotate_keys()
 


### PR DESCRIPTION
Second tranche of #70 (tranche 3 — `config.py` and `routes/ui.py` — remains).

- Annotates all 37 missing signatures in `services/crypto.py` and `routes/{api,oauth,saml}.py`: Flask views get `flask.typing.ResponseReturnValue` (covers every view return shape), crypto internals `-> None` (`regenerate_keys -> Dict[str, Any]`), helpers their real types.
- The ratchet list in `pyproject.toml` grows to **17 of 19 modules** under `disallow_untyped_defs`.

Three things the annotations forced into the open (the point of the exercise):

1. `_build_saml_response` returns **bytes**, not str — `etree.tostring(..., encoding="UTF-8")`; the `b64encode` call site type-checks now.
2. `_get_request_info()` in both route modules now returns a `TypedDict`, so the `**req_info` spreads into `audit.log(...)` are checked key-by-key against the keyword parameters instead of tripping dict invariance.
3. The SSO ACS-URL fallback is restructured so mypy can narrow `Optional[str]` (`requested_acs or default_acs_url`) — semantics identical to the old `if saml_info.get(...)` branch.

Verified: `mypy src` clean, `ruff check .` clean, 662 tests pass (59 SAML-focused ones re-run targeted after the ACS-URL rewrite), coverage 73% ≥ the 70% gate.