### PR TITLE
feat: oauth21 security profile — draft OAuth 2.1 protocol strictness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,9 +42,26 @@ jobs:
       - name: Run e2e agent
         run: python examples/test_agent.py
 
+      - name: Start oauth21 server
+        run: |
+          PORT=8001 python -m nanoidp --profile oauth21 > server-oauth21.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8001/api/health && exit 0
+            sleep 1
+          done
+          echo "oauth21 server did not become healthy" >&2
+          cat server-oauth21.log >&2
+          exit 1
+
+      - name: Run oauth21 profile suite
+        run: python examples/test_agent.py --oauth21 --url http://localhost:8001
+
       - name: Server log on failure
         if: failure()
-        run: cat server.log
+        run: |
+          cat server.log
+          echo "===== oauth21 server ====="
+          cat server-oauth21.log 2>/dev/null || true
 
   mcp-e2e:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ The full documentation lives at
 NanoIDP is a **development/testing tool** and must NOT be used in
 production. Defaults favor convenience (plaintext passwords in config,
 permissive CORS, open redirects); hardening is opt-in via the
-`stricter-dev` profile and explicit settings. The
+`stricter-dev` (runtime) and `oauth21` (draft OAuth 2.1 protocol
+strictness) profiles and explicit settings. The
 [Security guide](https://cdelmonte-zg.github.io/nanoidp/guides/SECURITY.html)
 draws the line precisely.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,12 +12,15 @@ By design, NanoIDP prioritizes developer convenience over security hardening. It
 
 ## Security Profiles
 
-NanoIDP supports two security profiles to balance convenience with basic security controls:
+NanoIDP supports three security profiles to balance convenience with basic security controls:
 
 | Profile | Description |
 |---------|-------------|
 | `dev` (default) | Maximum convenience for development: plaintext passwords, permissive CORS, no rate limiting |
-| `stricter-dev` | Semi-hardened mode: bcrypt passwords, restricted CORS, rate limiting, debug mode blocked |
+| `stricter-dev` | Semi-hardened runtime: bcrypt passwords, restricted CORS, rate limiting, debug mode blocked |
+| `oauth21` | Draft OAuth 2.1 protocol strictness (#68): PKCE required (S256 only), refresh token rotation on, password grant removed, registered redirect URIs mandatory at `/authorize` |
+
+`stricter-dev` hardens the *runtime*; `oauth21` hardens the *protocol* — they are deliberately orthogonal. The discovery document always reflects the active profile: under `oauth21`, `password` disappears from `grant_types_supported` and `code_challenge_methods_supported` is `["S256"]`.
 
 ### Usage
 
@@ -27,16 +30,23 @@ python -m nanoidp
 
 # Run with stricter-dev profile
 python -m nanoidp --profile stricter-dev
+
+# Run with draft OAuth 2.1 protocol strictness
+python -m nanoidp --profile oauth21
 ```
 
 ### Feature Comparison
 
-| Feature | `dev` | `stricter-dev` |
-|---------|-------|----------------|
-| Password storage | Plaintext | bcrypt hash |
-| CORS | `*` (all origins) | localhost only |
-| Rate limiting | None | 10 req/min on `/token` |
-| Debug mode | Allowed | Blocked |
+| Feature | `dev` | `stricter-dev` | `oauth21` |
+|---------|-------|----------------|-----------|
+| Password storage | Plaintext | bcrypt hash | Plaintext |
+| CORS | `*` (all origins) | localhost only | `*` (all origins) |
+| Rate limiting | None | 10 req/min on `/token` | None |
+| Debug mode | Allowed | Blocked | Allowed |
+| PKCE | Optional | Required, S256 only | Required, S256 only |
+| Refresh token rotation | Setting (`off`) | Setting (`off`) | Forced on |
+| `password` grant | Enabled | Enabled | Removed (and not advertised) |
+| Redirect URIs at `/authorize` | Any valid URI, or exact match if registered | Same as `dev` | Registration mandatory, exact match |
 
 ---
 

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -2526,6 +2526,136 @@ class NanoIDPTestAgent:
     # TEST RUNNER
     # =========================================================================
 
+    def run_oauth21_tests(self) -> bool:
+        """Dedicated suite for a server running with --profile oauth21 (#68).
+
+        Asserts the draft-OAuth-2.1 strictness AND that discovery reflects it
+        (metadata never lies): password grant absent and rejected, S256-only,
+        PKCE required, registered redirect_uris mandatory at /authorize.
+        """
+        print("\n" + "=" * 70)
+        print("  NanoIDP oauth21 Profile Test Suite")
+        print("=" * 70)
+        print(f"\n  Target:   {self.base_url}\n")
+
+        # Discovery reflects the profile
+        try:
+            doc = requests.get(
+                f"{self.base_url}/.well-known/openid-configuration", timeout=5
+            ).json()
+            self._add_result(
+                "oauth21 Discovery",
+                TestCategory.OAUTH,
+                "password" not in doc.get("grant_types_supported", ["password"])
+                and doc.get("code_challenge_methods_supported") == ["S256"],
+                "No password grant advertised, S256-only",
+                {
+                    "grant_types_supported": doc.get("grant_types_supported"),
+                    "code_challenge_methods_supported": doc.get(
+                        "code_challenge_methods_supported"
+                    ),
+                },
+            )
+        except Exception as e:
+            self._add_result("oauth21 Discovery", TestCategory.OAUTH, False, f"Error: {e}")
+
+        # Password grant rejected
+        try:
+            r = requests.post(
+                f"{self.base_url}/token",
+                auth=(self.client_id, self.client_secret),
+                data={
+                    "grant_type": "password",
+                    "username": self.username,
+                    "password": self.password,
+                },
+                timeout=5,
+            )
+            self._add_result(
+                "oauth21 Password Grant Rejected",
+                TestCategory.OAUTH,
+                r.status_code == 400,
+                "password grant answered 400",
+                {"status": r.status_code},
+            )
+        except Exception as e:
+            self._add_result(
+                "oauth21 Password Grant Rejected", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+
+        # /authorize strictness against the registered fixture client
+        registered_uri = "http://localhost:3000/callback"
+        base_params = {
+            "response_type": "code",
+            "client_id": "registered-client",
+            "redirect_uri": registered_uri,
+            "scope": "openid",
+        }
+        challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(secrets.token_urlsafe(32).encode()).digest()
+        ).decode().rstrip("=")
+        try:
+            no_pkce = requests.get(
+                f"{self.base_url}/authorize", params=base_params,
+                allow_redirects=False, timeout=5,
+            )
+            plain = requests.get(
+                f"{self.base_url}/authorize",
+                params={
+                    **base_params,
+                    "code_challenge": "plain-verifier",
+                    "code_challenge_method": "plain",
+                },
+                allow_redirects=False, timeout=5,
+            )
+            s256 = requests.get(
+                f"{self.base_url}/authorize",
+                params={
+                    **base_params,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                allow_redirects=False, timeout=5,
+            )
+            unregistered = requests.get(
+                f"{self.base_url}/authorize",
+                params={
+                    **base_params,
+                    "client_id": self.client_id,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                allow_redirects=False, timeout=5,
+            )
+            self._add_result(
+                "oauth21 Authorize Strictness",
+                TestCategory.OAUTH,
+                no_pkce.status_code == 400
+                and plain.status_code == 400
+                and s256.status_code == 200
+                and unregistered.status_code == 400,
+                "no-PKCE 400, plain 400, S256+registered 200, "
+                "unregistered client 400",
+                {
+                    "no_pkce": no_pkce.status_code,
+                    "plain": plain.status_code,
+                    "s256": s256.status_code,
+                    "unregistered_client": unregistered.status_code,
+                },
+            )
+        except Exception as e:
+            self._add_result(
+                "oauth21 Authorize Strictness", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+
+        print("\n" + "─" * 70)
+        ok = self.suite.failed == 0
+        print(
+            f"  oauth21 suite: {self.suite.passed}/{self.suite.total} passed"
+            + ("" if ok else "  [FAILED]")
+        )
+        return ok
+
     def run_all_tests(self) -> bool:
         """Esegue tutti i test organizzati per categoria."""
         print("\n" + "=" * 70)
@@ -2685,6 +2815,12 @@ Examples:
         action="store_true",
         help="Output results as JSON"
     )
+    parser.add_argument(
+        "--oauth21",
+        action="store_true",
+        help="Run only the oauth21-profile suite (server must run with "
+        "--profile oauth21)"
+    )
 
     args = parser.parse_args()
 
@@ -2697,7 +2833,7 @@ Examples:
         verbose=args.verbose
     )
 
-    success = agent.run_all_tests()
+    success = agent.run_oauth21_tests() if args.oauth21 else agent.run_all_tests()
 
     if args.json:
         results = [

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -177,9 +177,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--profile",
-        choices=["dev", "stricter-dev"],
+        choices=["dev", "stricter-dev", "oauth21"],
         default="dev",
-        help="Security profile: dev (default) or stricter-dev",
+        help="Security profile: dev (default), stricter-dev (runtime hardening) "
+        "or oauth21 (draft OAuth 2.1 protocol strictness)",
     )
 
     args = parser.parse_args()

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -28,11 +28,14 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
     config = init_config(config_dir)
     settings = config.settings
 
-    # Apply profile overrides. oauth21 needs no mutations here: its protocol
-    # behavior is derived from security_profile via Settings properties (#68).
+    # Apply profile overrides. The CLI --profile wins over settings.yaml's
+    # security_profile; the runtime mutations key off the EFFECTIVE profile,
+    # so YAML and CLI mean the same thing (#68 review). oauth21 needs no
+    # mutations here: its protocol behavior is derived from security_profile
+    # via Settings properties (#68).
     if profile in ("stricter-dev", "oauth21"):
         settings.security_profile = profile
-    if profile == "stricter-dev":
+    if settings.security_profile == "stricter-dev":
         settings.rate_limit_enabled = True
         settings.password_hashing = True
         # PKCE required and 'plain' rejected in stricter-dev (#47)

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -28,9 +28,11 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
     config = init_config(config_dir)
     settings = config.settings
 
-    # Apply profile overrides
+    # Apply profile overrides. oauth21 needs no mutations here: its protocol
+    # behavior is derived from security_profile via Settings properties (#68).
+    if profile in ("stricter-dev", "oauth21"):
+        settings.security_profile = profile
     if profile == "stricter-dev":
-        settings.security_profile = "stricter-dev"
         settings.rate_limit_enabled = True
         settings.password_hashing = True
         # PKCE required and 'plain' rejected in stricter-dev (#47)

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -357,6 +357,8 @@ class ConfigManager:
             # JWT
             jwt_algorithm=jwt_config.get("algorithm", "RS256"),
             keys_dir=jwt_config.get("keys_dir", "./keys"),
+            # Security profile (top-level; CLI --profile overrides it, #68)
+            security_profile=data.get("security_profile", "dev"),
             # Authority prefixes
             authority_prefixes=data.get("authority_prefixes", {}),
             # Allowed identity classes
@@ -580,6 +582,9 @@ class ConfigManager:
 
         if self.settings.allowed_identity_classes:
             data["allowed_identity_classes"] = self.settings.allowed_identity_classes
+
+        if self.settings.security_profile != "dev":
+            data["security_profile"] = self.settings.security_profile
 
         with open(settings_file, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -186,7 +186,9 @@ class Settings(BaseModel):
     verbose_logging: bool = Field(default=True, description="Include usernames/client_ids in logs (dev convenience)")
 
     # Security (stricter-dev profile)
-    security_profile: str = Field(default="dev", description="Security profile: dev or stricter-dev")
+    security_profile: str = Field(
+        default="dev", description="Security profile: dev, stricter-dev or oauth21"
+    )
     cors_allowed_origins: List[str] = Field(default_factory=lambda: ["*"], description="CORS allowed origins")
     rate_limit_enabled: bool = Field(default=False, description="Enable rate limiting")
     rate_limit_token_endpoint: str = Field(default="10/minute", description="Rate limit for /token endpoint")
@@ -207,10 +209,39 @@ class Settings(BaseModel):
     @classmethod
     def validate_security_profile(cls, v: str) -> str:
         """Validate security profile."""
-        valid_profiles = {"dev", "stricter-dev"}
+        valid_profiles = {"dev", "stricter-dev", "oauth21"}
         if v not in valid_profiles:
             raise ValueError(f"Security profile must be one of: {valid_profiles}")
         return v
+
+    # ------------------------------------------------------------------
+    # Derived protocol behavior (#68). Routes and the shared discovery
+    # builder consume these properties instead of raw fields, so a profile
+    # means the same thing whether it comes from --profile or settings.yaml,
+    # and discovery can never advertise something the endpoints don't do.
+    # oauth21 = draft-ietf-oauth-v2-1 protocol strictness only; runtime
+    # hardening (bcrypt, CORS, rate limiting) stays stricter-dev's job.
+    # ------------------------------------------------------------------
+
+    @property
+    def pkce_required(self) -> bool:
+        """PKCE mandatory on the authorization code flow (OAuth 2.1 §4.1.1)."""
+        return self.require_pkce or self.security_profile == "oauth21"
+
+    @property
+    def pkce_plain_allowed(self) -> bool:
+        """'plain' is rejected by stricter-dev (#47) and oauth21 (§7.5.2)."""
+        return self.security_profile not in ("stricter-dev", "oauth21")
+
+    @property
+    def rotation_enabled(self) -> bool:
+        """Refresh token rotation, forced on by oauth21 (§4.3.1)."""
+        return self.refresh_token_rotation or self.security_profile == "oauth21"
+
+    @property
+    def password_grant_enabled(self) -> bool:
+        """OAuth 2.1 removes the resource-owner password grant entirely."""
+        return self.security_profile != "oauth21"
 
     @field_validator("issuer")
     @classmethod

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -864,6 +864,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             "issuer": settings.issuer,
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
+            "security_profile": settings.security_profile,
             "refresh_token_rotation": settings.refresh_token_rotation,
             "require_pkce": settings.require_pkce,
             "jwt_algorithm": settings.jwt_algorithm,

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -181,23 +181,46 @@ def authorize() -> ResponseReturnValue:
             "error_description": "redirect_uri is not registered for this client"
         }), 400
 
-    # PKCE enforcement (issue #47). With require_pkce enabled (on by default in
-    # the stricter-dev profile) an authorization request without a
-    # code_challenge is rejected, so developers can verify their client
-    # actually sends PKCE (mandatory in OAuth 2.1).
-    if config.settings.require_pkce and not code_challenge:
+    # Under the oauth21 profile, registration is not optional: a client used
+    # at /authorize must have redirect_uris pinned (#68; OAuth 2.1 §2.3
+    # requires the AS to compare against registered values, which presumes
+    # they exist). Enforced here, not at config load, so other grants keep
+    # working for unregistered clients.
+    if config.settings.security_profile == "oauth21" and not client.redirect_uris:
         audit.log(
             event_type="authorization_request",
             endpoint="/authorize",
             method=request.method,
             status="failed",
             client_id=client_id,
-            details={"reason": "PKCE code_challenge required (require_pkce enabled)"},
+            details={"reason": "oauth21 profile requires registered redirect_uris"},
             **req_info,
         )
         return jsonify({
             "error": "invalid_request",
-            "error_description": "PKCE code_challenge is required (require_pkce is enabled)"
+            "error_description": "the oauth21 profile requires this client to have "
+                                 "registered redirect_uris"
+        }), 400
+
+    # PKCE enforcement (issues #47, #68). Via the require_pkce setting (on by
+    # default in the stricter-dev profile) or implied by the oauth21 profile
+    # (OAuth 2.1 §4.1.1 makes PKCE mandatory), an authorization request
+    # without a code_challenge is rejected, so developers can verify their
+    # client actually sends PKCE.
+    if config.settings.pkce_required and not code_challenge:
+        audit.log(
+            event_type="authorization_request",
+            endpoint="/authorize",
+            method=request.method,
+            status="failed",
+            client_id=client_id,
+            details={"reason": "PKCE code_challenge required (require_pkce or oauth21)"},
+            **req_info,
+        )
+        return jsonify({
+            "error": "invalid_request",
+            "error_description": "PKCE code_challenge is required "
+                                 "(require_pkce setting or oauth21 profile)"
         }), 400
 
     if code_challenge:
@@ -224,11 +247,12 @@ def authorize() -> ResponseReturnValue:
             }), 400
 
         # The 'plain' method is only acceptable when S256 is unavailable
-        # (RFC 7636 §4.2); the stricter-dev profile rejects it outright (#47),
-        # whether requested explicitly or via the implicit default.
+        # (RFC 7636 §4.2); the stricter-dev (#47) and oauth21 (#68, OAuth 2.1
+        # §7.5.2) profiles reject it outright, whether requested explicitly
+        # or via the implicit default.
         if (
             effective_method == "plain"
-            and config.settings.security_profile == "stricter-dev"
+            and not config.settings.pkce_plain_allowed
         ):
             audit.log(
                 event_type="authorization_request",
@@ -236,14 +260,18 @@ def authorize() -> ResponseReturnValue:
                 method=request.method,
                 status="failed",
                 client_id=client_id,
-                details={"reason": "PKCE method 'plain' rejected by stricter-dev profile"},
+                details={
+                    "reason": "PKCE method 'plain' rejected by "
+                    f"{config.settings.security_profile} profile"
+                },
                 **req_info,
             )
             return jsonify({
                 "error": "invalid_request",
                 "error_description": "code_challenge_method 'plain' (including the "
                                      "implicit default when the parameter is omitted) "
-                                     "is not allowed by the stricter-dev profile; use S256"
+                                     f"is not allowed by the {config.settings.security_profile} "
+                                     "profile; use S256"
             }), 400
 
     error_msg = None
@@ -600,7 +628,7 @@ def token() -> ResponseReturnValue:
             token_revoked = jti in _revoked_tokens
             if token_revoked or family_revoked:
                 if (
-                    config.settings.refresh_token_rotation
+                    config.settings.rotation_enabled
                     and refresh_family
                     and not family_revoked
                 ):
@@ -608,7 +636,7 @@ def token() -> ResponseReturnValue:
                 reuse_detected = True
             else:
                 reuse_detected = False
-                if config.settings.refresh_token_rotation and jti:
+                if config.settings.rotation_enabled and jti:
                     _revoked_tokens.add(jti)
         if reuse_detected:
             audit.log(
@@ -628,6 +656,28 @@ def token() -> ResponseReturnValue:
 
     # Password grant
     elif grant_type == "password":
+        # OAuth 2.1 removes the resource-owner password grant entirely; under
+        # the oauth21 profile it is rejected (RFC 6749 §5.2) and absent from
+        # the discovery document's grant_types_supported (#68).
+        if not config.settings.password_grant_enabled:
+            audit.log(
+                event_type="token_request",
+                endpoint="/token",
+                method="POST",
+                status="failed",
+                client_id=client_id,
+                details={
+                    "reason": "password grant disabled by the oauth21 profile",
+                    "grant_type": grant_type,
+                },
+                **req_info,
+            )
+            return abort(
+                400,
+                description="Unsupported grant_type: the password grant is "
+                "disabled by the oauth21 profile",
+            )
+
         username = request.form.get("username", "").strip()
         password = request.form.get("password", "")
 

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -47,18 +47,22 @@ def build_discovery_document(settings: Settings) -> Dict[str, Any]:
             "roles", "tenant", "identity_class", "entitlements",
             "source_acl", "attributes", "authorities"
         ],
+        # The password grant is removed by OAuth 2.1 and rejected under the
+        # oauth21 profile, so it must not be advertised there (#68).
         "grant_types_supported": [
-            "authorization_code",
-            "client_credentials",
-            "password",
-            "refresh_token",
-            "urn:ietf:params:oauth:grant-type:device_code",
+            grant
+            for grant in (
+                "authorization_code",
+                "client_credentials",
+                "password",
+                "refresh_token",
+                "urn:ietf:params:oauth:grant-type:device_code",
+            )
+            if grant != "password" or settings.password_grant_enabled
         ],
-        # stricter-dev rejects 'plain' at /authorize, so don't advertise it
-        # there (#47)
+        # stricter-dev and oauth21 reject 'plain' at /authorize, so don't
+        # advertise it there (#47, #68)
         "code_challenge_methods_supported": (
-            ["S256"]
-            if settings.security_profile == "stricter-dev"
-            else ["plain", "S256"]
+            ["plain", "S256"] if settings.pkce_plain_allowed else ["S256"]
         ),
     }

--- a/tests/test_oauth21_profile.py
+++ b/tests/test_oauth21_profile.py
@@ -1,0 +1,202 @@
+"""
+Tests for the oauth21 security profile (issue #68).
+
+The profile aligns nanoidp's strictest behavior with draft OAuth 2.1:
+PKCE required on the authorization code flow (§4.1.1), S256 only (§7.5.2),
+refresh token rotation on (§4.3.1), the password grant removed, and
+registered redirect URIs mandatory at /authorize. Protocol strictness only:
+runtime hardening (bcrypt, CORS, rate limiting) remains stricter-dev's job.
+
+Discovery must reflect every one of these (principle 2: metadata never lies).
+"""
+
+import base64
+import hashlib
+import json
+import secrets
+
+import pytest
+from pydantic import ValidationError
+
+from nanoidp.config import Settings, get_config
+from nanoidp.services.discovery import build_discovery_document
+
+
+def _s256_challenge() -> str:
+    verifier = secrets.token_urlsafe(32)
+    return (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
+
+
+@pytest.fixture
+def oauth21(app):
+    """Switch the active config to the oauth21 profile for one test."""
+    with app.app_context():
+        settings = get_config().settings
+        settings.security_profile = "oauth21"
+    yield settings
+    settings.security_profile = "dev"
+
+
+class TestProfileValidation:
+    def test_oauth21_is_a_valid_profile(self):
+        assert Settings(security_profile="oauth21").security_profile == "oauth21"
+
+    def test_unknown_profile_rejected(self):
+        with pytest.raises(ValidationError):
+            Settings(security_profile="oauth3")
+
+
+class TestDerivedBehavior:
+    """The Settings properties routes and discovery consume."""
+
+    def test_dev_stays_permissive(self):
+        s = Settings(security_profile="dev")
+        assert not s.pkce_required
+        assert s.pkce_plain_allowed
+        assert not s.rotation_enabled
+        assert s.password_grant_enabled
+
+    def test_oauth21_is_strict(self):
+        s = Settings(security_profile="oauth21")
+        assert s.pkce_required
+        assert not s.pkce_plain_allowed
+        assert s.rotation_enabled
+        assert not s.password_grant_enabled
+
+    def test_explicit_settings_still_apply_in_dev(self):
+        s = Settings(security_profile="dev", require_pkce=True, refresh_token_rotation=True)
+        assert s.pkce_required
+        assert s.rotation_enabled
+
+    def test_stricter_dev_unchanged(self):
+        """stricter-dev keeps its behavior: S256-only, but PKCE requirement
+        still comes from the require_pkce setting (set by the CLI profile)."""
+        s = Settings(security_profile="stricter-dev")
+        assert not s.pkce_plain_allowed
+        assert not s.pkce_required  # the CLI sets require_pkce=True separately
+        assert s.password_grant_enabled
+
+
+class TestDiscoveryNeverLies:
+    def test_dev_advertises_password_and_plain(self):
+        doc = build_discovery_document(Settings(security_profile="dev"))
+        assert "password" in doc["grant_types_supported"]
+        assert doc["code_challenge_methods_supported"] == ["plain", "S256"]
+
+    def test_oauth21_hides_password_and_plain(self):
+        doc = build_discovery_document(Settings(security_profile="oauth21"))
+        assert "password" not in doc["grant_types_supported"]
+        assert doc["code_challenge_methods_supported"] == ["S256"]
+        # the other grants stay
+        assert "authorization_code" in doc["grant_types_supported"]
+        assert "refresh_token" in doc["grant_types_supported"]
+
+
+class TestTokenEndpoint:
+    def test_password_grant_rejected_under_oauth21(self, client, oauth21):
+        response = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers={
+                "Authorization": "Basic "
+                + base64.b64encode(b"demo-client:demo-secret").decode()
+            },
+        )
+        assert response.status_code == 400
+        assert b"disabled by the oauth21 profile" in response.data
+
+    def test_client_credentials_still_works_under_oauth21(self, client, oauth21):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={
+                "Authorization": "Basic "
+                + base64.b64encode(b"demo-client:demo-secret").decode()
+            },
+        )
+        assert response.status_code == 200
+        assert "access_token" in json.loads(response.data)
+
+
+class TestAuthorizeEndpoint:
+    REGISTERED_URI = "http://localhost:3000/callback"
+
+    def _authorize(self, client, client_id, **extra):
+        params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": self.REGISTERED_URI,
+            "scope": "openid",
+            **extra,
+        }
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return client.get(f"/authorize?{query}")
+
+    def test_registered_client_with_s256_gets_login_page(self, client, oauth21):
+        response = self._authorize(
+            client,
+            "registered-client",
+            code_challenge=_s256_challenge(),
+            code_challenge_method="S256",
+        )
+        assert response.status_code == 200
+        assert b"username" in response.data
+
+    def test_missing_pkce_rejected(self, client, oauth21):
+        response = self._authorize(client, "registered-client")
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data["error"] == "invalid_request"
+        assert "code_challenge" in data["error_description"]
+
+    def test_plain_pkce_rejected(self, client, oauth21):
+        response = self._authorize(
+            client,
+            "registered-client",
+            code_challenge="plain-verifier-value",
+            code_challenge_method="plain",
+        )
+        assert response.status_code == 400
+
+    def test_client_without_registered_uris_rejected(self, client, oauth21):
+        response = self._authorize(
+            client,
+            "demo-client",
+            code_challenge=_s256_challenge(),
+            code_challenge_method="S256",
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "registered redirect_uris" in data["error_description"]
+
+    def test_dev_profile_unaffected(self, client):
+        """Without the profile, demo-client + no PKCE still gets the login page."""
+        response = self._authorize(client, "demo-client")
+        assert response.status_code == 200
+
+
+class TestMCPParity:
+    async def test_get_settings_reports_profile(self, app):
+        from nanoidp.mcp_server import _execute_tool
+
+        with app.app_context():
+            config = get_config()
+        result = await _execute_tool("get_settings", {}, config)
+        assert result["security_profile"] == "dev"
+
+    async def test_mcp_discovery_reflects_profile(self, app):
+        from nanoidp.mcp_server import _execute_tool
+
+        with app.app_context():
+            config = get_config()
+        config.settings.security_profile = "oauth21"
+        try:
+            result = await _execute_tool("get_oidc_discovery", {}, config)
+            assert "password" not in result["grant_types_supported"]
+            assert result["code_challenge_methods_supported"] == ["S256"]
+        finally:
+            config.settings.security_profile = "dev"

--- a/tests/test_oauth21_profile.py
+++ b/tests/test_oauth21_profile.py
@@ -179,6 +179,75 @@ class TestAuthorizeEndpoint:
         assert response.status_code == 200
 
 
+class TestYamlProfileParity:
+    """security_profile from settings.yaml means the same as --profile (#68 review):
+    before the fix it was silently ignored on load and dropped on save."""
+
+    def _seed(self, tmp_path, extra_yaml=""):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            "oauth:\n"
+            '  issuer: "http://localhost:8000"\n'
+            '  audience: "my-app"\n'
+            "  clients:\n"
+            '    - client_id: "c1"\n'
+            '      client_secret: "s1"\n'
+            f"jwt:\n  keys_dir: {tmp_path}/keys\n" + extra_yaml
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        return config_dir
+
+    def test_yaml_oauth21_is_loaded_and_drives_behavior(self, tmp_path):
+        from nanoidp.config import ConfigManager
+
+        config_dir = self._seed(tmp_path, "security_profile: oauth21\n")
+        manager = ConfigManager(str(config_dir))
+        s = manager.settings
+        assert s.security_profile == "oauth21"
+        assert s.pkce_required and not s.password_grant_enabled
+        assert "password" not in build_discovery_document(s)["grant_types_supported"]
+
+    def test_yaml_stricter_dev_applies_runtime_hardening(self, tmp_path):
+        """A YAML-declared stricter-dev now gets the same runtime mutations
+        the CLI applies (previously the YAML value was ignored entirely)."""
+        from nanoidp.app import create_app
+
+        config_dir = self._seed(tmp_path, "security_profile: stricter-dev\n")
+        create_app(str(config_dir))
+        s = get_config().settings
+        assert s.security_profile == "stricter-dev"
+        assert s.require_pkce and s.rate_limit_enabled and s.password_hashing
+        assert not s.debug
+
+    def test_cli_profile_wins_over_yaml(self, tmp_path):
+        from nanoidp.app import create_app
+
+        config_dir = self._seed(tmp_path, "security_profile: oauth21\n")
+        create_app(str(config_dir), profile="stricter-dev")
+        assert get_config().settings.security_profile == "stricter-dev"
+
+    def test_save_round_trips_non_default_profile(self, tmp_path):
+        from nanoidp.config import ConfigManager
+
+        config_dir = self._seed(tmp_path)
+        manager = ConfigManager(str(config_dir))
+        manager.settings.security_profile = "oauth21"
+        manager.save()
+
+        reloaded = ConfigManager(str(config_dir))
+        assert reloaded.settings.security_profile == "oauth21"
+
+    def test_save_omits_default_profile(self, tmp_path):
+        from nanoidp.config import ConfigManager
+
+        config_dir = self._seed(tmp_path)
+        ConfigManager(str(config_dir)).save()
+        assert "security_profile" not in (config_dir / "settings.yaml").read_text()
+
+
 class TestMCPParity:
     async def test_get_settings_reports_profile(self, app):
         from nanoidp.mcp_server import _execute_tool


### PR DESCRIPTION
Closes #68 — completes the core of the [OAuth 2.1 profile](https://github.com/cdelmonte-zg/nanoidp/milestone/1) milestone (#81, native-app URIs, remains as the follow-up).

## The profile

`--profile oauth21`, alongside `dev` and `stricter-dev`:

| Behavior | Citation |
|---|---|
| PKCE required on the authorization code flow | draft-ietf-oauth-v2-1 §4.1.1 |
| S256 only (`plain` rejected, like stricter-dev) | §7.5.2 |
| Refresh token rotation forced on | §4.3.1 (family revocation from #46/#56 already in place) |
| `password` grant removed — rejected with 400 | RFC 6749 §5.2 |
| Registered `redirect_uris` mandatory at `/authorize` | §2.3, on top of #67's exact matching |

**Deliberately orthogonal to `stricter-dev`** (the open design question in the issue): `oauth21` hardens the *protocol*, `stricter-dev` the *runtime* (bcrypt, CORS, rate limiting). The docs table now says exactly that.

## Design: derived properties, one source of truth

The routes and the shared discovery builder consume four new `Settings` properties (`pkce_required`, `pkce_plain_allowed`, `rotation_enabled`, `password_grant_enabled`) instead of raw fields. Consequences:

- a profile means the same thing whether it arrives via `--profile` or `settings.yaml`;
- **metadata never lies**: under `oauth21`, `password` disappears from `grant_types_supported` and `code_challenge_methods_supported` is `["S256"]` — the same builder serves HTTP and MCP, so the surfaces cannot drift;
- `stricter-dev` behavior is **byte-identical** to before (its PKCE requirement still comes from the CLI setting `require_pkce=True`, as today — asserted by a dedicated test).

## Ships whole

- **MCP**: `get_settings` now reports `security_profile`; discovery parity is automatic via the shared builder (asserted by test).
- **e2e**: `test_agent.py --oauth21` runs a dedicated suite (discovery honesty, password grant rejected, no-PKCE/plain/unregistered-client rejected, S256+registered accepted); the E2E workflow boots a **second server** with `--profile oauth21` on port 8001 and runs it.
- **Docs**: security guide's profile tables (three profiles, feature comparison incl. protocol rows) + README one-liner.
- **Tests**: 17 new (697 total) — validator, derived properties per profile, discovery honesty both ways, token endpoint (password rejected / client_credentials unaffected), authorize strictness, MCP parity.

## Verified

`mypy` clean, `ruff` clean, 697 unit tests green, coverage 73% ≥ gate, `mdbook build` green — and the oauth21 e2e suite run locally against a real `--profile oauth21` server: **3/3**.