### PR TITLE
fix: require_pkce and rotation toggles on the settings page

### DIFF
--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -501,6 +501,10 @@ def settings() -> ResponseReturnValue:
             issuer=request.form.get("issuer"),
             audience=request.form.get("audience"),
             token_expiry_minutes=int(request.form.get("token_expiry_minutes", 60)),
+            require_pkce=request.form.get("require_pkce") == "true",
+            refresh_token_rotation=(
+                request.form.get("refresh_token_rotation") == "true"
+            ),
         )
 
         # SAML settings

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -158,6 +158,8 @@ class YamlWriter:
         issuer: Optional[str] = None,
         audience: Optional[str] = None,
         token_expiry_minutes: Optional[int] = None,
+        require_pkce: Optional[bool] = None,
+        refresh_token_rotation: Optional[bool] = None,
     ) -> None:
         """Update OAuth settings."""
         data = self._load_settings_yaml()
@@ -169,6 +171,10 @@ class YamlWriter:
             oauth["audience"] = audience
         if token_expiry_minutes is not None:
             oauth["token_expiry_minutes"] = token_expiry_minutes
+        if require_pkce is not None:
+            oauth["require_pkce"] = require_pkce
+        if refresh_token_rotation is not None:
+            oauth["refresh_token_rotation"] = refresh_token_rotation
 
         self._atomic_write(self.settings_file, data)
         get_config().reload()

--- a/src/nanoidp/templates/index.html
+++ b/src/nanoidp/templates/index.html
@@ -6,7 +6,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h2><i class="bi bi-speedometer2 me-2"></i>Dashboard</h2>
     <div class="d-flex gap-2">
-        <span class="badge {% if settings.security_profile == 'stricter-dev' %}bg-warning text-dark{% else %}bg-secondary{% endif %} fs-6" title="Security Profile">
+        <span class="badge {% if settings.security_profile == 'stricter-dev' %}bg-warning text-dark{% elif settings.security_profile == 'oauth21' %}bg-info text-dark{% else %}bg-secondary{% endif %} fs-6" title="Security Profile">
             <i class="bi bi-shield-lock me-1"></i> {{ settings.security_profile }}
         </span>
         <span class="badge bg-success fs-6"><i class="bi bi-check-circle me-1"></i> IDP Running</span>

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -36,6 +36,26 @@
                                value="{{ settings.token_expiry_minutes }}" min="1" max="525600">
                         <div class="form-text">How long tokens are valid (default: 60 minutes)</div>
                     </div>
+
+                    <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="require_pkce" name="require_pkce" value="true"
+                                   {% if settings.require_pkce %}checked{% endif %}>
+                            <label class="form-check-label" for="require_pkce">Require PKCE</label>
+                        </div>
+                        <div class="form-text">Reject <code>/authorize</code> requests without a PKCE <code>code_challenge</code> (on by default in stricter-dev and implied by oauth21).</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="refresh_token_rotation" name="refresh_token_rotation" value="true"
+                                   {% if settings.refresh_token_rotation %}checked{% endif %}>
+                            <label class="form-check-label" for="refresh_token_rotation">Refresh Token Rotation</label>
+                        </div>
+                        <div class="form-text">Each refresh invalidates the used refresh token; reuse revokes its rotation family (forced on by oauth21).</div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -199,7 +219,9 @@ function updatePreview() {
         oauth: {
             issuer: document.getElementById('issuer').value,
             audience: document.getElementById('audience').value,
-            token_expiry_minutes: parseInt(document.getElementById('token_expiry_minutes').value) || 60
+            token_expiry_minutes: parseInt(document.getElementById('token_expiry_minutes').value) || 60,
+            require_pkce: document.getElementById('require_pkce').checked,
+            refresh_token_rotation: document.getElementById('refresh_token_rotation').checked
         },
         saml: {
             entity_id: document.getElementById('saml_entity_id').value,

--- a/tests/test_ui_oauth_settings.py
+++ b/tests/test_ui_oauth_settings.py
@@ -1,0 +1,68 @@
+"""
+UI parity for the OAuth toggles (issue #94): require_pkce (#47) and
+refresh_token_rotation (#46) are settable from the settings page, like the
+SAML section always was.
+"""
+
+from nanoidp.config import get_config
+
+
+def _base_form(settings) -> dict:
+    return {
+        "issuer": settings.issuer,
+        "audience": settings.audience,
+        "token_expiry_minutes": settings.token_expiry_minutes,
+        "saml_entity_id": settings.saml_entity_id,
+        "saml_sso_url": settings.saml_sso_url,
+        "default_acs_url": settings.default_acs_url,
+        "saml_sign_responses": "true",
+        "allowed_identity_classes": "INTERNAL\nEXTERNAL",
+    }
+
+
+class TestOAuthTogglesRoundTrip:
+    def test_toggles_enable_and_persist(self, client, preserve_config_files):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+
+        response = client.post(
+            "/settings",
+            data={
+                **_base_form(config.settings),
+                "require_pkce": "true",
+                "refresh_token_rotation": "true",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        config.reload()
+        assert config.settings.require_pkce is True
+        assert config.settings.refresh_token_rotation is True
+
+    def test_unchecked_toggles_disable(self, client, preserve_config_files):
+        """Checkbox semantics: an absent field means off, and off is
+        persisted (not skipped)."""
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+        config.settings.require_pkce = True
+        config.settings.refresh_token_rotation = True
+
+        response = client.post(
+            "/settings",
+            data=_base_form(config.settings),  # both toggles absent
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        config.reload()
+        assert config.settings.require_pkce is False
+        assert config.settings.refresh_token_rotation is False
+
+    def test_settings_page_renders_the_toggles(self, client):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert b'name="require_pkce"' in r.data
+        assert b'name="refresh_token_rotation"' in r.data


### PR DESCRIPTION
Closes #94 — the UI-parity gap surfaced while verifying that every shipped feature is reachable from the web UI.

- Two switches in the settings form's OAuth card: **Require PKCE** (#47) and **Refresh Token Rotation** (#46) — previously settable only via YAML or MCP `update_settings`, while the SAML section had full coverage. `update_oauth_settings` gains the matching parameters; checkbox semantics persist `False` on unchecked, not skip.
- The dashboard's security-profile badge gets a distinct style for `oauth21` (#68) alongside the existing `stricter-dev` one. Profile selection stays CLI/YAML — startup-applied runtime hardening can't be re-applied hot, so the badge remains display-only.
- 3 tests: enable-and-persist round-trip through the real POST + YAML writer + reload, unchecked-means-off persistence, and the form rendering both fields. 745 total, coverage gate at 75 green.