### PR TITLE
feat: registered redirect_uris with exact matching on /authorize

### DIFF
--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -61,6 +61,11 @@ oauth:
       additional_audiences:     # optional; makes the ID Token "aud" an array
         - "https://api.example.com"
         - "urn:service:billing"
+    - client_id: "registered-client"
+      client_secret: "secret"
+      description: "Client whose redirect_uri is pinned"
+      redirect_uris:            # optional; when set, /authorize enforces
+        - "http://localhost:3000/callback"  # exact string matching
 
 saml:
   entity_id: "http://localhost:8000/saml"
@@ -76,6 +81,13 @@ authority_prefixes:
 logging:
   verbose_logging: true  # Include usernames/client_ids in logs (default: true)
 ```
+
+**Registered redirect URIs** — a client with a non-empty `redirect_uris`
+list gets exact-string matching on `/authorize` (RFC 6749 §3.1.2.3,
+OAuth 2.1 §4.1.1): no prefix, host or path normalization, and a mismatch
+is answered with `400 invalid_request` directly — never by redirecting to
+the unvalidated URI (§3.1.2.4). Clients without the field keep accepting
+any syntactically valid URI, the permissive dev default.
 
 The SAML options (`strict_binding`, `sign_responses`, `c14n_algorithm`)
 are covered in detail in [SAML options](saml.md). Security-related

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -19,6 +19,11 @@ oauth:
     additional_audiences:
     - https://api.example.com
     - urn:service:billing
+  - client_id: registered-client
+    client_secret: registered-secret
+    description: Client with registered redirect URIs (exact matching, issue #67)
+    redirect_uris:
+    - http://localhost:3000/callback
 saml:
   entity_id: http://localhost:${PORT:8000}/saml
   sso_url: http://localhost:${PORT:8000}/saml/sso

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -517,6 +517,81 @@ class NanoIDPTestAgent:
             return None
         return token_resp.json()
 
+    def test_redirect_uri_exact_matching(self) -> TestResult:
+        """Registered redirect URIs are enforced with exact matching (issue #67).
+
+        Requires a 'registered-client' configured with
+        redirect_uris: ["http://localhost:3000/callback"] (present in the
+        default config). RFC 6749 §3.1.2.3 / OAuth 2.1 §4.1.1: simple string
+        comparison; a mismatch MUST NOT redirect (§3.1.2.4).
+        """
+        try:
+            base_params = {
+                "response_type": "code",
+                "client_id": "registered-client",
+                "scope": "openid",
+            }
+
+            # Exact match: accepted (login page)
+            ok = requests.get(
+                f"{self.base_url}/authorize",
+                params={**base_params, "redirect_uri": "http://localhost:3000/callback"},
+                allow_redirects=False,
+                timeout=5,
+            )
+
+            # Registered value plus a suffix: rejected, and NOT via redirect
+            evil = requests.get(
+                f"{self.base_url}/authorize",
+                params={**base_params, "redirect_uri": "http://localhost:3000/callbackevil"},
+                allow_redirects=False,
+                timeout=5,
+            )
+            evil_is_400 = evil.status_code == 400 and "Location" not in evil.headers
+            evil_error_ok = False
+            if evil_is_400:
+                try:
+                    evil_error_ok = evil.json().get("error") == "invalid_request"
+                except ValueError:
+                    evil_error_ok = False
+
+            # A client without registered URIs keeps the permissive behavior
+            permissive = requests.get(
+                f"{self.base_url}/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": self.client_id,
+                    "redirect_uri": "http://localhost:3000/anything",
+                    "scope": "openid",
+                },
+                allow_redirects=False,
+                timeout=5,
+            )
+
+            success = (
+                ok.status_code == 200
+                and evil_is_400
+                and evil_error_ok
+                and permissive.status_code == 200
+            )
+            return self._add_result(
+                "Redirect URI Exact Match",
+                TestCategory.OAUTH,
+                success,
+                "Registered URI accepted, mismatch rejected without redirect, "
+                "unregistered client stays permissive",
+                {
+                    "match_status": ok.status_code,
+                    "mismatch_status": evil.status_code,
+                    "mismatch_redirected": "Location" in evil.headers,
+                    "permissive_status": permissive.status_code,
+                },
+            )
+        except Exception as e:
+            return self._add_result(
+                "Redirect URI Exact Match", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+
     def test_id_token_audience(self) -> TestResult:
         """ID Token `aud` is the client_id; access token `aud` is the resource (issue #32)."""
         try:
@@ -2472,6 +2547,7 @@ class NanoIDPTestAgent:
                 self.test_password_grant,
                 self.test_client_credentials,
                 self.test_authorization_code_pkce,
+                self.test_redirect_uri_exact_matching,
                 self.test_id_token_audience,
                 self.test_id_token_time_claims,
                 self.test_id_token_audience_array,

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -42,13 +42,14 @@ def _expand_env_vars(value: Any) -> Any:
     return value
 
 
-def _coerce_additional_audiences(raw: Any, client_id: str) -> List[str]:
-    """Coerce a client's ``additional_audiences`` YAML value into a clean list.
+def _coerce_client_str_list(raw: Any, client_id: str, field: str) -> List[str]:
+    """Coerce a client's list-of-strings YAML value into a clean list.
 
-    The field is a ``List[str]`` on the model, but a single value is an easy
-    footgun in YAML (``additional_audiences: api://x``). Rather than let a raw
-    Pydantic ``ValidationError`` abort startup, accept a scalar string by wrapping
-    it, and raise a clear, client-scoped error for unsupported shapes (#35).
+    Fields like ``additional_audiences`` and ``redirect_uris`` are ``List[str]``
+    on the model, but a single value is an easy footgun in YAML
+    (``additional_audiences: api://x``). Rather than let a raw Pydantic
+    ``ValidationError`` abort startup, accept a scalar string by wrapping it,
+    and raise a clear, client-scoped error for unsupported shapes (#35).
     """
     label = client_id or "<missing client_id>"
     if raw is None:
@@ -59,14 +60,19 @@ def _coerce_additional_audiences(raw: Any, client_id: str) -> List[str]:
         non_strings = [a for a in raw if not isinstance(a, str)]
         if non_strings:
             raise ValueError(
-                f"Client '{label}': additional_audiences must be a list of strings, "
+                f"Client '{label}': {field} must be a list of strings, "
                 f"got non-string item(s): {non_strings!r}"
             )
         return [a for a in raw if a]
     raise ValueError(
-        f"Client '{label}': additional_audiences must be a string or a list of "
+        f"Client '{label}': {field} must be a string or a list of "
         f"strings, got {type(raw).__name__}"
     )
+
+
+def _coerce_additional_audiences(raw: Any, client_id: str) -> List[str]:
+    """Coerce a client's ``additional_audiences`` YAML value (see above)."""
+    return _coerce_client_str_list(raw, client_id, "additional_audiences")
 
 
 class User(BaseModel):
@@ -117,6 +123,14 @@ class OAuthClient(BaseModel):
     additional_audiences: List[str] = Field(
         default_factory=list,
         description="Extra audiences added to the ID Token 'aud' alongside the client_id",
+    )
+    redirect_uris: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Registered redirect URIs; when non-empty, /authorize enforces exact "
+            "string matching (RFC 6749 §3.1.2.3, OAuth 2.1 §4.1.1). Empty = any "
+            "syntactically valid URI is accepted (dev default)."
+        ),
     )
 
 
@@ -284,6 +298,9 @@ class ConfigManager:
                 description=client_data.get("description", ""),
                 additional_audiences=_coerce_additional_audiences(
                     client_data.get("additional_audiences", []), client_id
+                ),
+                redirect_uris=_coerce_client_str_list(
+                    client_data.get("redirect_uris", []), client_id, "redirect_uris"
                 ),
             ))
 
@@ -499,6 +516,8 @@ class ConfigManager:
             }
             if client.additional_audiences:
                 client_entry["additional_audiences"] = client.additional_audiences
+            if client.redirect_uris:
+                client_entry["redirect_uris"] = client.redirect_uris
             clients_data.append(client_entry)
 
         data = {

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -151,21 +151,27 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
         "client_id": client.client_id,
         "description": client.description,
         "additional_audiences": client.additional_audiences,
+        "redirect_uris": client.redirect_uris,
     }
 
 
-def _normalize_audiences(value: Any) -> list[str]:
-    """Coerce a raw audiences argument into a list of non-empty strings.
+def _normalize_str_list(value: Any, field: str) -> list[str]:
+    """Coerce a raw list argument into a list of non-empty strings.
 
-    Only ``None`` (argument omitted) and an empty list mean "no audiences"; any
+    Only ``None`` (argument omitted) and an empty list mean "no values"; any
     other non-list (``""``, ``0``, ``False``) is a type error and is rejected,
     rather than silently coerced to ``[]`` (#37).
     """
     if value is None:
         return []
     if not isinstance(value, list) or not all(isinstance(a, str) for a in value):
-        raise ValueError("additional_audiences must be a list of strings")
+        raise ValueError(f"{field} must be a list of strings")
     return [a for a in value if a]
+
+
+def _normalize_audiences(value: Any) -> list[str]:
+    """Coerce a raw audiences argument (see ``_normalize_str_list``)."""
+    return _normalize_str_list(value, "additional_audiences")
 
 
 # =============================================================================
@@ -413,6 +419,11 @@ async def list_tools() -> list[Tool]:
                         "items": {"type": "string"},
                         "description": "Extra audiences added to the ID Token 'aud' alongside the client_id (optional)",
                     },
+                    "redirect_uris": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Registered redirect URIs; when non-empty, /authorize enforces exact matching (optional)",
+                    },
                 },
                 "required": ["client_id", "client_secret"],
             },
@@ -439,6 +450,11 @@ async def list_tools() -> list[Tool]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Replace the client's extra ID Token audiences (optional)",
+                    },
+                    "redirect_uris": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Replace the client's registered redirect URIs; empty list removes the restriction (optional)",
                     },
                 },
                 "required": ["client_id"],
@@ -794,6 +810,9 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             client_secret=arguments["client_secret"],
             description=arguments.get("description", ""),
             additional_audiences=_normalize_audiences(arguments.get("additional_audiences")),
+            redirect_uris=_normalize_str_list(
+                arguments.get("redirect_uris"), "redirect_uris"
+            ),
         )
         config.settings.clients.append(new_client)
         return {"success": True, "client": _client_to_dict(new_client)}
@@ -812,6 +831,11 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             if "additional_audiences" in arguments
             else None
         )
+        new_redirect_uris = (
+            _normalize_str_list(arguments["redirect_uris"], "redirect_uris")
+            if "redirect_uris" in arguments
+            else None
+        )
 
         if "client_secret" in arguments:
             client.client_secret = arguments["client_secret"]
@@ -819,6 +843,8 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             client.description = arguments["description"]
         if new_audiences is not None:
             client.additional_audiences = new_audiences
+        if new_redirect_uris is not None:
+            client.redirect_uris = new_redirect_uris
 
         return {"success": True, "client": _client_to_dict(client)}
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -149,7 +149,7 @@ def authorize() -> ResponseReturnValue:
             "error_description": "Unknown client_id"
         }), 400
 
-    # Validate redirect_uri (basic validation - in production should check against registered URIs)
+    # Syntactic validation: must at least parse as an absolute URL.
     try:
         parsed = urlparse(redirect_uri)
         if not parsed.scheme or not parsed.netloc:
@@ -158,6 +158,27 @@ def authorize() -> ResponseReturnValue:
         return jsonify({
             "error": "invalid_request",
             "error_description": "Invalid redirect_uri"
+        }), 400
+
+    # Exact matching against registered redirect URIs (issue #67). RFC 6749
+    # §3.1.2.3 / OAuth 2.1 §4.1.1 require simple string comparison — no
+    # prefix, host or path normalization. Clients without registered URIs
+    # keep the permissive dev behavior (hardening is opt-in, principle 3).
+    # A mismatch MUST NOT redirect (§3.1.2.4): the error is returned
+    # directly, never sent to the unvalidated URI.
+    if client.redirect_uris and redirect_uri not in client.redirect_uris:
+        audit.log(
+            event_type="authorization_request",
+            endpoint="/authorize",
+            method=request.method,
+            status="failed",
+            client_id=client_id,
+            details={"reason": "redirect_uri not registered for client"},
+            **req_info,
+        )
+        return jsonify({
+            "error": "invalid_request",
+            "error_description": "redirect_uri is not registered for this client"
         }), 400
 
     # PKCE enforcement (issue #47). With require_pkce enabled (on by default in

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -326,8 +326,8 @@ def clients() -> ResponseReturnValue:
     )
 
 
-def _parse_audiences(form_value: str) -> list[str]:
-    """Parse a newline-separated additional_audiences form field into a clean list."""
+def _parse_textarea_list(form_value: str) -> list[str]:
+    """Parse a newline-separated textarea form field into a clean list of strings."""
     return [a.strip() for a in (form_value or "").splitlines() if a.strip()]
 
 
@@ -360,7 +360,10 @@ def client_create() -> ResponseReturnValue:
             client_id=client_id,
             client_secret=client_secret,
             description=request.form.get("description", ""),
-            additional_audiences=_parse_audiences(request.form.get("additional_audiences", "")),
+            additional_audiences=_parse_textarea_list(
+                request.form.get("additional_audiences", "")
+            ),
+            redirect_uris=_parse_textarea_list(request.form.get("redirect_uris", "")),
         )
 
         yaml_writer = get_yaml_writer()
@@ -413,7 +416,10 @@ def client_edit(client_id: str) -> ResponseReturnValue:
             client_id=client_id,
             client_secret=client_secret,
             description=request.form.get("description", ""),
-            additional_audiences=_parse_audiences(request.form.get("additional_audiences", "")),
+            additional_audiences=_parse_textarea_list(
+                request.form.get("additional_audiences", "")
+            ),
+            redirect_uris=_parse_textarea_list(request.form.get("redirect_uris", "")),
         )
 
         yaml_writer = get_yaml_writer()
@@ -471,6 +477,7 @@ def client_regenerate_secret(client_id: str) -> ResponseReturnValue:
             client_secret=new_secret,
             description=client.description,
             additional_audiences=client.additional_audiences,
+            redirect_uris=client.redirect_uris,
         )
 
         yaml_writer = get_yaml_writer()

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -188,6 +188,8 @@ class YamlWriter:
         }
         if client.additional_audiences:
             client_data["additional_audiences"] = client.additional_audiences
+        if client.redirect_uris:
+            client_data["redirect_uris"] = client.redirect_uris
 
         if existing_idx is not None:
             clients[existing_idx] = client_data

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -68,6 +68,16 @@
                             When more than one distinct audience results, <code>aud</code> becomes an array and an <code>azp</code> claim is emitted.
                         </div>
                     </div>
+
+                    <div class="mb-3">
+                        <label for="redirect_uris" class="form-label">Registered Redirect URIs</label>
+                        <textarea class="form-control" id="redirect_uris" name="redirect_uris"
+                                  rows="3" placeholder="One URI per line, e.g.&#10;http://localhost:3000/callback">{{ client.redirect_uris | join('\n') if client else '' }}</textarea>
+                        <div class="form-text">
+                            When set, <code>/authorize</code> only accepts a <code>redirect_uri</code> that matches one of these exactly
+                            (RFC 6749 §3.1.2.3, OAuth 2.1 §4.1.1). Leave empty to accept any syntactically valid URI (dev default).
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/tests/test_redirect_uri_matching.py
+++ b/tests/test_redirect_uri_matching.py
@@ -1,0 +1,215 @@
+"""
+Tests for registered redirect URIs with exact matching on /authorize (issue #67).
+
+RFC 6749 §3.1.2.3 / OAuth 2.1 §4.1.1: when a client has registered redirect
+URIs, the authorization endpoint compares the requested ``redirect_uri`` using
+simple string comparison — no prefix, host or path normalization. A mismatch
+MUST NOT redirect (§3.1.2.4); the error is returned directly. Clients without
+registered URIs keep the permissive dev behavior (hardening is opt-in).
+"""
+
+import json
+
+import pytest
+
+from nanoidp.config import ConfigManager, OAuthClient, get_config
+from nanoidp.services.yaml_writer import YamlWriter
+
+REGISTERED = "http://localhost:3000/callback"
+
+
+@pytest.fixture
+def registered_client(app):
+    """Register a client with pinned redirect URIs on the active config."""
+    with app.app_context():
+        config = get_config()
+        config.settings.clients.append(
+            OAuthClient(
+                client_id="pinned-client",
+                client_secret="pinned-secret",
+                redirect_uris=[REGISTERED, "https://app.example.com/cb"],
+            )
+        )
+    return "pinned-client"
+
+
+def _authorize(client, client_id, redirect_uri):
+    return client.get(
+        f"/authorize?response_type=code&client_id={client_id}"
+        f"&redirect_uri={redirect_uri}&scope=openid"
+    )
+
+
+class TestExactMatching:
+    """Enforcement on GET /authorize for clients with registered URIs."""
+
+    def test_exact_match_is_accepted(self, client, registered_client):
+        response = _authorize(client, registered_client, REGISTERED)
+        assert response.status_code == 200
+        assert b"username" in response.data  # login form rendered
+
+    def test_every_registered_uri_is_accepted(self, client, registered_client):
+        response = _authorize(client, registered_client, "https://app.example.com/cb")
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "mismatch",
+        [
+            "http://localhost:3000/callback/",  # trailing slash
+            "http://localhost:3000/other",  # different path
+            "http://localhost:3001/callback",  # different port
+            "http://localhost:3000/callback?x=1",  # extra query
+            "http://localhost:3000/callbackevil",  # registered prefix + suffix
+            "https://localhost:3000/callback",  # different scheme
+            "http://evil.example.com/callback",  # different host
+        ],
+    )
+    def test_mismatch_is_rejected_without_redirect(
+        self, client, registered_client, mismatch
+    ):
+        response = _authorize(client, registered_client, mismatch)
+        assert response.status_code == 400
+        # §3.1.2.4: never redirect to an unvalidated URI
+        assert "Location" not in response.headers
+        data = json.loads(response.data)
+        assert data["error"] == "invalid_request"
+        assert "not registered" in data["error_description"]
+
+    def test_client_without_registered_uris_stays_permissive(self, client):
+        """demo-client has no redirect_uris: any valid URI keeps working."""
+        response = _authorize(client, "demo-client", "http://anything.example/cb")
+        assert response.status_code == 200
+
+    def test_mismatch_enforced_on_login_post_too(self, client, registered_client):
+        """The POST leg (login form submit) revalidates against the registry."""
+        response = client.post(
+            "/authorize",
+            data={
+                "response_type": "code",
+                "client_id": registered_client,
+                "redirect_uri": "http://localhost:3000/callbackevil",
+                "scope": "openid",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert response.status_code == 400
+        assert "Location" not in response.headers
+
+
+class TestConfigLoadAndPersistence:
+    """redirect_uris round-trip through YAML load and the writer."""
+
+    def _seed(self, tmp_path, redirect_yaml):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            "oauth:\n"
+            '  issuer: "http://localhost:8000"\n'
+            '  audience: "my-app"\n'
+            "  clients:\n"
+            '    - client_id: "c1"\n'
+            '      client_secret: "s1"\n' + redirect_yaml
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        return config_dir
+
+    def test_load_list(self, tmp_path):
+        config_dir = self._seed(
+            tmp_path, '      redirect_uris:\n        - "http://a/cb"\n        - "http://b/cb"\n'
+        )
+        manager = ConfigManager(str(config_dir))
+        assert manager.get_client("c1").redirect_uris == ["http://a/cb", "http://b/cb"]
+
+    def test_load_scalar_is_wrapped(self, tmp_path):
+        """A single string is a YAML footgun, coerced like additional_audiences (#35)."""
+        config_dir = self._seed(tmp_path, '      redirect_uris: "http://a/cb"\n')
+        manager = ConfigManager(str(config_dir))
+        assert manager.get_client("c1").redirect_uris == ["http://a/cb"]
+
+    def test_load_non_string_items_rejected(self, tmp_path):
+        config_dir = self._seed(tmp_path, "      redirect_uris:\n        - 123\n")
+        with pytest.raises(ValueError, match="redirect_uris must be a list of strings"):
+            ConfigManager(str(config_dir))
+
+    def test_save_client_persists_redirect_uris(self, tmp_path):
+        config_dir = self._seed(tmp_path, "")
+        writer = YamlWriter(str(config_dir))
+
+        writer.save_client(
+            OAuthClient(
+                client_id="c1", client_secret="s1", redirect_uris=["http://a/cb"]
+            ),
+            is_new=False,
+        )
+
+        reloaded = ConfigManager(str(config_dir))
+        assert reloaded.get_client("c1").redirect_uris == ["http://a/cb"]
+
+
+class TestMCPClientTools:
+    """create_client/update_client expose redirect_uris (MCP/HTTP parity)."""
+
+    def _config(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            "oauth:\n"
+            '  issuer: "http://localhost:8000"\n'
+            "  clients:\n"
+            '    - client_id: "test"\n'
+            '      client_secret: "test"\n'
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        return ConfigManager(str(config_dir))
+
+    async def test_create_client_with_redirect_uris(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+
+        config = self._config(tmp_path)
+        result = await _execute_tool(
+            "create_client",
+            {
+                "client_id": "pinned",
+                "client_secret": "s",
+                "redirect_uris": ["http://a/cb"],
+            },
+            config,
+        )
+
+        assert result["success"] is True
+        assert result["client"]["redirect_uris"] == ["http://a/cb"]
+        assert config.get_client("pinned").redirect_uris == ["http://a/cb"]
+
+    async def test_update_client_replaces_and_clears_redirect_uris(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+
+        config = self._config(tmp_path)
+        await _execute_tool(
+            "update_client",
+            {"client_id": "test", "redirect_uris": ["http://a/cb"]},
+            config,
+        )
+        assert config.get_client("test").redirect_uris == ["http://a/cb"]
+
+        # empty list removes the restriction
+        result = await _execute_tool(
+            "update_client", {"client_id": "test", "redirect_uris": []}, config
+        )
+        assert result["success"] is True
+        assert config.get_client("test").redirect_uris == []
+
+    async def test_invalid_redirect_uris_type_rejected(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+
+        config = self._config(tmp_path)
+        with pytest.raises(ValueError, match="redirect_uris must be a list of strings"):
+            await _execute_tool(
+                "create_client",
+                {"client_id": "bad", "client_secret": "s", "redirect_uris": "http://a"},
+                config,
+            )


### PR DESCRIPTION
Closes #67 — first feature PR of the [OAuth 2.1 profile](https://github.com/cdelmonte-zg/nanoidp/milestone/1) milestone, and the prerequisite for #68.

## Behavior

- `OAuthClient` gains an optional `redirect_uris: [...]` list. When **non-empty**, `/authorize` enforces **exact string matching** (RFC 6749 §3.1.2.3, OAuth 2.1 §4.1.1): no prefix, host, path or trailing-slash normalization.
- A mismatch answers `400 invalid_request` **directly** — per §3.1.2.4 the error is never delivered by redirecting to the unvalidated URI. The rejection is audit-logged.
- When the list is absent/empty, the permissive dev behavior is unchanged (principle 3: hardening is opt-in). The upcoming `oauth21` profile (#68) will make registration mandatory.

## Ships whole (principle 5)

- **Config**: YAML load with the same scalar-string coercion as `additional_audiences` (#35) — the coercer is generalized (`_coerce_client_str_list`), with `_coerce_additional_audiences` kept as a wrapper since tests import it. Round-trips through `ConfigManager.save()` and the YAML writer.
- **Web UI**: textarea on the client form (one URI per line), preserved across edit and secret-regeneration.
- **MCP**: `create_client`/`update_client` schemas + handlers, `redirect_uris` in client dicts; `_normalize_audiences` generalized the same way. Empty list via `update_client` removes the restriction.
- **e2e**: new `test_redirect_uri_exact_matching` in `examples/test_agent.py`, backed by a `registered-client` fixture in the default config (same pattern as `multi-aud-client`).
- **Docs**: the book's configuration reference (example + semantics paragraph).
- **Tests**: 18 new (680 total) — exact match accepted, 7 mismatch shapes (trailing slash, port, scheme, host, path, query, prefix+suffix) rejected without a `Location` header, enforcement on the POST login leg, YAML load/scalar coercion/persistence round-trip, MCP create/update/clear/invalid-type.

## Verified

`mypy src` clean, `ruff` clean, 680 unit tests green, `mdbook build` green — and a **full e2e run against a live server: 41/41**, including the new test (registered URI accepted, `…/callbackevil` rejected with 400 and no redirect, `demo-client` still permissive).