### PR TITLE
ci: e2e workflow — live-server agent run + MCP stdio smoke test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   http-e2e:
     runs-on: ubuntu-latest
+    # The agent has per-request timeouts, but a wedged server or a hung
+    # login flow would otherwise burn the 360-minute Actions default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -45,6 +48,9 @@ jobs:
 
   mcp-e2e:
     runs-on: ubuntu-latest
+    # stdio has no request timeouts: if the server starts but hangs in
+    # initialize/list_tools/call_tool, only this job timeout saves the run.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,61 @@
+# End-to-end checks that the unit suite structurally cannot cover (#79):
+# the HTTP agent drives a real server over the network, and the MCP smoke
+# test drives the real stdio server — the transport whose startup crash
+# once went unnoticed because unit tests call _execute_tool directly (#56).
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  http-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Start server
+        run: |
+          python -m nanoidp > server.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8000/api/health && exit 0
+            sleep 1
+          done
+          echo "server did not become healthy" >&2
+          cat server.log >&2
+          exit 1
+
+      - name: Run e2e agent
+        run: python examples/test_agent.py
+
+      - name: Server log on failure
+        if: failure()
+        run: cat server.log
+
+  mcp-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: MCP stdio smoke test
+        run: python examples/mcp_smoke_test.py --config ./config

--- a/examples/mcp_smoke_test.py
+++ b/examples/mcp_smoke_test.py
@@ -22,6 +22,8 @@ import sys
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+# Deliberately a hard number: the docs advertise the tool count, so growing or
+# shrinking the MCP surface must consciously update both (metadata never lies).
 EXPECTED_TOOLS = 24
 
 

--- a/examples/mcp_smoke_test.py
+++ b/examples/mcp_smoke_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""MCP stdio smoke test: drive the real `nanoidp-mcp` server end-to-end.
+
+The unit tests call ``_execute_tool`` directly, which is why the stdio
+entrypoint could crash at startup for years without a test noticing (#56).
+This script exercises the actual transport: it launches ``nanoidp-mcp`` as a
+subprocess, performs the MCP handshake, lists the tools and calls a couple of
+read-only ones, asserting on the results.
+
+Usage:
+    python examples/mcp_smoke_test.py [--config ./config]
+
+Exit code 0 on success, 1 on any failure.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+EXPECTED_TOOLS = 24
+
+
+async def run(config_dir: str) -> int:
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "nanoidp.mcp_server"],
+        env={**os.environ, "NANOIDP_CONFIG_DIR": config_dir},
+    )
+
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            print("[OK] MCP handshake (initialize)")
+
+            tools = (await session.list_tools()).tools
+            names = sorted(t.name for t in tools)
+            if len(names) != EXPECTED_TOOLS:
+                print(
+                    f"[FAIL] expected {EXPECTED_TOOLS} tools, got {len(names)}: {names}"
+                )
+                return 1
+            print(f"[OK] list_tools: {len(names)} tools")
+
+            # Read-only calls through the real dispatch path
+            result = await session.call_tool("list_users", {})
+            payload = json.loads(result.content[0].text)
+            users = payload.get("users", payload) if isinstance(payload, dict) else payload
+            if not users:
+                print(f"[FAIL] list_users returned no users: {payload!r}")
+                return 1
+            print(f"[OK] list_users: {len(users)} user(s)")
+
+            result = await session.call_tool("get_oidc_discovery", {})
+            discovery = json.loads(result.content[0].text)
+            if "issuer" not in discovery or "token_endpoint" not in discovery:
+                print(f"[FAIL] discovery document incomplete: {discovery!r}")
+                return 1
+            print(f"[OK] get_oidc_discovery: issuer={discovery['issuer']}")
+
+            result = await session.call_tool("get_keys_info", {})
+            keys_info = json.loads(result.content[0].text)
+            if "active_kid" not in keys_info and "kid" not in keys_info:
+                print(f"[FAIL] get_keys_info missing kid: {keys_info!r}")
+                return 1
+            print("[OK] get_keys_info")
+
+    print("\n[SUCCESS] MCP stdio smoke test passed")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config", default="./config", help="Config directory (default: ./config)"
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(args.config)))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.8.0",
     "types-PyYAML",
+    "requests>=2.31.0",  # examples/test_agent.py (e2e)
 ]
 
 [project.scripts]


### PR DESCRIPTION
Closes #79 (CI quality gates milestone).

Two new CI jobs covering what pytest structurally cannot:

- **http-e2e** — boots `python -m nanoidp`, polls `/api/health` until ready, runs the full `examples/test_agent.py` (41 checks over real HTTP: every grant, SAML both bindings, key rotation, REST API). Server log dumped on failure.
- **mcp-e2e** — new `examples/mcp_smoke_test.py` launches the real MCP server over **stdio** via the `mcp` client library: handshake, `list_tools` asserted at 24, then `list_users` / `get_oidc_discovery` / `get_keys_info` through the actual dispatch path. This is the regression guard for the class of bug found in #56, where the stdio entrypoint crashed at startup for its entire existence because unit tests bypass the transport via `_execute_tool`. The script doubles as a usable example for driving nanoidp's MCP server programmatically.

Verified locally: smoke test passes (handshake, 24 tools, all calls OK) and a full agent run against a live server is 41/41.

Note for reviewers: independent of #78 — whichever merges first, the other stays green (the agent's new redirect-URI test and its config fixture travel together in #78).