### PR TITLE
chore: release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-07-08
+
+### Added
+- **`oauth21` security profile** (#68): opt-in draft-OAuth-2.1 protocol
+  strictness alongside `dev` and `stricter-dev` — PKCE required on the
+  authorization code flow with S256 only (draft-ietf-oauth-v2-1 §4.1.1,
+  §7.5.2), refresh token rotation forced on (§4.3.1), the password grant
+  removed (RFC 6749 §5.2) and absent from discovery, and registered
+  redirect URIs mandatory at `/authorize`. Protocol behavior lives in
+  derived `Settings` properties consumed by both the routes and the shared
+  discovery builder, so the profile means the same thing from `--profile`
+  or `settings.yaml` and discovery can never advertise what the endpoints
+  refuse. Deliberately orthogonal to `stricter-dev` (runtime hardening).
+- **Registered redirect URIs with exact matching** (#67): clients gain an
+  optional `redirect_uris` list; when non-empty, `/authorize` compares the
+  requested `redirect_uri` with simple string comparison (RFC 6749
+  §3.1.2.3, OAuth 2.1 §4.1.1) and answers a mismatch with
+  `400 invalid_request` directly — never by redirecting to the unvalidated
+  URI (§3.1.2.4). Exposed in the web UI, MCP client tools and YAML.
+- **Signed AuthnRequest verification** (#69): with
+  `saml.want_authn_requests_signed: true` and PEM certificates in
+  `saml.sp_certificates`, nanoidp requires and verifies AuthnRequest
+  signatures under both bindings — the HTTP-Redirect query-string
+  signature over the raw transmitted fragment (SAML 2.0 Bindings
+  §3.4.4.1; rsa-sha256/rsa-sha512/legacy rsa-sha1) and the HTTP-POST
+  enveloped `ds:Signature` (Core §5) — rejecting unsigned or invalid
+  requests with 400, failing closed without registered certificates. The
+  verified Redirect request is bound server-side in the session, so the
+  inline-login leg only accepts byte-identical values. Metadata advertises
+  `WantAuthnRequestsSigned="true"` if and only if enforcement is on.
+  `examples/gen_sp_keypair.py` generates a test SP keypair.
+- **E2E workflow in CI** (#79): every PR now boots real servers and runs
+  `examples/test_agent.py` against them (default profile, `--oauth21`,
+  `--saml-signed` with a generated SP keypair) plus an MCP **stdio** smoke
+  test (`examples/mcp_smoke_test.py`) driving the real transport — the
+  regression guard for the class of bug where the stdio entrypoint crashed
+  unnoticed because unit tests bypass it (#56).
+- **Coverage gate in CI** (#71, #72): `--cov-fail-under`, introduced at 70
+  and ratcheted to 75 after the wizard went from 0% to 99% coverage;
+  measured coverage 78%. The dead Codecov upload (never configured, failed
+  silently since inception) was removed in favor of in-CI enforcement.
+- **Documentation site**: mdBook on GitHub Pages
+  (<https://cdelmonte-zg.github.io/nanoidp/>) with getting-started, guides
+  and a full reference; canonical docs are symlinked so there is a single
+  source of truth, and the README became a landing page.
+- **Web UI parity** (#94): `require_pkce` and `refresh_token_rotation`
+  toggles on the settings page; SP-certificates and signed-AuthnRequests
+  fields (#69); `redirect_uris` on the client form (#67); the dashboard
+  badge distinguishes the `oauth21` profile.
+- MCP: `get_settings` reports `security_profile`; `update_settings` covers
+  the SAML verification fields; client tools carry `redirect_uris`.
+
+### Changed
+- **`src/` is fully annotated** and mypy runs with a global
+  `disallow_untyped_defs` (#70) — new unannotated code fails CI.
+- **Internal architecture** (behavior-invariant, #83–#86): one shared YAML
+  serialization path for `ConfigManager` and the UI writer; the token
+  endpoint dispatches to per-grant handlers with device-flow and
+  revocation state in dedicated services (`DeviceCodeStore`,
+  `RevocationStore`); a single `audit_event` helper replaced 58 duplicated
+  audit blocks (invariance proven by a before/after snapshot harness); the
+  Pydantic models moved to `models.py` with compatibility re-exports.
+- `security_profile` is now read from `settings.yaml` (top-level key) and
+  round-trips on save; the CLI `--profile` still wins. A YAML-declared
+  `stricter-dev` now applies its runtime hardening (previously the YAML
+  value was silently ignored).
+
+### Fixed
+- **`ConfigManager.save()` was lossy** (#87): the save path behind MCP
+  `save_config` rewrote `settings.yaml` from scratch, silently deleting
+  every section it didn't own — `jwt` (external keys!), `session`,
+  `logging` levels, `server.debug` and custom keys. Saving is now
+  read-modify-write and preserves them, atomically and with a `.bak`
+  backup like the UI path always did.
+
 ## [2.2.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@
 
 - **OAuth2 / OIDC** - OAuth2/OIDC support for development and integration testing: Authorization Code, Password, Client Credentials, Refresh Token, and Device Authorization grants
 - **PKCE Support** - Proof Key for Code Exchange (RFC 7636) with S256 and plain methods
+- **Security Profiles** - `stricter-dev` (runtime hardening) and `oauth21` (draft OAuth 2.1 protocol strictness: PKCE-only S256, rotation, no password grant, registered redirect URIs)
 - **Token Management** - Introspection (RFC 7662) and Revocation (RFC 7009) endpoints
 - **OIDC Logout** - End Session endpoint for RP-initiated logout
 - **Device Flow** - Device Authorization Grant (RFC 8628) for CLI/IoT applications
-- **SAML 2.0** - SSO and AttributeQuery endpoints with configurable signed assertions
+- **SAML 2.0** - SSO and AttributeQuery endpoints with configurable signed assertions and opt-in verification of signed AuthnRequests
 - **MCP Server** - Model Context Protocol integration for Claude Code
 - **Web UI** - Full configuration interface for users, clients, settings, and more
 - **YAML Configuration** - File-based configuration, no database required

--- a/book/src/guides/token-requests.md
+++ b/book/src/guides/token-requests.md
@@ -15,6 +15,9 @@ curl -X POST 'http://localhost:8000/token' \
 Add `&scope=openid` to also receive an ID Token — see
 [Tokens and claims](../reference/tokens.md) for what comes back.
 
+> Under the `oauth21` profile this grant is rejected with `400` and does
+> not appear in `grant_types_supported` — OAuth 2.1 removes it entirely.
+
 ## Client credentials grant
 
 ```bash

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -35,9 +35,14 @@ against them without depending on accidental or invented semantics.
   Client Credentials, Refresh Token (with optional rotation), and Device
   Authorization grants, plus introspection, revocation, and RP-initiated
   logout. See the [Quickstart](getting-started/quickstart.md).
+- **Test against draft OAuth 2.1.** The `oauth21` profile enforces the
+  draft's strictness — PKCE required with S256 only, rotation on, no
+  password grant, registered redirect URIs with exact matching — and the
+  discovery document reflects it.
 - **Test SAML 2.0.** SSO over HTTP-POST and HTTP-Redirect bindings and
   AttributeQuery, with configurable response signing, strict-binding mode,
-  and canonicalization algorithms.
+  canonicalization algorithms, and opt-in verification of signed
+  AuthnRequests against registered SP certificates.
 - **Drive it from an agent.** An [MCP server](guides/MCP_WORKFLOW.md)
   exposes users, clients, tokens, keys, and settings to Claude Code and
   other MCP-compatible tools.
@@ -49,9 +54,10 @@ against them without depending on accidental or invented semantics.
 NanoIDP is **not a production identity provider** and must not operate as
 one. Defaults favor getting a first token in under a minute — plaintext
 passwords in config files, permissive CORS, open redirects. Hardening is
-opt-in where testing needs it (`stricter-dev` profile, `require_pkce`,
-`refresh_token_rotation`); the [Security guide](guides/SECURITY.md) draws
-the line precisely.
+opt-in where testing needs it — the `stricter-dev` (runtime) and
+`oauth21` (protocol) profiles, `require_pkce`, `refresh_token_rotation`,
+`want_authn_requests_signed`; the [Security guide](guides/SECURITY.md)
+draws the line precisely.
 
 What it promises instead: **metadata never lies.** Discovery advertises
 exactly what the endpoints implement, and spec-relevant behavior is

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -72,6 +72,12 @@ saml:
   sso_url: "http://localhost:8000/saml/sso"
   default_acs_url: "http://localhost:8080/login/saml2/sso/nanoidp"
   sign_responses: true  # Set to false for testing unsigned SAML flows
+  want_authn_requests_signed: false  # verify AuthnRequest signatures (see SAML options)
+  # sp_certificates:                 # PEM files, required when the above is true
+  #   - /path/to/sp-cert.pem
+
+# Optional; also settable at startup with --profile (which wins over YAML)
+# security_profile: oauth21   # dev (default) | stricter-dev | oauth21
 
 authority_prefixes:
   roles: "ROLE_"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.2.0"
+version = "2.3.0"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump + consolidated changelog for everything landed since v2.2.0 (22 commits, PRs #64–#95): the `oauth21` profile, registered redirect URIs with exact matching, signed AuthnRequest verification, the E2E CI workflow (three live servers + MCP stdio smoke), the coverage gate at 75, full mypy strictness, the behavior-invariant internal-architecture milestone, the docs site, UI parity — and the #87 lossy-save fix.

All additive or opt-in, no breaking changes → minor bump per semver.

After merge, per the documented process:

```bash
git checkout main && git pull
git tag v2.3.0
git push origin v2.3.0
```

The tag triggers the publish workflows (TestPyPI → PyPI, GHCR with `v2.3.0` and `latest`).