### PR TITLE
chore: point pyproject URLs at the docs page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ nanoidp = "nanoidp.__main__:main"
 nanoidp-mcp = "nanoidp.mcp_server:main"
 
 [project.urls]
-Homepage = "https://github.com/cdelmonte-zg/nanoidp"
-Documentation = "https://github.com/cdelmonte-zg/nanoidp#readme"
+Homepage = "https://cdelmonte-zg.github.io/nanoidp/"
+Documentation = "https://cdelmonte-zg.github.io/nanoidp/"
 Repository = "https://github.com/cdelmonte-zg/nanoidp.git"
 Issues = "https://github.com/cdelmonte-zg/nanoidp/issues"
 


### PR DESCRIPTION
Aligns `[project.urls]` with the repo homepage and GitHub Pages docs site.

- `Homepage` -> https://cdelmonte-zg.github.io/nanoidp/
- `Documentation` -> https://cdelmonte-zg.github.io/nanoidp/
- `Repository` / `Issues` unchanged (GitHub)

So that the repo homepage, GitHub topics, and PyPI metadata all point at the same docs page. Takes effect in PyPI metadata on the next published release.