### PR TITLE
mypy ratchet tranche 3: src/ fully annotated, flag flipped globally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,40 +106,15 @@ ignore = [
 ]
 
 [tool.mypy]
-# Gradual-adoption baseline (#55): catch real type errors in src/ without
-# demanding full annotation coverage yet. Tighten over time (e.g. enable
-# disallow_untyped_defs per module) as annotations improve.
+# Baseline from #55, ratcheted to full annotation coverage in #70: every def
+# in src/ is annotated and stays that way.
 python_version = "3.10"
 files = ["src"]
+disallow_untyped_defs = true
 check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 no_implicit_optional = true
-
-[[tool.mypy.overrides]]
-# Typing ratchet (#70): modules here require fully annotated defs. The list
-# only grows; when all of src/ is in, flip disallow_untyped_defs globally
-# and delete this block. Still out: config, routes.ui.
-module = [
-    "nanoidp",
-    "nanoidp.__main__",
-    "nanoidp.app",
-    "nanoidp.exceptions",
-    "nanoidp.mcp_server",
-    "nanoidp.wizard",
-    "nanoidp.routes",
-    "nanoidp.routes.api",
-    "nanoidp.routes.oauth",
-    "nanoidp.routes.saml",
-    "nanoidp.services",
-    "nanoidp.services.audit",
-    "nanoidp.services.auth_code",
-    "nanoidp.services.crypto",
-    "nanoidp.services.discovery",
-    "nanoidp.services.token",
-    "nanoidp.services.yaml_writer",
-]
-disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 # Only these dependencies ship no type stubs; keeping the list explicit (vs a

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -246,14 +246,14 @@ class ConfigManager:
         # Default to ./config
         return "./config"
 
-    def _load_config(self):
+    def _load_config(self) -> None:
         """Load all configuration files."""
         self._load_settings()
         self._load_users()
         logger.info(f"Loaded configuration from {self.config_dir}")
         logger.info(f"Loaded {len(self.users)} users")
 
-    def _load_settings(self):
+    def _load_settings(self) -> None:
         """Load settings from settings.yaml."""
         settings_file = self.config_dir / "settings.yaml"
 
@@ -322,7 +322,7 @@ class ConfigManager:
             verbose_logging=logging_config.get("verbose_logging", True),
         )
 
-    def _set_default_settings(self):
+    def _set_default_settings(self) -> None:
         """Set default settings with demo client."""
         self.settings = Settings(
             clients=[OAuthClient(
@@ -338,7 +338,7 @@ class ConfigManager:
             allowed_identity_classes=["INTERNAL", "EXTERNAL", "PARTNER", "SERVICE"],
         )
 
-    def _load_users(self):
+    def _load_users(self) -> None:
         """Load users from users.yaml."""
         users_file = self.config_dir / "users.yaml"
 
@@ -379,7 +379,7 @@ class ConfigManager:
                 attributes=attributes,
             )
 
-    def _set_default_users(self):
+    def _set_default_users(self) -> None:
         """Set default users."""
         self.users = {
             "admin": User(
@@ -445,18 +445,18 @@ class ConfigManager:
                 return client
         return None
 
-    def reload(self):
+    def reload(self) -> None:
         """Reload configuration from files."""
         self._load_config()
         logger.info("Configuration reloaded")
 
-    def save(self):
+    def save(self) -> None:
         """Save current configuration to YAML files."""
         self._save_users()
         self._save_settings()
         logger.info(f"Configuration saved to {self.config_dir}")
 
-    def _save_users(self):
+    def _save_users(self) -> None:
         """Save users to users.yaml."""
         users_file = self.config_dir / "users.yaml"
 
@@ -486,7 +486,7 @@ class ConfigManager:
         with open(users_file, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
-    def _save_settings(self):
+    def _save_settings(self) -> None:
         """Save settings to settings.yaml."""
         settings_file = self.config_dir / "settings.yaml"
 

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -219,7 +219,7 @@ class Settings(BaseModel):
 class ConfigManager:
     """Manages configuration loading and access."""
 
-    def __init__(self, config_dir: Optional[str] = None):
+    def __init__(self, config_dir: Optional[str] = None) -> None:
         self.config_dir = Path(config_dir or self._find_config_dir())
         self.settings: Settings = Settings()
         self.users: Dict[str, User] = {}

--- a/src/nanoidp/exceptions.py
+++ b/src/nanoidp/exceptions.py
@@ -9,7 +9,7 @@ from typing import Optional
 class NanoIDPError(Exception):
     """Base exception for all NanoIDP errors."""
 
-    def __init__(self, message: str, code: str = "NANOIDP_ERROR"):
+    def __init__(self, message: str, code: str = "NANOIDP_ERROR") -> None:
         self.message = message
         self.code = code
         super().__init__(message)
@@ -19,21 +19,21 @@ class NanoIDPError(Exception):
 class AuthenticationError(NanoIDPError):
     """Base class for authentication-related errors."""
 
-    def __init__(self, message: str, code: str = "AUTH_ERROR"):
+    def __init__(self, message: str, code: str = "AUTH_ERROR") -> None:
         super().__init__(message, code)
 
 
 class InvalidCredentialsError(AuthenticationError):
     """Raised when username/password credentials are invalid."""
 
-    def __init__(self, message: str = "Invalid username or password"):
+    def __init__(self, message: str = "Invalid username or password") -> None:
         super().__init__(message, "INVALID_CREDENTIALS")
 
 
 class UserNotFoundError(AuthenticationError):
     """Raised when a user is not found."""
 
-    def __init__(self, username: str):
+    def __init__(self, username: str) -> None:
         super().__init__(f"User not found: {username}", "USER_NOT_FOUND")
         self.username = username
 
@@ -42,14 +42,14 @@ class UserNotFoundError(AuthenticationError):
 class ClientError(NanoIDPError):
     """Base class for OAuth client-related errors."""
 
-    def __init__(self, message: str, code: str = "CLIENT_ERROR"):
+    def __init__(self, message: str, code: str = "CLIENT_ERROR") -> None:
         super().__init__(message, code)
 
 
 class ClientNotFoundError(ClientError):
     """Raised when an OAuth client is not found."""
 
-    def __init__(self, client_id: str):
+    def __init__(self, client_id: str) -> None:
         super().__init__(f"Client not found: {client_id}", "CLIENT_NOT_FOUND")
         self.client_id = client_id
 
@@ -57,7 +57,7 @@ class ClientNotFoundError(ClientError):
 class InvalidClientCredentialsError(ClientError):
     """Raised when client credentials are invalid."""
 
-    def __init__(self, client_id: str):
+    def __init__(self, client_id: str) -> None:
         super().__init__(
             f"Invalid credentials for client: {client_id}",
             "INVALID_CLIENT_CREDENTIALS"
@@ -69,28 +69,28 @@ class InvalidClientCredentialsError(ClientError):
 class TokenError(NanoIDPError):
     """Base class for token-related errors."""
 
-    def __init__(self, message: str, code: str = "TOKEN_ERROR"):
+    def __init__(self, message: str, code: str = "TOKEN_ERROR") -> None:
         super().__init__(message, code)
 
 
 class InvalidTokenError(TokenError):
     """Raised when a token is invalid or malformed."""
 
-    def __init__(self, message: str = "Invalid token"):
+    def __init__(self, message: str = "Invalid token") -> None:
         super().__init__(message, "INVALID_TOKEN")
 
 
 class ExpiredTokenError(TokenError):
     """Raised when a token has expired."""
 
-    def __init__(self, message: str = "Token has expired"):
+    def __init__(self, message: str = "Token has expired") -> None:
         super().__init__(message, "EXPIRED_TOKEN")
 
 
 class RevokedTokenError(TokenError):
     """Raised when a token has been revoked."""
 
-    def __init__(self, message: str = "Token has been revoked"):
+    def __init__(self, message: str = "Token has been revoked") -> None:
         super().__init__(message, "REVOKED_TOKEN")
 
 
@@ -98,28 +98,28 @@ class RevokedTokenError(TokenError):
 class AuthCodeError(NanoIDPError):
     """Base class for authorization code errors."""
 
-    def __init__(self, message: str, code: str = "AUTH_CODE_ERROR"):
+    def __init__(self, message: str, code: str = "AUTH_CODE_ERROR") -> None:
         super().__init__(message, code)
 
 
 class InvalidAuthCodeError(AuthCodeError):
     """Raised when an authorization code is invalid."""
 
-    def __init__(self, message: str = "Invalid authorization code"):
+    def __init__(self, message: str = "Invalid authorization code") -> None:
         super().__init__(message, "INVALID_AUTH_CODE")
 
 
 class ExpiredAuthCodeError(AuthCodeError):
     """Raised when an authorization code has expired."""
 
-    def __init__(self, message: str = "Authorization code has expired"):
+    def __init__(self, message: str = "Authorization code has expired") -> None:
         super().__init__(message, "EXPIRED_AUTH_CODE")
 
 
 class PKCEValidationError(AuthCodeError):
     """Raised when PKCE code_verifier validation fails."""
 
-    def __init__(self, message: str = "PKCE validation failed"):
+    def __init__(self, message: str = "PKCE validation failed") -> None:
         super().__init__(message, "PKCE_VALIDATION_FAILED")
 
 
@@ -127,14 +127,14 @@ class PKCEValidationError(AuthCodeError):
 class ConfigurationError(NanoIDPError):
     """Base class for configuration-related errors."""
 
-    def __init__(self, message: str, code: str = "CONFIG_ERROR"):
+    def __init__(self, message: str, code: str = "CONFIG_ERROR") -> None:
         super().__init__(message, code)
 
 
 class ConfigFileNotFoundError(ConfigurationError):
     """Raised when a configuration file is not found."""
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str) -> None:
         super().__init__(
             f"Configuration file not found: {file_path}",
             "CONFIG_FILE_NOT_FOUND"
@@ -145,7 +145,7 @@ class ConfigFileNotFoundError(ConfigurationError):
 class InvalidConfigurationError(ConfigurationError):
     """Raised when configuration is invalid."""
 
-    def __init__(self, message: str, field: Optional[str] = None):
+    def __init__(self, message: str, field: Optional[str] = None) -> None:
         super().__init__(message, "INVALID_CONFIGURATION")
         self.field = field
 
@@ -154,14 +154,14 @@ class InvalidConfigurationError(ConfigurationError):
 class GrantError(NanoIDPError):
     """Base class for OAuth2 grant errors."""
 
-    def __init__(self, message: str, code: str = "GRANT_ERROR"):
+    def __init__(self, message: str, code: str = "GRANT_ERROR") -> None:
         super().__init__(message, code)
 
 
 class UnsupportedGrantTypeError(GrantError):
     """Raised when an unsupported grant type is requested."""
 
-    def __init__(self, grant_type: str):
+    def __init__(self, grant_type: str) -> None:
         super().__init__(
             f"Unsupported grant type: {grant_type}",
             "UNSUPPORTED_GRANT_TYPE"
@@ -172,7 +172,7 @@ class UnsupportedGrantTypeError(GrantError):
 class InvalidGrantError(GrantError):
     """Raised when a grant is invalid."""
 
-    def __init__(self, message: str = "Invalid grant"):
+    def __init__(self, message: str = "Invalid grant") -> None:
         super().__init__(message, "INVALID_GRANT")
 
 
@@ -180,19 +180,19 @@ class InvalidGrantError(GrantError):
 class SAMLError(NanoIDPError):
     """Base class for SAML-related errors."""
 
-    def __init__(self, message: str, code: str = "SAML_ERROR"):
+    def __init__(self, message: str, code: str = "SAML_ERROR") -> None:
         super().__init__(message, code)
 
 
 class InvalidSAMLRequestError(SAMLError):
     """Raised when a SAML request is invalid."""
 
-    def __init__(self, message: str = "Invalid SAML request"):
+    def __init__(self, message: str = "Invalid SAML request") -> None:
         super().__init__(message, "INVALID_SAML_REQUEST")
 
 
 class SAMLSignatureError(SAMLError):
     """Raised when SAML signature validation fails."""
 
-    def __init__(self, message: str = "SAML signature validation failed"):
+    def __init__(self, message: str = "SAML signature validation failed") -> None:
         super().__init__(message, "SAML_SIGNATURE_ERROR")

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -61,7 +61,7 @@ MUTATING_TOOLS = {
 }
 
 
-def _check_admin_secret(tool_name: str, arguments: dict) -> Tuple[bool, str]:
+def _check_admin_secret(tool_name: str, arguments: dict[str, Any]) -> Tuple[bool, str]:
     """Check if admin secret is required and valid.
 
     Args:

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -7,7 +7,7 @@ import logging
 import secrets
 import threading
 import time
-from typing import TypedDict
+from typing import Any, TypedDict
 from urllib.parse import urlencode, urlparse
 
 import jwt as pyjwt
@@ -1247,7 +1247,8 @@ def end_session() -> ResponseReturnValue:
 # mutation / deletion) must hold the lock: Flask serves requests on multiple
 # threads and the polling client races against the user's verification and
 # against its own retries (issue #43).
-_device_codes: dict = {}
+# device_code -> grant state dict, plus "user:<code>" -> device_code back-references
+_device_codes: dict[str, Any] = {}
 _device_codes_lock = threading.RLock()
 
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -326,7 +326,7 @@ def clients() -> ResponseReturnValue:
     )
 
 
-def _parse_audiences(form_value: str) -> list:
+def _parse_audiences(form_value: str) -> list[str]:
     """Parse a newline-separated additional_audiences form field into a clean list."""
     return [a.strip() for a in (form_value or "").splitlines() if a.strip()]
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -8,7 +8,17 @@ import logging
 import secrets
 from io import StringIO
 
-from flask import Blueprint, Response, flash, redirect, render_template, request, session, url_for
+from flask import (
+    Blueprint,
+    Response,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from flask.typing import ResponseReturnValue
 
 from ..config import OAuthClient, User, get_config
 from ..services import get_audit_log, get_token_service, get_yaml_writer
@@ -21,7 +31,7 @@ ui_bp = Blueprint("ui", __name__)
 # ==================== Dashboard ====================
 
 @ui_bp.route("/")
-def index():
+def index() -> ResponseReturnValue:
     """Dashboard home page."""
     config = get_config()
     audit = get_audit_log()
@@ -39,7 +49,7 @@ def index():
 # ==================== Authentication ====================
 
 @ui_bp.route("/login", methods=["GET", "POST"])
-def login():
+def login() -> ResponseReturnValue:
     """Login page for web UI.
 
     Note: SAML SSO uses inline login at /saml/sso to preserve binding context.
@@ -99,7 +109,7 @@ def login():
 
 
 @ui_bp.route("/logout")
-def logout():
+def logout() -> ResponseReturnValue:
     """Logout and clear session."""
     username = session.get("user")
     session.clear()
@@ -122,7 +132,7 @@ def logout():
 # ==================== Users Management ====================
 
 @ui_bp.route("/users")
-def users():
+def users() -> ResponseReturnValue:
     """Users management page."""
     config = get_config()
     return render_template(
@@ -133,7 +143,7 @@ def users():
 
 
 @ui_bp.route("/users/create", methods=["GET", "POST"])
-def user_create():
+def user_create() -> ResponseReturnValue:
     """Create new user."""
     config = get_config()
 
@@ -200,7 +210,7 @@ def user_create():
 
 
 @ui_bp.route("/users/<username>")
-def user_detail(username: str):
+def user_detail(username: str) -> ResponseReturnValue:
     """User detail page."""
     config = get_config()
 
@@ -221,7 +231,7 @@ def user_detail(username: str):
 
 
 @ui_bp.route("/users/<username>/edit", methods=["GET", "POST"])
-def user_edit(username: str):
+def user_edit(username: str) -> ResponseReturnValue:
     """Edit user."""
     config = get_config()
 
@@ -285,7 +295,7 @@ def user_edit(username: str):
 
 
 @ui_bp.route("/users/<username>/delete", methods=["POST"])
-def user_delete(username: str):
+def user_delete(username: str) -> ResponseReturnValue:
     """Delete user."""
     try:
         yaml_writer = get_yaml_writer()
@@ -306,7 +316,7 @@ def user_delete(username: str):
 # ==================== OAuth Clients Management ====================
 
 @ui_bp.route("/clients")
-def clients():
+def clients() -> ResponseReturnValue:
     """OAuth clients management page."""
     config = get_config()
     return render_template(
@@ -322,7 +332,7 @@ def _parse_audiences(form_value: str) -> list:
 
 
 @ui_bp.route("/clients/create", methods=["GET", "POST"])
-def client_create():
+def client_create() -> ResponseReturnValue:
     """Create new OAuth client."""
     if request.method == "GET":
         # Generate a random client secret
@@ -369,7 +379,7 @@ def client_create():
 
 
 @ui_bp.route("/clients/<client_id>/edit", methods=["GET", "POST"])
-def client_edit(client_id: str):
+def client_edit(client_id: str) -> ResponseReturnValue:
     """Edit OAuth client."""
     config = get_config()
 
@@ -419,7 +429,7 @@ def client_edit(client_id: str):
 
 
 @ui_bp.route("/clients/<client_id>/delete", methods=["POST"])
-def client_delete(client_id: str):
+def client_delete(client_id: str) -> ResponseReturnValue:
     """Delete OAuth client."""
     try:
         yaml_writer = get_yaml_writer()
@@ -438,7 +448,7 @@ def client_delete(client_id: str):
 
 
 @ui_bp.route("/clients/<client_id>/regenerate-secret", methods=["POST"])
-def client_regenerate_secret(client_id: str):
+def client_regenerate_secret(client_id: str) -> ResponseReturnValue:
     """Regenerate OAuth client secret."""
     config = get_config()
 
@@ -478,7 +488,7 @@ def client_regenerate_secret(client_id: str):
 # ==================== Settings ====================
 
 @ui_bp.route("/settings", methods=["GET", "POST"])
-def settings():
+def settings() -> ResponseReturnValue:
     """IdP settings configuration page."""
     config = get_config()
 
@@ -527,7 +537,7 @@ def settings():
 # ==================== Keys Management ====================
 
 @ui_bp.route("/keys")
-def keys():
+def keys() -> ResponseReturnValue:
     """Keys and certificates management page."""
     import os
     from datetime import datetime
@@ -567,7 +577,7 @@ def keys():
 
 
 @ui_bp.route("/keys/regenerate", methods=["POST"])
-def keys_regenerate():
+def keys_regenerate() -> ResponseReturnValue:
     """Regenerate RSA keys and certificate."""
     config = get_config()
     from ..services import get_crypto_service
@@ -586,7 +596,7 @@ def keys_regenerate():
 
 
 @ui_bp.route("/keys/download/<key_type>")
-def keys_download(key_type: str):
+def keys_download(key_type: str) -> ResponseReturnValue:
     """Download key or certificate."""
     config = get_config()
     from ..services import get_crypto_service
@@ -613,7 +623,7 @@ def keys_download(key_type: str):
 # ==================== Claims Configuration ====================
 
 @ui_bp.route("/claims", methods=["GET", "POST"])
-def claims():
+def claims() -> ResponseReturnValue:
     """Claims and authority prefixes configuration."""
     config = get_config()
 
@@ -657,7 +667,7 @@ def claims():
 
 
 @ui_bp.route("/claims/preview/<username>")
-def claims_preview(username: str):
+def claims_preview(username: str) -> ResponseReturnValue:
     """Preview token claims for a user (AJAX endpoint)."""
     config = get_config()
 
@@ -685,7 +695,7 @@ def claims_preview(username: str):
 # ==================== Audit Log ====================
 
 @ui_bp.route("/audit")
-def audit():
+def audit() -> ResponseReturnValue:
     """Audit log page."""
     audit_log = get_audit_log()
 
@@ -725,7 +735,7 @@ def audit():
 
 
 @ui_bp.route("/audit/export/<format>")
-def audit_export(format: str):
+def audit_export(format: str) -> ResponseReturnValue:
     """Export audit log with applied filters."""
     audit_log = get_audit_log()
 
@@ -772,7 +782,7 @@ def audit_export(format: str):
 
 
 @ui_bp.route("/audit/clear", methods=["POST"])
-def audit_clear():
+def audit_clear() -> ResponseReturnValue:
     """Clear the audit log."""
     audit_log = get_audit_log()
     audit_log.clear()
@@ -784,7 +794,7 @@ def audit_clear():
 # ==================== Token Testing ====================
 
 @ui_bp.route("/test")
-def test_page():
+def test_page() -> ResponseReturnValue:
     """Token testing page."""
     config = get_config()
     return render_template(

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -45,7 +45,7 @@ class AuditEntry:
 class AuditLog:
     """In-memory audit log with size limit."""
 
-    def __init__(self, max_entries: int = 1000):
+    def __init__(self, max_entries: int = 1000) -> None:
         self.max_entries = max_entries
         self._entries: deque = deque(maxlen=max_entries)
         self._lock = Lock()

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class YamlWriter:
     """Service for safely writing YAML configuration files."""
 
-    def __init__(self, config_dir: Optional[str] = None):
+    def __init__(self, config_dir: Optional[str] = None) -> None:
         config = get_config()
         self.config_dir = Path(config_dir or config.config_dir)
         self.users_file = self.config_dir / "users.yaml"


### PR DESCRIPTION
Closes #70 — final tranche, completing the [Typing strictness](https://github.com/cdelmonte-zg/nanoidp/milestone/3) milestone.

- Annotates the last 32 signatures: the nine `config.py` loaders/savers (`-> None`, all of them), and the 23 `routes/ui.py` views (`-> ResponseReturnValue`, same as the other route modules).
- Flips `disallow_untyped_defs = true` **globally** in `[tool.mypy]` and deletes the per-module ratchet override — the ratchet's end state per the issue. Any new unannotated def anywhere in `src/` now fails CI.

Unlike tranche 2, no cascade fixes were needed: `check_untyped_defs` had already been checking these bodies, so the annotations were purely declarative.

Verified: `mypy src` clean (19 files), `ruff check .` clean, 662 tests pass, coverage 73% ≥ the 70% gate.