### PR TITLE
docs: document missing endpoints and allowed_identity_classes

### DIFF
--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -84,6 +84,14 @@ authority_prefixes:
   identity_class: "IDENTITY_"
   entitlements: "ENT_"
 
+# Optional; the identity-class values selectable when editing a user
+# (web UI and user forms). Defaults to the four values below.
+allowed_identity_classes:
+  - "INTERNAL"
+  - "EXTERNAL"
+  - "PARTNER"
+  - "SERVICE"
+
 logging:
   verbose_logging: true  # Include usernames/client_ids in logs (default: true)
 ```

--- a/book/src/reference/endpoints.md
+++ b/book/src/reference/endpoints.md
@@ -6,13 +6,13 @@
 |----------|-------------|
 | `GET /.well-known/openid-configuration` | OIDC Discovery |
 | `GET /.well-known/jwks.json` | JSON Web Key Set |
-| `GET /authorize` | Authorization endpoint (login page) |
+| `GET/POST /authorize` | Authorization endpoint (login page) |
 | `POST /token` | Token endpoint |
 | `GET/POST /userinfo` | UserInfo endpoint |
 | `POST /introspect` | Token Introspection (RFC 7662) |
 | `POST /revoke` | Token Revocation (RFC 7009) |
-| `GET/POST /logout` | OIDC End Session / Logout |
-| `POST /device_authorization` | Device Authorization (RFC 8628) |
+| `GET/POST /logout` | OIDC End Session / Logout (alias: `/end_session`) |
+| `POST /device_authorization` | Device Authorization (RFC 8628; alias: `/device/code`) |
 | `GET/POST /device` | Device verification page |
 
 curl examples for every grant are in
@@ -23,6 +23,7 @@ curl examples for every grant are in
 | Endpoint | Description |
 |----------|-------------|
 | `GET /saml/metadata` | IdP Metadata |
+| `GET /saml/cert.pem` | IdP signing certificate (PEM) |
 | `GET/POST /saml/sso` | Single Sign-On (supports both HTTP-POST and HTTP-Redirect bindings) |
 | `POST /saml/attribute-query` | Attribute Query |
 
@@ -38,6 +39,9 @@ covered in [SAML options](saml.md).
 | `GET /api/users/{username}` | Get user details |
 | `POST /api/users/{username}/token` | Generate token |
 | `GET /api/audit` | Get audit log |
+| `GET /api/audit/stats` | Audit log statistics |
+| `POST /api/audit/clear` | Clear the audit log |
+| `GET /api/config` | Get current configuration |
 | `POST /api/config/reload` | Reload configuration |
 | `POST /api/keys/rotate` | Rotate cryptographic keys |
 | `GET /api/keys/info` | Get key information |


### PR DESCRIPTION
## What

An audit of the documentation against the current code (v2.3.0) found **minor reference drift** — everything else (version, MCP tool sync, `aud`/`azp` token contract, SAML signing) was accurate. This PR fixes the drift.

### `book/src/reference/endpoints.md`
- **`/authorize`** accepts `GET` **and** `POST` (`routes/oauth.py:54`), was documented as `GET` only.
- Add **`GET /saml/cert.pem`** — IdP signing certificate (`routes/saml.py:346`).
- Add **`GET /api/audit/stats`** (`api.py:99`), **`POST /api/audit/clear`** (`api.py:106`), **`GET /api/config`** (`api.py:114`) to the REST API table.
- Note the **`/end_session`** (alias of `/logout`, `oauth.py:1159`) and **`/device/code`** (alias of `/device_authorization`, `oauth.py:1229`) aliases.

### `book/src/reference/configuration.md`
- Document the top-level **`allowed_identity_classes`** setting (`models.py:158`, default `INTERNAL/EXTERNAL/PARTNER/SERVICE` in `config.py:187`), which was present in the model and web UI but absent from every reference page.

## Notes

- Docs only, no behavioral change. mdBook builds clean.
- Independent of #98 (em-dash cleanup); they touch different regions of `configuration.md` and merge without conflict.