### PR TITLE
refactor: single YAML persistence path; save no longer lossy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ config/*.local.yaml
 
 # mdBook output
 book/book/
+
+# Transient backups from atomic YAML writes
+config/*.yaml.bak

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -14,6 +14,12 @@ from typing import Any, Dict, List, Optional
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from .serialization import (
+    apply_settings_document,
+    apply_users_document,
+    atomic_write_yaml,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -507,87 +513,32 @@ class ConfigManager:
         logger.info(f"Configuration saved to {self.config_dir}")
 
     def _save_users(self) -> None:
-        """Save users to users.yaml."""
+        """Save users to users.yaml (shared builder, read-modify-write, #83)."""
         users_file = self.config_dir / "users.yaml"
 
-        users_data = {}
-        for username, user in self.users.items():
-            user_dict: Dict[str, Any] = {
-                "password": user.password,
-                "email": user.email,
-                "roles": user.roles,
-                "tenant": user.tenant,
-            }
-            if user.identity_class:
-                user_dict["identity_class"] = user.identity_class
-            if user.entitlements:
-                user_dict["entitlements"] = user.entitlements
-            if user.source_acl:
-                user_dict["source_acl"] = user.source_acl
-            if user.attributes:
-                user_dict["attributes"] = user.attributes
-            users_data[username] = user_dict
+        document: Dict[str, Any] = {}
+        if users_file.exists():
+            with open(users_file, "r") as f:
+                document = yaml.safe_load(f) or {}
 
-        data = {
-            "users": users_data,
-            "default_user": self.default_user,
-        }
-
-        with open(users_file, "w") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        apply_users_document(document, self.users, self.default_user)
+        atomic_write_yaml(users_file, document)
 
     def _save_settings(self) -> None:
-        """Save settings to settings.yaml."""
+        """Save settings to settings.yaml (shared builder, #83).
+
+        Read-modify-write: keys this codebase doesn't manage (jwt, session,
+        logging.level, custom keys) are preserved instead of deleted (#87).
+        """
         settings_file = self.config_dir / "settings.yaml"
 
-        clients_data = []
-        for client in self.settings.clients:
-            client_entry: Dict[str, Any] = {
-                "client_id": client.client_id,
-                "client_secret": client.client_secret,
-                "description": client.description,
-            }
-            if client.additional_audiences:
-                client_entry["additional_audiences"] = client.additional_audiences
-            if client.redirect_uris:
-                client_entry["redirect_uris"] = client.redirect_uris
-            clients_data.append(client_entry)
+        document: Dict[str, Any] = {}
+        if settings_file.exists():
+            with open(settings_file, "r") as f:
+                document = yaml.safe_load(f) or {}
 
-        data = {
-            "server": {
-                "host": self.settings.host,
-                "port": self.settings.port,
-            },
-            "oauth": {
-                "issuer": self.settings.issuer,
-                "audience": self.settings.audience,
-                "token_expiry_minutes": self.settings.token_expiry_minutes,
-                "refresh_token_rotation": self.settings.refresh_token_rotation,
-                "require_pkce": self.settings.require_pkce,
-                "clients": clients_data,
-            },
-            "saml": {
-                "entity_id": self.settings.saml_entity_id,
-                "sso_url": self.settings.saml_sso_url,
-                "default_acs_url": self.settings.default_acs_url,
-                "sign_responses": self.settings.saml_sign_responses,
-                "c14n_algorithm": self.settings.saml_c14n_algorithm,
-                "strict_binding": self.settings.strict_saml_binding,
-            },
-            "logging": {
-                "verbose_logging": self.settings.verbose_logging,
-            },
-            "authority_prefixes": self.settings.authority_prefixes,
-        }
-
-        if self.settings.allowed_identity_classes:
-            data["allowed_identity_classes"] = self.settings.allowed_identity_classes
-
-        if self.settings.security_profile != "dev":
-            data["security_profile"] = self.settings.security_profile
-
-        with open(settings_file, "w") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        apply_settings_document(document, self.settings)
+        atomic_write_yaml(settings_file, document)
 
 
 # Global config instance

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -1,0 +1,165 @@
+"""
+Single source of truth for serializing config objects into their YAML documents.
+
+``ConfigManager.save()`` and the ``YamlWriter`` behind the web UI used to each
+build their own YAML entries. The duplication drifted repeatedly — #32 (UI
+saves dropped ``additional_audiences``), #78 (``redirect_uris`` had to be added
+in two places), #82 (``security_profile`` persisted only via ``ConfigManager``)
+— and ``ConfigManager`` rewrote ``settings.yaml`` from scratch, deleting every
+section it didn't own (#87). Both paths now delegate here (#83): entry builders
+produce identical entries, and ``apply_settings_document`` is read-modify-write,
+so keys this module doesn't manage (``jwt``, ``session``, custom keys) survive
+any save.
+
+This module deliberately has no runtime imports from the package (models are
+type-checking-only), so it can be imported from ``config.py`` without cycles.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict
+
+import yaml
+
+if TYPE_CHECKING:
+    from .config import OAuthClient, Settings, User
+
+logger = logging.getLogger(__name__)
+
+
+def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
+    """Build the settings.yaml entry for an OAuth client.
+
+    Optional list fields are omitted when empty, so a default client stays a
+    three-line entry.
+    """
+    entry: Dict[str, Any] = {
+        "client_id": client.client_id,
+        "client_secret": client.client_secret,
+        "description": client.description,
+    }
+    if client.additional_audiences:
+        entry["additional_audiences"] = client.additional_audiences
+    if client.redirect_uris:
+        entry["redirect_uris"] = client.redirect_uris
+    return entry
+
+
+def user_to_yaml(user: User) -> Dict[str, Any]:
+    """Build the users.yaml entry for a user.
+
+    Canonical form is sparse: optional fields and model defaults
+    (``tenant: default``, empty lists) are omitted and restored by the loader's
+    defaults on the next read.
+    """
+    entry: Dict[str, Any] = {
+        "password": user.password,
+        "email": user.email,
+    }
+    if user.identity_class:
+        entry["identity_class"] = user.identity_class
+    if user.entitlements:
+        entry["entitlements"] = user.entitlements
+    if user.roles:
+        entry["roles"] = user.roles
+    if user.tenant and user.tenant != "default":
+        entry["tenant"] = user.tenant
+    if user.source_acl:
+        entry["source_acl"] = user.source_acl
+    if user.attributes:
+        entry["attributes"] = user.attributes
+    return entry
+
+
+def apply_settings_document(
+    document: Dict[str, Any], settings: Settings
+) -> Dict[str, Any]:
+    """Update the settings.yaml keys this codebase manages, in place.
+
+    Read-modify-write: ``document`` is the currently persisted document (or
+    ``{}``), and only owned keys are (re)written — anything else (``jwt``,
+    ``session``, ``logging`` keys other than ``verbose_logging``, unknown
+    custom keys) is preserved verbatim (#87). Optional owned keys are removed
+    when back at their defaults, so a cleared ``security_profile`` does not
+    linger in the file.
+    """
+    server = document.setdefault("server", {})
+    server["host"] = settings.host
+    server["port"] = settings.port
+
+    oauth = document.setdefault("oauth", {})
+    oauth["issuer"] = settings.issuer
+    oauth["audience"] = settings.audience
+    oauth["token_expiry_minutes"] = settings.token_expiry_minutes
+    oauth["refresh_token_rotation"] = settings.refresh_token_rotation
+    oauth["require_pkce"] = settings.require_pkce
+    oauth["clients"] = [client_to_yaml(client) for client in settings.clients]
+
+    saml = document.setdefault("saml", {})
+    saml["entity_id"] = settings.saml_entity_id
+    saml["sso_url"] = settings.saml_sso_url
+    saml["default_acs_url"] = settings.default_acs_url
+    saml["sign_responses"] = settings.saml_sign_responses
+    saml["c14n_algorithm"] = settings.saml_c14n_algorithm
+    saml["strict_binding"] = settings.strict_saml_binding
+
+    document.setdefault("logging", {})["verbose_logging"] = settings.verbose_logging
+    document["authority_prefixes"] = settings.authority_prefixes
+
+    if settings.allowed_identity_classes:
+        document["allowed_identity_classes"] = settings.allowed_identity_classes
+    else:
+        document.pop("allowed_identity_classes", None)
+
+    if settings.security_profile != "dev":
+        document["security_profile"] = settings.security_profile
+    else:
+        document.pop("security_profile", None)
+
+    return document
+
+
+def apply_users_document(
+    document: Dict[str, Any], users: Dict[str, User], default_user: str
+) -> Dict[str, Any]:
+    """Update the users.yaml keys this codebase manages, in place.
+
+    The full user map is owned; unknown top-level keys are preserved.
+    """
+    document["users"] = {
+        username: user_to_yaml(user) for username, user in users.items()
+    }
+    document["default_user"] = default_user
+    return document
+
+
+def atomic_write_yaml(file_path: Path, data: Dict[str, Any]) -> None:
+    """Atomically write a YAML document, with a .bak of the previous version.
+
+    Writes to a temp file in the same directory and renames over the target;
+    on failure the previous content is restored from the backup.
+    """
+    backup_path = file_path.with_suffix(".yaml.bak")
+    if file_path.exists():
+        shutil.copy2(file_path, backup_path)
+
+    fd, temp_path = tempfile.mkstemp(
+        suffix=".yaml", prefix=file_path.stem + "_", dir=file_path.parent
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        os.replace(temp_path, file_path)
+        logger.info(f"Successfully wrote {file_path}")
+    except Exception as e:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        if backup_path.exists():
+            shutil.copy2(backup_path, file_path)
+            logger.warning(f"Restored {file_path} from backup after write failure")
+        raise RuntimeError(f"Failed to write {file_path}: {e}") from e

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -4,15 +4,13 @@ Provides atomic write operations for YAML configuration files.
 """
 
 import logging
-import os
-import shutil
-import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
 
 from ..config import OAuthClient, User, get_config
+from ..serialization import atomic_write_yaml, client_to_yaml, user_to_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -27,41 +25,8 @@ class YamlWriter:
         self.settings_file = self.config_dir / "settings.yaml"
 
     def _atomic_write(self, file_path: Path, data: Dict[str, Any]) -> None:
-        """
-        Atomically write data to a YAML file.
-        Uses a temporary file and rename to ensure atomic operation.
-        """
-        # Create backup
-        backup_path = file_path.with_suffix(".yaml.bak")
-        if file_path.exists():
-            shutil.copy2(file_path, backup_path)
-
-        # Write to temporary file first
-        fd, temp_path = tempfile.mkstemp(
-            suffix=".yaml",
-            prefix=file_path.stem + "_",
-            dir=file_path.parent
-        )
-
-        try:
-            with os.fdopen(fd, "w") as f:
-                yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
-
-            # Atomic rename
-            os.replace(temp_path, file_path)
-            logger.info(f"Successfully wrote {file_path}")
-
-        except Exception as e:
-            # Clean up temp file if it exists
-            if os.path.exists(temp_path):
-                os.unlink(temp_path)
-
-            # Restore from backup if available
-            if backup_path.exists():
-                shutil.copy2(backup_path, file_path)
-                logger.warning(f"Restored {file_path} from backup after write failure")
-
-            raise RuntimeError(f"Failed to write {file_path}: {e}") from e
+        """Atomically write a YAML document (shared implementation, #83)."""
+        atomic_write_yaml(file_path, data)
 
     def _load_users_yaml(self) -> Dict[str, Any]:
         """Load the current users.yaml content."""
@@ -94,27 +59,7 @@ class YamlWriter:
         if is_new and user.username in data.get("users", {}):
             raise ValueError(f"User '{user.username}' already exists")
 
-        user_data: Dict[str, Any] = {
-            "password": user.password,
-            "email": user.email,
-        }
-
-        # Only include non-empty optional fields
-        if user.identity_class:
-            user_data["identity_class"] = user.identity_class
-        if user.entitlements:
-            user_data["entitlements"] = user.entitlements
-        if user.roles:
-            user_data["roles"] = user.roles
-        if user.tenant and user.tenant != "default":
-            user_data["tenant"] = user.tenant
-        if user.source_acl:
-            user_data["source_acl"] = user.source_acl
-        # Custom attributes
-        if user.attributes:
-            user_data["attributes"] = user.attributes
-
-        data.setdefault("users", {})[user.username] = user_data
+        data.setdefault("users", {})[user.username] = user_to_yaml(user)
 
         self._atomic_write(self.users_file, data)
 
@@ -181,15 +126,7 @@ class YamlWriter:
         if is_new and existing_idx is not None:
             raise ValueError(f"Client '{client.client_id}' already exists")
 
-        client_data: Dict[str, Any] = {
-            "client_id": client.client_id,
-            "client_secret": client.client_secret,
-            "description": client.description,
-        }
-        if client.additional_audiences:
-            client_data["additional_audiences"] = client.additional_audiences
-        if client.redirect_uris:
-            client_data["redirect_uris"] = client.redirect_uris
+        client_data = client_to_yaml(client)
 
         if existing_idx is not None:
             clients[existing_idx] = client_data

--- a/tests/test_persistence_unification.py
+++ b/tests/test_persistence_unification.py
@@ -1,0 +1,174 @@
+"""
+Tests for the single YAML persistence path (issue #83) and the lossy-save fix
+(issue #87).
+
+Both ``ConfigManager.save()`` and the web UI's ``YamlWriter`` must produce
+identical entries (they used to drift: #32, #78, #82), and saving must never
+delete keys the codebase doesn't manage.
+"""
+
+from typing import Any, Dict
+
+import yaml
+
+from nanoidp.config import ConfigManager, OAuthClient, User
+from nanoidp.serialization import client_to_yaml, user_to_yaml
+from nanoidp.services.yaml_writer import YamlWriter
+
+
+def _seed(tmp_path, settings_yaml: str) -> Any:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "settings.yaml").write_text(settings_yaml)
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+BASE_SETTINGS = (
+    "oauth:\n"
+    '  issuer: "http://localhost:8000"\n'
+    '  audience: "my-app"\n'
+    "  clients:\n"
+    '    - client_id: "c1"\n'
+    '      client_secret: "s1"\n'
+)
+
+
+def _read(path) -> Dict[str, Any]:
+    return yaml.safe_load(path.read_text())
+
+
+class TestSingleClientEntry:
+    """One builder, byte-identical entries from both persistence paths."""
+
+    CLIENT = OAuthClient(
+        client_id="c1",
+        client_secret="s1",
+        description="d",
+        additional_audiences=["https://api.example.com"],
+        redirect_uris=["http://localhost:3000/cb"],
+    )
+
+    def test_both_paths_write_the_same_client_entry(self, tmp_path):
+        # Path 1: ConfigManager.save()
+        dir1 = _seed(tmp_path / "a", BASE_SETTINGS)
+        manager = ConfigManager(str(dir1))
+        manager.settings.clients = [self.CLIENT]
+        manager.save()
+        entry1 = _read(dir1 / "settings.yaml")["oauth"]["clients"][0]
+
+        # Path 2: YamlWriter.save_client()
+        dir2 = _seed(tmp_path / "b", BASE_SETTINGS)
+        ConfigManager(str(dir2))  # writer resolves the active config dir lazily
+        writer = YamlWriter(str(dir2))
+        writer.save_client(self.CLIENT, is_new=False)
+        entry2 = _read(dir2 / "settings.yaml")["oauth"]["clients"][0]
+
+        assert entry1 == entry2 == client_to_yaml(self.CLIENT)
+
+    def test_optional_fields_omitted_when_empty(self):
+        entry = client_to_yaml(OAuthClient(client_id="c", client_secret="s"))
+        assert "additional_audiences" not in entry
+        assert "redirect_uris" not in entry
+
+
+class TestSaveIsNotLossy:
+    """#87: ConfigManager.save() must preserve keys it doesn't manage."""
+
+    def test_foreign_sections_survive_save(self, tmp_path):
+        config_dir = _seed(
+            tmp_path,
+            BASE_SETTINGS
+            + "server:\n  host: 0.0.0.0\n  port: 8000\n  debug: true\n"
+            + "jwt:\n  keys_dir: /custom/keys\n  max_previous_keys: 5\n"
+            + "session:\n  secret_key: super-secret\n"
+            + "logging:\n  level: DEBUG\n  log_token_requests: false\n"
+            + "my_custom_extension:\n  enabled: true\n",
+        )
+        manager = ConfigManager(str(config_dir))
+        manager.save()
+
+        doc = _read(config_dir / "settings.yaml")
+        assert doc["jwt"] == {"keys_dir": "/custom/keys", "max_previous_keys": 5}
+        assert doc["session"] == {"secret_key": "super-secret"}
+        assert doc["logging"]["level"] == "DEBUG"
+        assert doc["logging"]["log_token_requests"] is False
+        assert doc["server"]["debug"] is True
+        assert doc["my_custom_extension"] == {"enabled": True}
+        # ...while owned keys are written
+        assert doc["oauth"]["issuer"] == "http://localhost:8000"
+
+    def test_cleared_optional_keys_are_removed(self, tmp_path):
+        config_dir = _seed(
+            tmp_path,
+            BASE_SETTINGS
+            + "security_profile: oauth21\n"
+            + "allowed_identity_classes: [INTERNAL]\n",
+        )
+        manager = ConfigManager(str(config_dir))
+        manager.settings.security_profile = "dev"
+        manager.settings.allowed_identity_classes = []
+        manager.save()
+
+        doc = _read(config_dir / "settings.yaml")
+        assert "security_profile" not in doc
+        assert "allowed_identity_classes" not in doc
+
+    def test_save_creates_backup(self, tmp_path):
+        config_dir = _seed(tmp_path, BASE_SETTINGS)
+        ConfigManager(str(config_dir)).save()
+        assert (config_dir / "settings.yaml.bak").exists()
+
+
+class TestSingleUserEntry:
+    """Users serialize sparsely and identically from both paths."""
+
+    USER = User(
+        username="alice",
+        password="pw",
+        email="alice@example.org",
+        roles=["USER"],
+    )
+
+    def test_both_paths_write_the_same_user_entry(self, tmp_path):
+        dir1 = _seed(tmp_path / "a", BASE_SETTINGS)
+        manager = ConfigManager(str(dir1))
+        manager.users["alice"] = self.USER
+        manager.save()
+        entry1 = _read(dir1 / "users.yaml")["users"]["alice"]
+
+        dir2 = _seed(tmp_path / "b", BASE_SETTINGS)
+        ConfigManager(str(dir2))
+        writer = YamlWriter(str(dir2))
+        writer.save_user(self.USER, is_new=True)
+        entry2 = _read(dir2 / "users.yaml")["users"]["alice"]
+
+        assert entry1 == entry2 == user_to_yaml(self.USER)
+
+    def test_defaults_are_omitted_and_round_trip(self, tmp_path):
+        """Sparse form: default tenant / empty lists are dropped on disk and
+        restored by the loader's defaults — semantics unchanged."""
+        entry = user_to_yaml(self.USER)
+        assert "tenant" not in entry  # default
+        assert "entitlements" not in entry  # empty
+
+        config_dir = _seed(tmp_path, BASE_SETTINGS)
+        manager = ConfigManager(str(config_dir))
+        manager.users["alice"] = self.USER
+        manager.save()
+
+        reloaded = ConfigManager(str(config_dir)).users["alice"]
+        assert reloaded.tenant == "default"
+        assert reloaded.roles == ["USER"]
+        assert reloaded.entitlements == []
+
+    def test_unknown_top_level_users_key_preserved(self, tmp_path):
+        config_dir = _seed(tmp_path, BASE_SETTINGS)
+        users_file = config_dir / "users.yaml"
+        users_file.write_text(users_file.read_text() + "my_note: keep me\n")
+
+        manager = ConfigManager(str(config_dir))
+        manager.save()
+        assert _read(users_file)["my_note"] == "keep me"


### PR DESCRIPTION
Closes #83, closes #87 — first PR of the [Internal architecture](https://github.com/cdelmonte-zg/nanoidp/milestone/6) milestone.

## What moved

New `nanoidp/serialization.py` — the single place that knows how a client entry, a user entry, and the two YAML documents are built (`client_to_yaml`, `user_to_yaml`, `apply_settings_document`, `apply_users_document`, `atomic_write_yaml`). `ConfigManager.save()` and the UI's `YamlWriter` both delegate to it. The module has no runtime imports from the package (models are TYPE_CHECKING-only), so `config.py` can import it without cycles.

The drift class this kills has three prior incidents on record: #32 (UI saves dropped `additional_audiences`), #78 (`redirect_uris` had to be added to two serializers), #82 (`security_profile` persisted by one path only).

## Disclosed behavior deltas (per the issue's ground rule)

1. **#87 fixed — save is no longer lossy.** `ConfigManager.save()` (MCP `save_config`) used to rewrite `settings.yaml` from scratch, deleting `jwt:`, `session:`, `logging.level`, `server.debug` and any custom key — an external-keys setup was silently wiped from disk. It is now read-modify-write like the UI path always was. Cleared optional keys (`security_profile` back to `dev`, emptied `allowed_identity_classes`) are removed rather than left stale.
2. **User entries take the sparse form everywhere** (the writer's form): default `tenant` and empty lists are omitted on disk and restored by loader defaults on read. Round-trip semantics unchanged — asserted by test.
3. **`ConfigManager.save()` writes atomically** with a `.yaml.bak` backup, matching the UI path; `config/*.yaml.bak` is gitignored (the UI already produced them).

Out of scope, noted in #87: `${PORT:...}` placeholders are still resolved on save for owned keys — the long-standing e2e caveat, a separate problem.

## Tests

8 new in `test_persistence_unification.py`: byte-identical client and user entries from both paths, foreign-section preservation (jwt/session/logging/custom), stale-key removal, backup creation, sparse-form round-trip, unknown users.yaml key preservation. Suite: 710 green, coverage 74% (up 1 point — the shared module is fully covered), mypy/ruff clean.