### PR TITLE
feat: opt-in verification of signed AuthnRequests, both bindings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,12 +56,45 @@ jobs:
       - name: Run oauth21 profile suite
         run: python examples/test_agent.py --oauth21 --url http://localhost:8001
 
+      - name: Prepare signed-SAML config
+        run: |
+          python examples/gen_sp_keypair.py --out e2e-saml
+          cp -r config e2e-saml/config
+          python - <<'EOF'
+          import yaml
+          path = "e2e-saml/config/settings.yaml"
+          with open(path) as f:
+              doc = yaml.safe_load(f)
+          doc.setdefault("saml", {})["want_authn_requests_signed"] = True
+          doc["saml"]["sp_certificates"] = ["e2e-saml/sp-cert.pem"]
+          with open(path, "w") as f:
+              yaml.safe_dump(doc, f, sort_keys=False)
+          EOF
+
+      - name: Start signed-SAML server
+        run: |
+          PORT=8002 NANOIDP_CONFIG_DIR=e2e-saml/config python -m nanoidp > server-saml.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8002/api/health && exit 0
+            sleep 1
+          done
+          echo "signed-SAML server did not become healthy" >&2
+          cat server-saml.log >&2
+          exit 1
+
+      - name: Run signed-AuthnRequests suite
+        run: |
+          python examples/test_agent.py --saml-signed --url http://localhost:8002 \
+            --sp-key e2e-saml/sp-key.pem --sp-cert e2e-saml/sp-cert.pem
+
       - name: Server log on failure
         if: failure()
         run: |
           cat server.log
           echo "===== oauth21 server ====="
           cat server-oauth21.log 2>/dev/null || true
+          echo "===== signed-SAML server ====="
+          cat server-saml.log 2>/dev/null || true
 
   mcp-e2e:
     runs-on: ubuntu-latest

--- a/book/src/reference/saml.md
+++ b/book/src/reference/saml.md
@@ -58,6 +58,38 @@ When `sign_responses: true` (default), responses include:
 When `sign_responses: false`, responses are sent without any signature
 elements.
 
+## Signed AuthnRequests
+
+By default, nanoidp accepts unsigned AuthnRequests (and ignores
+`Signature`/`SigAlg` query parameters). SPs that sign their requests can
+turn on verification:
+
+```yaml
+saml:
+  want_authn_requests_signed: true
+  sp_certificates:
+    - /path/to/sp-cert.pem   # PEM; one entry per trusted SP
+```
+
+With the flag on, nanoidp **requires and verifies** the signature under
+both bindings and rejects unsigned or invalid requests with `400`:
+
+- **HTTP-Redirect** — the query-string signature over the URL-encoded
+  `SAMLRequest[&RelayState]&SigAlg` fragment (SAML 2.0 Bindings
+  §3.4.4.1); `rsa-sha256`, `rsa-sha512` and legacy `rsa-sha1` SigAlg
+  values are supported.
+- **HTTP-POST** — the enveloped `<ds:Signature>` inside the AuthnRequest
+  (SAML 2.0 Core §5).
+
+The metadata advertises `WantAuthnRequestsSigned="true"` if and only if
+enforcement is on. A request verifies if any registered certificate
+validates it.
+
+Need a test SP keypair? `python examples/gen_sp_keypair.py --out .`
+generates `sp-key.pem`/`sp-cert.pem`, and
+`examples/test_agent.py --saml-signed` exercises the whole behavior
+against a running server.
+
 ## XML canonicalization algorithm
 
 By default, NanoIDP uses **Exclusive C14N** for XML canonicalization,

--- a/examples/gen_sp_keypair.py
+++ b/examples/gen_sp_keypair.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Generate a self-signed SP keypair for testing signed AuthnRequests (#69).
+
+Writes sp-key.pem and sp-cert.pem into the target directory; register the
+certificate in settings.yaml:
+
+    saml:
+      want_authn_requests_signed: true
+      sp_certificates:
+        - /path/to/sp-cert.pem
+
+Usage:
+    python examples/gen_sp_keypair.py [--out DIR] [--cn COMMON_NAME]
+"""
+
+import argparse
+import datetime
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default=".", help="Output directory (default: .)")
+    parser.add_argument("--cn", default="test-sp", help="Certificate CN (default: test-sp)")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, args.cn)])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .sign(key, hashes.SHA256())
+    )
+
+    key_path = out / "sp-key.pem"
+    cert_path = out / "sp-cert.pem"
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    print(f"Wrote {key_path} and {cert_path} (CN={args.cn})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -2656,6 +2656,147 @@ class NanoIDPTestAgent:
         )
         return ok
 
+    def run_saml_signed_tests(self, sp_key_path: str, sp_cert_path: str) -> bool:
+        """Dedicated suite for a server with saml.want_authn_requests_signed (#69).
+
+        Requires the server to have the given SP certificate registered in
+        saml.sp_certificates. Signs real AuthnRequests with the SP key and
+        asserts acceptance/rejection under both bindings, plus the metadata
+        advertisement (metadata never lies).
+        """
+        import zlib
+        from urllib.parse import quote
+
+        from cryptography.hazmat.primitives import hashes as c_hashes
+        from cryptography.hazmat.primitives import serialization as c_ser
+        from cryptography.hazmat.primitives.asymmetric import padding as c_padding
+
+        print("\n" + "=" * 70)
+        print("  NanoIDP Signed-AuthnRequests Test Suite")
+        print("=" * 70)
+        print(f"\n  Target:   {self.base_url}\n")
+
+        with open(sp_key_path, "rb") as f:
+            sp_key = c_ser.load_pem_private_key(f.read(), password=None)
+        with open(sp_cert_path, "rb") as f:
+            sp_cert_pem = f.read()
+
+        authn = (
+            '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" '
+            'xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_e2e-signed-1" '
+            'Version="2.0" IssueInstant="2026-01-01T00:00:00Z" '
+            'AssertionConsumerServiceURL="http://localhost:8080/login/saml2/sso/nanoidp">'
+            "<saml:Issuer>e2e-signed-sp</saml:Issuer></samlp:AuthnRequest>"
+        ).encode()
+
+        # Metadata advertisement
+        try:
+            meta = requests.get(f"{self.base_url}/saml/metadata", timeout=5)
+            self._add_result(
+                "Signed AuthnRequests Metadata",
+                TestCategory.SAML,
+                'WantAuthnRequestsSigned="true"' in meta.text,
+                "WantAuthnRequestsSigned advertised",
+            )
+        except Exception as e:
+            self._add_result(
+                "Signed AuthnRequests Metadata", TestCategory.SAML, False, f"Error: {e}"
+            )
+
+        # Redirect binding: signed accepted, unsigned/tampered rejected
+        sig_alg = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+        deflated = zlib.compress(authn, 9)[2:-4]
+        sr = quote(base64.b64encode(deflated).decode(), safe="")
+        fragment = f"SAMLRequest={sr}&SigAlg={quote(sig_alg, safe='')}"
+        signature = sp_key.sign(
+            fragment.encode(), c_padding.PKCS1v15(), c_hashes.SHA256()
+        )
+        sig_q = quote(base64.b64encode(signature).decode(), safe="")
+        try:
+            ok = requests.get(
+                f"{self.base_url}/saml/sso?{fragment}&Signature={sig_q}",
+                allow_redirects=False, timeout=5,
+            )
+            unsigned = requests.get(
+                f"{self.base_url}/saml/sso?SAMLRequest={sr}",
+                allow_redirects=False, timeout=5,
+            )
+            evil = zlib.compress(authn.replace(b"_e2e-signed-1", b"_evil"), 9)[2:-4]
+            evil_sr = quote(base64.b64encode(evil).decode(), safe="")
+            tampered = requests.get(
+                f"{self.base_url}/saml/sso?SAMLRequest={evil_sr}"
+                f"&SigAlg={quote(sig_alg, safe='')}&Signature={sig_q}",
+                allow_redirects=False, timeout=5,
+            )
+            self._add_result(
+                "Signed Redirect Binding",
+                TestCategory.SAML,
+                ok.status_code == 200
+                and unsigned.status_code == 400
+                and tampered.status_code == 400,
+                "signed 200, unsigned 400, tampered 400",
+                {
+                    "signed": ok.status_code,
+                    "unsigned": unsigned.status_code,
+                    "tampered": tampered.status_code,
+                },
+            )
+        except Exception as e:
+            self._add_result(
+                "Signed Redirect Binding", TestCategory.SAML, False, f"Error: {e}"
+            )
+
+        # POST binding: enveloped XML signature
+        try:
+            from lxml import etree as l_etree
+            from signxml import XMLSigner, methods
+
+            root = l_etree.fromstring(authn)
+            signed_root = XMLSigner(
+                method=methods.enveloped,
+                signature_algorithm="rsa-sha256",
+                digest_algorithm="sha256",
+            ).sign(
+                root,
+                key=sp_key.private_bytes(
+                    c_ser.Encoding.PEM,
+                    c_ser.PrivateFormat.PKCS8,
+                    c_ser.NoEncryption(),
+                ),
+                cert=sp_cert_pem.decode(),
+            )
+            signed_b64 = base64.b64encode(l_etree.tostring(signed_root)).decode()
+
+            ok = requests.post(
+                f"{self.base_url}/saml/sso",
+                data={"SAMLRequest": signed_b64},
+                allow_redirects=False, timeout=5,
+            )
+            unsigned = requests.post(
+                f"{self.base_url}/saml/sso",
+                data={"SAMLRequest": base64.b64encode(authn).decode()},
+                allow_redirects=False, timeout=5,
+            )
+            self._add_result(
+                "Signed POST Binding",
+                TestCategory.SAML,
+                ok.status_code == 200 and unsigned.status_code == 400,
+                "signed 200, unsigned 400",
+                {"signed": ok.status_code, "unsigned": unsigned.status_code},
+            )
+        except Exception as e:
+            self._add_result(
+                "Signed POST Binding", TestCategory.SAML, False, f"Error: {e}"
+            )
+
+        print("\n" + "─" * 70)
+        ok_all = self.suite.failed == 0
+        print(
+            f"  signed-authnrequests suite: {self.suite.passed}/{self.suite.total} passed"
+            + ("" if ok_all else "  [FAILED]")
+        )
+        return ok_all
+
     def run_all_tests(self) -> bool:
         """Esegue tutti i test organizzati per categoria."""
         print("\n" + "=" * 70)
@@ -2821,6 +2962,22 @@ Examples:
         help="Run only the oauth21-profile suite (server must run with "
         "--profile oauth21)"
     )
+    parser.add_argument(
+        "--saml-signed",
+        action="store_true",
+        help="Run only the signed-AuthnRequests suite (server must have "
+        "saml.want_authn_requests_signed and the SP cert registered)"
+    )
+    parser.add_argument(
+        "--sp-key",
+        default="sp-key.pem",
+        help="SP private key PEM for --saml-signed (default: sp-key.pem)"
+    )
+    parser.add_argument(
+        "--sp-cert",
+        default="sp-cert.pem",
+        help="SP certificate PEM for --saml-signed (default: sp-cert.pem)"
+    )
 
     args = parser.parse_args()
 
@@ -2833,7 +2990,12 @@ Examples:
         verbose=args.verbose
     )
 
-    success = agent.run_oauth21_tests() if args.oauth21 else agent.run_all_tests()
+    if args.oauth21:
+        success = agent.run_oauth21_tests()
+    elif args.saml_signed:
+        success = agent.run_saml_signed_tests(args.sp_key, args.sp_cert)
+    else:
+        success = agent.run_all_tests()
 
     if args.json:
         results = [

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -148,6 +148,10 @@ class ConfigManager:
             default_acs_url=saml.get("default_acs_url", "http://localhost:8080/login/saml2/sso/samlIdp"),
             saml_sign_responses=saml.get("sign_responses", True),
             saml_c14n_algorithm=saml.get("c14n_algorithm", "exc_c14n"),
+            saml_want_authn_requests_signed=saml.get(
+                "want_authn_requests_signed", False
+            ),
+            saml_sp_certificates=saml.get("sp_certificates", []) or [],
             strict_saml_binding=saml.get("strict_binding", False),
             # JWT
             jwt_algorithm=jwt_config.get("algorithm", "RS256"),

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -521,6 +521,15 @@ async def list_tools() -> list[Tool]:
                         "enum": ["c14n", "c14n11", "exc_c14n"],
                         "description": "XML canonicalization algorithm: 'c14n' (1.0), 'c14n11' (1.1), or 'exc_c14n' (Exclusive 1.0)",
                     },
+                    "saml_want_authn_requests_signed": {
+                        "type": "boolean",
+                        "description": "Require and verify AuthnRequest signatures, both bindings (#69)",
+                    },
+                    "saml_sp_certificates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "PEM certificate files of SPs whose AuthnRequest signatures are accepted",
+                    },
                     "strict_saml_binding": {
                         "type": "boolean",
                         "description": "Enforce strict SAML binding compliance (reject GET with uncompressed data)",
@@ -874,6 +883,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
                 "sign_responses": settings.saml_sign_responses,
                 "c14n_algorithm": settings.saml_c14n_algorithm,
                 "strict_binding": settings.strict_saml_binding,
+                "want_authn_requests_signed": (
+                    settings.saml_want_authn_requests_signed
+                ),
+                "sp_certificates": settings.saml_sp_certificates,
             },
             "logging": {
                 "verbose_logging": settings.verbose_logging,
@@ -907,6 +920,16 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         if "strict_saml_binding" in arguments:
             settings.strict_saml_binding = arguments["strict_saml_binding"]
             updated.append("strict_saml_binding")
+        if "saml_want_authn_requests_signed" in arguments:
+            settings.saml_want_authn_requests_signed = arguments[
+                "saml_want_authn_requests_signed"
+            ]
+            updated.append("saml_want_authn_requests_signed")
+        if "saml_sp_certificates" in arguments:
+            settings.saml_sp_certificates = _normalize_str_list(
+                arguments["saml_sp_certificates"], "saml_sp_certificates"
+            )
+            updated.append("saml_sp_certificates")
         if "verbose_logging" in arguments:
             settings.verbose_logging = arguments["verbose_logging"]
             updated.append("verbose_logging")
@@ -929,6 +952,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
                 "saml_sign_responses": settings.saml_sign_responses,
                 "saml_c14n_algorithm": settings.saml_c14n_algorithm,
                 "strict_saml_binding": settings.strict_saml_binding,
+                "saml_want_authn_requests_signed": (
+                    settings.saml_want_authn_requests_signed
+                ),
+                "saml_sp_certificates": settings.saml_sp_certificates,
                 "verbose_logging": settings.verbose_logging,
             },
         }

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -132,6 +132,16 @@ class Settings(BaseModel):
         default="exc_c14n",
         description="XML canonicalization algorithm: 'exc_c14n' (Exclusive 1.0, default), 'c14n' (1.0), or 'c14n11' (1.1)"
     )
+    saml_want_authn_requests_signed: bool = Field(
+        default=False,
+        description="Require and verify signatures on AuthnRequests, both "
+        "bindings (#69); advertised as WantAuthnRequestsSigned in metadata",
+    )
+    saml_sp_certificates: List[str] = Field(
+        default_factory=list,
+        description="PEM certificate files of SPs whose AuthnRequest "
+        "signatures are accepted",
+    )
     strict_saml_binding: bool = Field(
         default=False,
         description="Enforce strict SAML binding compliance (reject GET with uncompressed data)"

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -372,23 +372,43 @@ def sso() -> ResponseReturnValue:
 
     # AuthnRequest signature verification (#69), opt-in via
     # saml.want_authn_requests_signed. Verified where the request ENTERS:
-    # - GET = Redirect binding: query-string signature (Bindings §3.4.4.1),
-    #   which only exists on the original URL — the inline-login POST leg
-    #   cannot carry it, so that leg relies on the entry check.
+    # - GET = Redirect binding: query-string signature (Bindings §3.4.4.1).
+    #   The signature only exists on the original URL and cannot survive the
+    #   login-form roundtrip, so the verified request is bound SERVER-SIDE in
+    #   the session; the POST login leg (saml_original_verb=GET) is admitted
+    #   only for values byte-identical to a request this session already
+    #   verified, and fails closed otherwise (#69 review: hidden form fields
+    #   are client-controlled and must not be trusted on their own).
     # - POST without saml_original_verb = POST-binding entry: enveloped XML
     #   signature (Core §5).
     # - POST login leg of a POST-binding request (saml_original_verb=POST):
     #   the signature still travels inside the XML, so it is re-verified.
     if config.settings.saml_want_authn_requests_signed:
         form_leg_verb = (request.form.get("saml_original_verb") or "").upper()
-        verify_xml = request.method == "POST" and form_leg_verb in ("", "POST")
         try:
             if request.method == "GET":
                 verify_redirect_signature(
                     request.query_string.decode("latin-1"),
                     load_sp_certificates(config.settings.saml_sp_certificates),
                 )
-            elif verify_xml:
+                # A later Redirect-leg POST may only replay exactly this
+                # verified request. Overwritten by each newly verified GET.
+                session["saml_verified_redirect"] = {
+                    "SAMLRequest": saml_request_b64,
+                    "RelayState": relay_state,
+                }
+            elif form_leg_verb == "GET":
+                verified = session.get("saml_verified_redirect")
+                if (
+                    not isinstance(verified, dict)
+                    or verified.get("SAMLRequest") != saml_request_b64
+                    or verified.get("RelayState") != relay_state
+                ):
+                    raise SAMLSignatureError(
+                        "Redirect-binding login continuation does not match a "
+                        "signature-verified request in this session"
+                    )
+            else:
                 xml_bytes = _decode_saml_request_bytes(saml_request_b64)
                 verify_post_signature(
                     xml_bytes,

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -15,7 +15,13 @@ from flask.typing import ResponseReturnValue
 from lxml import etree
 
 from ..config import get_config
+from ..exceptions import SAMLSignatureError
 from ..services import get_crypto_service
+from ..services.saml_verification import (
+    load_sp_certificates,
+    verify_post_signature,
+    verify_redirect_signature,
+)
 from ._audit import audit_event
 
 # Create secure XML parser (XXE protection without deprecated defusedxml.lxml)
@@ -66,6 +72,19 @@ def _get_c14n_algorithm(config_value: str) -> "CanonicalizationMethod":
     return CanonicalizationMethod.EXCLUSIVE_XML_CANONICALIZATION_1_0
 
 saml_bp = Blueprint("saml", __name__, url_prefix="/saml")
+
+
+def _decode_saml_request_bytes(saml_request_b64: str) -> bytes:
+    """Decode a SAMLRequest to raw XML bytes, deflate-tolerant (#69).
+
+    Signature verification needs the XML before the full parse; binding
+    strictness is still enforced later by ``_parse_saml_request``.
+    """
+    decoded = b64decode(saml_request_b64)
+    try:
+        return zlib.decompress(decoded, -zlib.MAX_WBITS)
+    except zlib.error:
+        return decoded
 
 
 def _parse_saml_request(
@@ -294,6 +313,10 @@ def metadata() -> ResponseReturnValue:
         "{urn:oasis:names:tc:SAML:2.0:metadata}IDPSSODescriptor",
         protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol",
     )
+    # Advertised if and only if verification is actually enforced (#69,
+    # principle 2: metadata never lies).
+    if settings.saml_want_authn_requests_signed:
+        idpsso.set("WantAuthnRequestsSigned", "true")
 
     # KeyDescriptor
     kd = etree.SubElement(idpsso, "{urn:oasis:names:tc:SAML:2.0:metadata}KeyDescriptor", use="signing")
@@ -346,6 +369,39 @@ def sso() -> ResponseReturnValue:
 
     if not saml_request_b64:
         return abort(400, description="missing SAMLRequest")
+
+    # AuthnRequest signature verification (#69), opt-in via
+    # saml.want_authn_requests_signed. Verified where the request ENTERS:
+    # - GET = Redirect binding: query-string signature (Bindings §3.4.4.1),
+    #   which only exists on the original URL — the inline-login POST leg
+    #   cannot carry it, so that leg relies on the entry check.
+    # - POST without saml_original_verb = POST-binding entry: enveloped XML
+    #   signature (Core §5).
+    # - POST login leg of a POST-binding request (saml_original_verb=POST):
+    #   the signature still travels inside the XML, so it is re-verified.
+    if config.settings.saml_want_authn_requests_signed:
+        form_leg_verb = (request.form.get("saml_original_verb") or "").upper()
+        verify_xml = request.method == "POST" and form_leg_verb in ("", "POST")
+        try:
+            if request.method == "GET":
+                verify_redirect_signature(
+                    request.query_string.decode("latin-1"),
+                    load_sp_certificates(config.settings.saml_sp_certificates),
+                )
+            elif verify_xml:
+                xml_bytes = _decode_saml_request_bytes(saml_request_b64)
+                verify_post_signature(
+                    xml_bytes,
+                    load_sp_certificates(config.settings.saml_sp_certificates),
+                )
+        except SAMLSignatureError as e:
+            audit_event(
+                "saml_request",
+                "failed",
+                endpoint="/saml/sso",
+                details={"reason": f"AuthnRequest signature rejected: {e}"},
+            )
+            return abort(400, description=f"AuthnRequest signature rejected: {e}")
 
     # Check if user is authenticated
     username = session.get("user")
@@ -404,11 +460,9 @@ def sso() -> ResponseReturnValue:
         )
         return abort(401, description=f"user '{username}' not found")
 
-    # Parse SAMLRequest
-    # NOTE: For HTTP-Redirect binding, SPs may send Signature/SigAlg query params.
-    # We do NOT verify the query string signature (dev tool - signature verification
-    # would require SP certificate which we don't have). This is acceptable for
-    # development/testing but not for production use.
+    # Parse SAMLRequest. Signature verification (when enabled) already
+    # happened at the top of this function (#69); without the opt-in,
+    # Signature/SigAlg query params are accepted and ignored, as before.
     #
     # Use original HTTP verb from form if set (inline login case: original GET
     # compressed SAMLRequest is POSTed back after login form submission).

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -510,6 +510,12 @@ def settings() -> ResponseReturnValue:
             default_acs_url=request.form.get("default_acs_url"),
             sign_responses=request.form.get("saml_sign_responses") == "true",
             strict_binding=request.form.get("strict_saml_binding") == "true",
+            want_authn_requests_signed=(
+                request.form.get("saml_want_authn_requests_signed") == "true"
+            ),
+            sp_certificates=_parse_textarea_list(
+                request.form.get("saml_sp_certificates", "")
+            ),
             c14n_algorithm=request.form.get("saml_c14n_algorithm"),
         )
 

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -107,6 +107,11 @@ def apply_settings_document(
     saml["sign_responses"] = settings.saml_sign_responses
     saml["c14n_algorithm"] = settings.saml_c14n_algorithm
     saml["strict_binding"] = settings.strict_saml_binding
+    saml["want_authn_requests_signed"] = settings.saml_want_authn_requests_signed
+    if settings.saml_sp_certificates:
+        saml["sp_certificates"] = settings.saml_sp_certificates
+    else:
+        saml.pop("sp_certificates", None)
 
     document.setdefault("logging", {})["verbose_logging"] = settings.verbose_logging
     document["authority_prefixes"] = settings.authority_prefixes

--- a/src/nanoidp/services/saml_verification.py
+++ b/src/nanoidp/services/saml_verification.py
@@ -1,0 +1,154 @@
+"""
+AuthnRequest signature verification (issue #69).
+
+Opt-in via ``saml.want_authn_requests_signed``: SPs that sign their requests
+can test that nanoidp actually validates the signatures, under both bindings:
+
+- **HTTP-Redirect** (SAML 2.0 Bindings §3.4.4.1): the signature covers the
+  URL-encoded query fragment ``SAMLRequest=...[&RelayState=...]&SigAlg=...``
+  exactly as transmitted, so verification works on the *raw* query string —
+  re-encoding the values would break it.
+- **HTTP-POST** (SAML 2.0 Core §5): an enveloped ``ds:Signature`` inside the
+  AuthnRequest XML, verified with signxml against the registered
+  certificates. XML always passes through ``secure_fromstring`` semantics
+  upstream (XXE-safe); signxml gets the raw bytes and applies its own
+  hardened parsing.
+
+SP certificates are PEM files listed in ``saml.sp_certificates``; a request
+verifies if any registered certificate validates it.
+"""
+
+import base64
+import logging
+from typing import Callable, Dict, List, Optional, Tuple
+from urllib.parse import unquote
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509 import load_pem_x509_certificate
+
+from ..exceptions import SAMLSignatureError
+
+logger = logging.getLogger(__name__)
+
+# SigAlg URIs (RFC 4051 / xmldsig) accepted for the Redirect binding. SHA-1 is
+# obsolete but kept for legacy SPs — this is a dev tool and the point is
+# exercising the SP's actual configuration.
+_REDIRECT_SIG_ALGS: Dict[str, Callable[[], hashes.HashAlgorithm]] = {
+    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256": hashes.SHA256,
+    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512": hashes.SHA512,
+    "http://www.w3.org/2000/09/xmldsig#rsa-sha1": hashes.SHA1,
+}
+
+
+def load_sp_certificates(paths: List[str]) -> List[bytes]:
+    """Read the registered SP certificate PEMs; unreadable paths are skipped
+    with a warning (a missing file must not take the whole IdP down)."""
+    certs: List[bytes] = []
+    for path in paths:
+        try:
+            with open(path, "rb") as f:
+                certs.append(f.read())
+        except OSError as e:
+            logger.warning(f"SP certificate '{path}' could not be read: {e}")
+    return certs
+
+
+def _raw_query_params(raw_query: str) -> List[Tuple[str, str]]:
+    """Split a raw query string into (name, raw_value) pairs WITHOUT decoding
+    the values — the Redirect-binding signature covers the transmitted bytes."""
+    pairs: List[Tuple[str, str]] = []
+    for chunk in raw_query.split("&"):
+        if not chunk:
+            continue
+        name, _, raw_value = chunk.partition("=")
+        pairs.append((name, raw_value))
+    return pairs
+
+
+def verify_redirect_signature(raw_query: str, cert_pems: List[bytes]) -> None:
+    """Verify an HTTP-Redirect binding signature (Bindings §3.4.4.1).
+
+    Raises SAMLSignatureError when the request is unsigned, uses an
+    unsupported SigAlg, or no registered certificate validates it.
+    """
+    params = dict(_raw_query_params(raw_query))
+    if "Signature" not in params or "SigAlg" not in params:
+        raise SAMLSignatureError(
+            "AuthnRequest is not signed (Signature/SigAlg query parameters "
+            "required by want_authn_requests_signed)"
+        )
+
+    sig_alg = unquote(params["SigAlg"])
+    hash_cls = _REDIRECT_SIG_ALGS.get(sig_alg)
+    if hash_cls is None:
+        raise SAMLSignatureError(f"Unsupported SigAlg: {sig_alg}")
+
+    try:
+        signature = base64.b64decode(unquote(params["Signature"]), validate=True)
+    except Exception as e:
+        raise SAMLSignatureError(f"Malformed Signature parameter: {e}") from e
+
+    # The signed octet string is the URL-encoded fragment in transmission
+    # order, Signature excluded (Bindings §3.4.4.1).
+    ordered = [
+        f"{name}={raw_value}"
+        for name, raw_value in _raw_query_params(raw_query)
+        if name in ("SAMLRequest", "RelayState", "SigAlg")
+    ]
+    signed_octets = "&".join(ordered).encode("utf-8")
+
+    if not cert_pems:
+        raise SAMLSignatureError(
+            "want_authn_requests_signed is enabled but no saml.sp_certificates "
+            "are registered"
+        )
+
+    last_error: Optional[Exception] = None
+    for pem in cert_pems:
+        try:
+            public_key = load_pem_x509_certificate(pem).public_key()
+            if not isinstance(public_key, rsa.RSAPublicKey):
+                raise SAMLSignatureError("SP certificate does not carry an RSA key")
+            public_key.verify(signature, signed_octets, padding.PKCS1v15(), hash_cls())
+            return
+        except Exception as e:  # try the next registered certificate
+            last_error = e
+    raise SAMLSignatureError(
+        f"Redirect-binding signature did not verify against any registered "
+        f"SP certificate: {last_error}"
+    )
+
+
+def verify_post_signature(xml_bytes: bytes, cert_pems: List[bytes]) -> None:
+    """Verify an enveloped XML signature on an AuthnRequest (Core §5).
+
+    Raises SAMLSignatureError when the document is unsigned or no registered
+    certificate validates it.
+    """
+    # Imported lazily: signxml is heavyweight and this only runs when the
+    # opt-in verification is enabled.
+    from signxml import XMLVerifier
+
+    if b"Signature" not in xml_bytes:
+        raise SAMLSignatureError(
+            "AuthnRequest carries no XML signature "
+            "(required by want_authn_requests_signed)"
+        )
+    if not cert_pems:
+        raise SAMLSignatureError(
+            "want_authn_requests_signed is enabled but no saml.sp_certificates "
+            "are registered"
+        )
+
+    last_error: Optional[Exception] = None
+    for pem in cert_pems:
+        try:
+            XMLVerifier().verify(xml_bytes, x509_cert=pem.decode("ascii"))
+            return
+        except Exception as e:
+            last_error = e
+    raise SAMLSignatureError(
+        f"POST-binding XML signature did not verify against any registered "
+        f"SP certificate: {last_error}"
+    )

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -180,6 +180,8 @@ class YamlWriter:
         default_acs_url: Optional[str] = None,
         sign_responses: Optional[bool] = None,
         strict_binding: Optional[bool] = None,
+        want_authn_requests_signed: Optional[bool] = None,
+        sp_certificates: Optional[List[str]] = None,
         c14n_algorithm: Optional[str] = None,
     ) -> None:
         """Update SAML settings."""
@@ -196,6 +198,13 @@ class YamlWriter:
             saml["sign_responses"] = sign_responses
         if strict_binding is not None:
             saml["strict_binding"] = strict_binding
+        if want_authn_requests_signed is not None:
+            saml["want_authn_requests_signed"] = want_authn_requests_signed
+        if sp_certificates is not None:
+            if sp_certificates:
+                saml["sp_certificates"] = sp_certificates
+            else:
+                saml.pop("sp_certificates", None)
         if c14n_algorithm is not None:
             saml["c14n_algorithm"] = c14n_algorithm
 

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -89,6 +89,23 @@
                     </div>
 
                     <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="saml_want_authn_requests_signed" name="saml_want_authn_requests_signed" value="true"
+                                   {% if settings.saml_want_authn_requests_signed %}checked{% endif %}>
+                            <label class="form-check-label" for="saml_want_authn_requests_signed">Require Signed AuthnRequests</label>
+                        </div>
+                        <div class="form-text">Verify AuthnRequest signatures (both bindings) against the registered SP certificates; advertised as <code>WantAuthnRequestsSigned</code> in metadata.</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="saml_sp_certificates" class="form-label">SP Certificates</label>
+                        <textarea class="form-control" id="saml_sp_certificates" name="saml_sp_certificates"
+                                  rows="2" placeholder="One PEM file path per line">{{ settings.saml_sp_certificates | join('\n') }}</textarea>
+                        <div class="form-text">PEM certificate files of SPs whose AuthnRequest signatures are accepted.</div>
+                    </div>
+
+                    <div class="mb-3">
                         <label for="saml_c14n_algorithm" class="form-label">Canonicalization Algorithm</label>
                         <select class="form-select" id="saml_c14n_algorithm" name="saml_c14n_algorithm">
                             <option value="exc_c14n" {% if settings.saml_c14n_algorithm == 'exc_c14n' %}selected{% endif %}>Exclusive C14N 1.0 (default)</option>
@@ -190,6 +207,9 @@ function updatePreview() {
             default_acs_url: document.getElementById('default_acs_url').value,
             sign_responses: document.getElementById('saml_sign_responses').checked,
             strict_binding: document.getElementById('strict_saml_binding').checked,
+            want_authn_requests_signed: document.getElementById('saml_want_authn_requests_signed').checked,
+            sp_certificates: document.getElementById('saml_sp_certificates').value
+                .split('\n').map(s => s.trim()).filter(s => s),
             c14n_algorithm: document.getElementById('saml_c14n_algorithm').value
         },
         allowed_identity_classes: document.getElementById('allowed_identity_classes').value

--- a/tests/test_saml_signed_authnrequests.py
+++ b/tests/test_saml_signed_authnrequests.py
@@ -1,0 +1,238 @@
+"""
+Tests for opt-in AuthnRequest signature verification (issue #69).
+
+With ``saml.want_authn_requests_signed`` on, nanoidp verifies:
+- HTTP-Redirect binding: the query-string signature over the URL-encoded
+  ``SAMLRequest[&RelayState]&SigAlg`` fragment (SAML 2.0 Bindings §3.4.4.1);
+- HTTP-POST binding: the enveloped ``ds:Signature`` (SAML 2.0 Core §5);
+against the certificates registered in ``saml.sp_certificates``. Default is
+off (principle 3), and the metadata advertises ``WantAuthnRequestsSigned``
+if and only if enforcement is on (principle 2).
+"""
+
+import base64
+import datetime
+import zlib
+from urllib.parse import quote
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import NameOID
+from lxml import etree
+from signxml import XMLSigner, methods
+
+from nanoidp.config import get_config
+
+RSA_SHA256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+
+AUTHN_REQUEST = (
+    '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" '
+    'xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_sig-test-1" '
+    'Version="2.0" IssueInstant="2026-01-01T00:00:00Z" '
+    'AssertionConsumerServiceURL="http://localhost:8080/login/saml2/sso/nanoidp">'
+    "<saml:Issuer>signed-sp</saml:Issuer></samlp:AuthnRequest>"
+).encode()
+
+
+def _make_keypair():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "signed-sp")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+SP_KEY, SP_CERT = _make_keypair()
+OTHER_KEY, OTHER_CERT = _make_keypair()
+
+
+def _pem(cert) -> bytes:
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _key_pem(key) -> bytes:
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+
+
+@pytest.fixture
+def signed_mode(app, tmp_path):
+    """Enable verification with the SP certificate registered."""
+    cert_path = tmp_path / "sp-cert.pem"
+    cert_path.write_bytes(_pem(SP_CERT))
+    with app.app_context():
+        settings = get_config().settings
+        settings.saml_want_authn_requests_signed = True
+        settings.saml_sp_certificates = [str(cert_path)]
+    yield settings
+    settings.saml_want_authn_requests_signed = False
+    settings.saml_sp_certificates = []
+
+
+def _redirect_query(key=SP_KEY, relay_state="RS", sig_alg=RSA_SHA256, tamper=False):
+    """Build a signed HTTP-Redirect query string (Bindings §3.4.4.1)."""
+    deflated = zlib.compress(AUTHN_REQUEST, 9)[2:-4]
+    b64 = base64.b64encode(deflated).decode()
+    parts = [f"SAMLRequest={quote(b64, safe='')}"]
+    if relay_state is not None:
+        parts.append(f"RelayState={quote(relay_state, safe='')}")
+    parts.append(f"SigAlg={quote(sig_alg, safe='')}")
+    signed_octets = "&".join(parts).encode()
+    signature = key.sign(signed_octets, padding.PKCS1v15(), hashes.SHA256())
+    if tamper:
+        # a different (but well-formed) request after signing
+        other = zlib.compress(AUTHN_REQUEST.replace(b"_sig-test-1", b"_evil"), 9)[2:-4]
+        parts[0] = f"SAMLRequest={quote(base64.b64encode(other).decode(), safe='')}"
+    return "&".join(parts) + f"&Signature={quote(base64.b64encode(signature).decode(), safe='')}"
+
+
+def _signed_post_request(key=SP_KEY, cert=SP_CERT, tamper=False) -> str:
+    """Build a base64 POST-binding AuthnRequest with an enveloped signature."""
+    root = etree.fromstring(AUTHN_REQUEST)
+    signed = XMLSigner(
+        method=methods.enveloped,
+        signature_algorithm="rsa-sha256",
+        digest_algorithm="sha256",
+    ).sign(root, key=_key_pem(key), cert=_pem(cert).decode())
+    xml = etree.tostring(signed)
+    if tamper:
+        xml = xml.replace(b"signed-sp", b"evil-sp")
+    return base64.b64encode(xml).decode()
+
+
+class TestRedirectBinding:
+    def test_signed_request_accepted(self, client, signed_mode):
+        r = client.get(f"/saml/sso?{_redirect_query()}")
+        assert r.status_code == 200
+        assert b"username" in r.data  # login form
+
+    def test_signed_without_relay_state_accepted(self, client, signed_mode):
+        r = client.get(f"/saml/sso?{_redirect_query(relay_state=None)}")
+        assert r.status_code == 200
+
+    def test_unsigned_request_rejected(self, client, signed_mode):
+        deflated = zlib.compress(AUTHN_REQUEST, 9)[2:-4]
+        b64 = quote(base64.b64encode(deflated).decode(), safe="")
+        r = client.get(f"/saml/sso?SAMLRequest={b64}")
+        assert r.status_code == 400
+        assert b"not signed" in r.data
+
+    def test_tampered_request_rejected(self, client, signed_mode):
+        r = client.get(f"/saml/sso?{_redirect_query(tamper=True)}")
+        assert r.status_code == 400
+
+    def test_wrong_key_rejected(self, client, signed_mode):
+        r = client.get(f"/saml/sso?{_redirect_query(key=OTHER_KEY)}")
+        assert r.status_code == 400
+
+    def test_unsupported_sigalg_rejected(self, client, signed_mode):
+        r = client.get(
+            f"/saml/sso?{_redirect_query(sig_alg='http://example.com/fake-alg')}"
+        )
+        assert r.status_code == 400
+        assert b"Unsupported SigAlg" in r.data
+
+    def test_no_registered_certificates_fails_closed(self, client, signed_mode):
+        signed_mode.saml_sp_certificates = []
+        r = client.get(f"/saml/sso?{_redirect_query()}")
+        assert r.status_code == 400
+
+
+class TestPostBinding:
+    def test_signed_request_accepted(self, client, signed_mode):
+        r = client.post("/saml/sso", data={"SAMLRequest": _signed_post_request()})
+        assert r.status_code == 200
+        assert b"username" in r.data
+
+    def test_full_login_flow_with_signed_request(self, client, signed_mode):
+        """The login leg re-verifies the embedded signature and issues the
+        SAML response."""
+        r = client.post(
+            "/saml/sso",
+            data={
+                "SAMLRequest": _signed_post_request(),
+                "saml_original_verb": "POST",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert r.status_code == 200
+        assert b"SAMLResponse" in r.data
+
+    def test_unsigned_request_rejected(self, client, signed_mode):
+        r = client.post(
+            "/saml/sso",
+            data={"SAMLRequest": base64.b64encode(AUTHN_REQUEST).decode()},
+        )
+        assert r.status_code == 400
+        assert b"no XML signature" in r.data
+
+    def test_tampered_request_rejected(self, client, signed_mode):
+        r = client.post(
+            "/saml/sso", data={"SAMLRequest": _signed_post_request(tamper=True)}
+        )
+        assert r.status_code == 400
+
+    def test_wrong_key_rejected(self, client, signed_mode):
+        r = client.post(
+            "/saml/sso",
+            data={"SAMLRequest": _signed_post_request(key=OTHER_KEY, cert=OTHER_CERT)},
+        )
+        assert r.status_code == 400
+
+
+class TestDefaultsAndMetadata:
+    def test_default_off_keeps_unsigned_requests_working(self, client):
+        deflated = zlib.compress(AUTHN_REQUEST, 9)[2:-4]
+        b64 = quote(base64.b64encode(deflated).decode(), safe="")
+        r = client.get(f"/saml/sso?SAMLRequest={b64}")
+        assert r.status_code == 200
+
+    def test_metadata_omits_flag_by_default(self, client):
+        r = client.get("/saml/metadata")
+        assert b"WantAuthnRequestsSigned" not in r.data
+
+    def test_metadata_advertises_flag_when_enforced(self, client, signed_mode):
+        r = client.get("/saml/metadata")
+        assert b'WantAuthnRequestsSigned="true"' in r.data
+
+
+class TestPersistence:
+    def test_settings_round_trip(self, tmp_path):
+        from nanoidp.config import ConfigManager
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            "oauth:\n"
+            '  issuer: "http://localhost:8000"\n'
+            "saml:\n"
+            "  want_authn_requests_signed: true\n"
+            "  sp_certificates:\n"
+            '    - "/certs/sp.pem"\n'
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        manager = ConfigManager(str(config_dir))
+        assert manager.settings.saml_want_authn_requests_signed is True
+        assert manager.settings.saml_sp_certificates == ["/certs/sp.pem"]
+
+        manager.save()
+        reloaded = ConfigManager(str(config_dir))
+        assert reloaded.settings.saml_want_authn_requests_signed is True
+        assert reloaded.settings.saml_sp_certificates == ["/certs/sp.pem"]

--- a/tests/test_saml_signed_authnrequests.py
+++ b/tests/test_saml_signed_authnrequests.py
@@ -195,6 +195,87 @@ class TestPostBinding:
         assert r.status_code == 400
 
 
+class TestRedirectLegBinding:
+    """The Redirect login leg is bound server-side (#69 review): a POST with
+    saml_original_verb=GET is only admitted for values byte-identical to a
+    request this session already verified — hidden form fields alone are
+    client-controlled and must not bypass enforcement."""
+
+    def _unsigned_b64(self, request_id: bytes = b"_sig-test-1") -> str:
+        deflated = zlib.compress(AUTHN_REQUEST.replace(b"_sig-test-1", request_id), 9)[2:-4]
+        return base64.b64encode(deflated).decode()
+
+    def test_forged_get_leg_without_prior_verification_fails_closed(
+        self, client, signed_mode
+    ):
+        """Login-continuation forgery: no verified GET ever happened."""
+        r = client.post(
+            "/saml/sso",
+            data={
+                "SAMLRequest": self._unsigned_b64(),
+                "saml_original_verb": "GET",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert r.status_code == 400
+        assert b"signature-verified request" in r.data
+
+    def test_forged_get_leg_with_authenticated_session_fails_closed(
+        self, client, signed_mode
+    ):
+        """Already-authenticated bypass: session user set, still no verified
+        Redirect request bound — must not proceed to response generation."""
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        r = client.post(
+            "/saml/sso",
+            data={"SAMLRequest": self._unsigned_b64(), "saml_original_verb": "GET"},
+        )
+        assert r.status_code == 400
+        assert b"SAMLResponse" not in r.data
+
+    def test_get_leg_with_different_request_than_verified_rejected(
+        self, client, signed_mode
+    ):
+        """A verified GET binds THAT request; swapping in another on the login
+        leg is rejected."""
+        query = _redirect_query()
+        assert client.get(f"/saml/sso?{query}").status_code == 200
+        r = client.post(
+            "/saml/sso",
+            data={
+                "SAMLRequest": self._unsigned_b64(b"_other"),
+                "RelayState": "RS",
+                "saml_original_verb": "GET",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert r.status_code == 400
+
+    def test_legitimate_redirect_login_flow_completes(self, client, signed_mode):
+        """Verified GET, then the login leg with byte-identical values issues
+        the SAML response."""
+        query = _redirect_query()
+        assert client.get(f"/saml/sso?{query}").status_code == 200
+        # the exact SAMLRequest value the form carries (decoded from the query)
+        deflated = zlib.compress(AUTHN_REQUEST, 9)[2:-4]
+        same_b64 = base64.b64encode(deflated).decode()
+        r = client.post(
+            "/saml/sso",
+            data={
+                "SAMLRequest": same_b64,
+                "RelayState": "RS",
+                "saml_original_verb": "GET",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert r.status_code == 200
+        assert b"SAMLResponse" in r.data
+
+
 class TestDefaultsAndMetadata:
     def test_default_off_keeps_unsigned_requests_working(self, client):
         deflated = zlib.compress(AUTHN_REQUEST, 9)[2:-4]


### PR DESCRIPTION
Closes #69 — completes the [SAML hardening](https://github.com/cdelmonte-zg/nanoidp/milestone/2) milestone, and with it the last big feature on the vision board.

## Behavior

```yaml
saml:
  want_authn_requests_signed: true
  sp_certificates:
    - /path/to/sp-cert.pem
```

With the flag on, nanoidp **requires and verifies** AuthnRequest signatures and rejects unsigned/invalid requests with `400` (audit-logged):

| Binding | What is verified | Citation |
|---|---|---|
| HTTP-Redirect | Query-string signature over the URL-encoded `SAMLRequest[&RelayState]&SigAlg` fragment **exactly as transmitted** — verification runs on the raw query string, since re-encoding would break it. `rsa-sha256`/`rsa-sha512`/legacy `rsa-sha1`. | Bindings §3.4.4.1 |
| HTTP-POST | Enveloped `<ds:Signature>` via signxml | Core §5 |

- **Metadata never lies**: `WantAuthnRequestsSigned="true"` is advertised if and only if enforcement is on.
- **Default off** (principle 3): unsigned requests and ignored `Signature`/`SigAlg` params behave exactly as before — all 710 pre-existing tests pass untouched.
- **Fails closed**: flag on with no registered certificates rejects rather than waves through.
- **Verification point**: where the request *enters*. The POST-binding inline-login leg re-verifies (the signature travels inside the XML); the Redirect leg can't — the query signature doesn't survive the login form roundtrip — so it relies on the entry check, documented in the code.

## Ships whole (principle 5)

- **Settings**: model fields, YAML load, persistence through the shared serializer (both writers, courtesy of #83).
- **Web UI**: toggle + SP-certificates field on the settings page.
- **MCP**: `get_settings`/`update_settings` cover both fields (settings surface only — the protocol surface stays HTTP, per the scoped parity principle).
- **Tooling**: `examples/gen_sp_keypair.py` generates a test SP keypair (documented in the book — useful to anyone testing a signing SP).
- **e2e**: `test_agent.py --saml-signed` signs real requests with the SP key and asserts metadata + accept/reject under both bindings; the E2E workflow runs it against a **third server** booted with verification enabled and a generated keypair.
- **Docs**: new "Signed AuthnRequests" section in the book's SAML reference.
- **Tests**: 16 new (726 total) — signed/unsigned/tampered/wrong-key/unsupported-SigAlg/no-certs per binding, full login flow with re-verification, metadata both ways, defaults-off, settings round-trip.

## Verified

`mypy` clean (25 files), `ruff` clean, **726 tests green, coverage 76%** (+1) — plus, against live servers: the standard agent **41/41** (defaults untouched) and the signed suite **3/3** with verification enforced.