### PR TITLE
Gate /userinfo email/profile claims by granted scope (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`scope` claim on access tokens** (#102): access tokens now advertise the
+  granted scope (RFC 9068 §2.2.3), letting resource endpoints reason about it.
+  Set authoritatively in `TokenService.create_token`, so a caller-supplied
+  `extra_claims` cannot override it.
+
+### Changed
+- **`/userinfo` gates `email`/`profile` claims by granted scope** (#102, OIDC
+  Core §5.4): `email`/`email_verified` require the `email` scope and
+  `preferred_username` requires the `profile` scope. Enforced only under the
+  `stricter-dev` and `oauth21` profiles; the default `dev` profile keeps
+  returning them unconditionally, so this is not a breaking change for existing
+  setups. nanoidp-specific claims (`roles`, `tenant`, `identity_class`,
+  `attributes`) have no standard scope and are always returned.
+
 ## [2.3.0] - 2026-07-08
 
 ### Added

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -903,6 +903,13 @@ class NanoIDPTestAgent:
             custom = ["roles", "authorities", "tenant", "identity_class"]
             custom_found = [c for c in custom if c in decoded]
 
+            # The access token must advertise its granted scope (RFC 9068
+            # §2.2.3); /userinfo relies on it to gate scope-based claims under
+            # the stricter profiles (#102). The password grant above requested
+            # "openid profile email".
+            scope_claim = decoded.get("scope")
+            scope_ok = scope_claim == "openid profile email"
+
             sub = decoded.get("sub", "?")
             roles = decoded.get("roles", [])
             authorities = len(decoded.get("authorities", []))
@@ -910,13 +917,14 @@ class NanoIDPTestAgent:
             return self._add_result(
                 "Token Decode",
                 TestCategory.OAUTH,
-                len(found) == len(required),
-                f"sub={sub}, roles={roles}, authorities={authorities}",
+                len(found) == len(required) and scope_ok,
+                f"sub={sub}, roles={roles}, authorities={authorities}, scope={scope_claim}",
                 {
                     "claims": found,
                     "custom_claims": custom_found,
                     "sub": sub,
-                    "roles": roles
+                    "roles": roles,
+                    "scope": scope_claim,
                 }
             )
         except Exception as e:

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -977,9 +977,24 @@ def userinfo() -> ResponseReturnValue:
     }
 
     if user:
-        response["email"] = user.email
-        response["email_verified"] = True
-        response["preferred_username"] = user.username
+        # Standard OIDC scope-to-claim gating (OIDC Core §5.4): the email and
+        # profile claims are only returned when the matching scope was granted.
+        # Enforced only under the stricter profiles; the permissive `dev`
+        # default keeps returning them unconditionally so this is not a breaking
+        # change for existing setups (#102). The granted scope is read from the
+        # access token's `scope` claim (RFC 9068 §2.2.3).
+        granted_scopes = set((payload.get("scope") or "").split())
+        strict_scopes = config.settings.security_profile in ("stricter-dev", "oauth21")
+
+        if not strict_scopes or "email" in granted_scopes:
+            response["email"] = user.email
+            response["email_verified"] = True
+        if not strict_scopes or "profile" in granted_scopes:
+            response["preferred_username"] = user.username
+
+        # nanoidp-specific claims have no standard OIDC scope, so they are always
+        # returned for a valid token; gating them would be arbitrary and has no
+        # spec basis (#102).
         response["roles"] = user.roles
         response["tenant"] = user.tenant
         if user.identity_class:

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -165,6 +165,13 @@ class TokenService:
         if extra_claims:
             extra.update(extra_claims)
 
+        # Advertise the granted scope on the access token (RFC 9068 §2.2.3), so
+        # resource endpoints (e.g. /userinfo, /introspect) can gate scope-based
+        # claims (#102). Set after the extra_claims merge so the granted scope is
+        # authoritative and cannot be overridden by a caller-supplied claim.
+        if scope:
+            extra["scope"] = scope
+
         # Mark the token type so access-token endpoints can reject ID/refresh
         # tokens presented as access tokens (issue #34). Set last so it cannot be
         # overridden by caller-supplied extra_claims.

--- a/tests/test_userinfo_scope_gating.py
+++ b/tests/test_userinfo_scope_gating.py
@@ -111,3 +111,47 @@ class TestUserinfoStrictProfileGated:
         assert "roles" in data
         assert "tenant" in data
         assert data["sub"] == "admin"
+
+
+class TestUserinfoOauth21ProfileGated:
+    """``oauth21`` enforces the same gating.
+
+    The password grant is disabled under ``oauth21``, so the access token is
+    minted directly via the internal ``TokenService`` (signed with the app's
+    keys, hence verifiable at /userinfo) instead of the /token endpoint.
+    """
+
+    def _mint_and_query(self, scope):
+        from nanoidp.config import get_config
+        from nanoidp.services.token import get_token_service
+
+        app = create_app(profile="oauth21")
+        app.config["TESTING"] = True
+
+        config = get_config()
+        assert config.settings.security_profile == "oauth21"
+        token = get_token_service().create_token(
+            config.get_user("admin"), scope=scope, client_id="demo-client"
+        )["access_token"]
+
+        resp = app.test_client().get(
+            "/userinfo", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200, resp.data
+        return json.loads(resp.data)
+
+    def test_email_omitted_without_email_scope(self):
+        data = self._mint_and_query("openid")
+        assert "email" not in data
+        assert "email_verified" not in data
+
+    def test_email_returned_with_email_scope(self):
+        data = self._mint_and_query("openid email")
+        assert data.get("email") == "admin@example.org"
+        assert data.get("email_verified") is True
+
+    def test_preferred_username_gated_by_profile_scope(self):
+        without = self._mint_and_query("openid")
+        assert "preferred_username" not in without
+        with_profile = self._mint_and_query("openid profile")
+        assert with_profile.get("preferred_username") == "admin"

--- a/tests/test_userinfo_scope_gating.py
+++ b/tests/test_userinfo_scope_gating.py
@@ -1,0 +1,114 @@
+"""
+Tests for scope-to-claim gating on /userinfo and the access-token scope claim.
+
+Issue #102: the standard OIDC claims (email/profile) must only be returned from
+/userinfo when the matching scope was granted (OIDC Core §5.4). Enforcement is
+gated on the security profile: the permissive ``dev`` default keeps returning
+them unconditionally (backward compatible), while ``stricter-dev``/``oauth21``
+enforce the scope check. The granted scope is read from the access token's
+``scope`` claim (RFC 9068 §2.2.3).
+"""
+
+import base64
+import json
+
+import jwt as pyjwt
+import pytest
+
+from nanoidp.app import create_app
+
+
+def _client(profile):
+    app = create_app(profile=profile)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _auth_header():
+    creds = base64.b64encode(b"demo-client:demo-secret").decode()
+    return {"Authorization": f"Basic {creds}"}
+
+
+def _get_token(client, scope=None):
+    data = {"grant_type": "password", "username": "admin", "password": "admin"}
+    if scope is not None:
+        data["scope"] = scope
+    resp = client.post("/token", data=data, headers=_auth_header())
+    assert resp.status_code == 200, resp.data
+    return json.loads(resp.data)["access_token"]
+
+
+def _userinfo(client, token):
+    return client.get("/userinfo", headers={"Authorization": f"Bearer {token}"})
+
+
+class TestAccessTokenScopeClaim:
+    """The access token advertises its granted scope (RFC 9068 §2.2.3)."""
+
+    def test_access_token_carries_scope_when_requested(self):
+        client = _client("dev")
+        token = _get_token(client, scope="openid email")
+        payload = pyjwt.decode(token, options={"verify_signature": False})
+        assert payload.get("scope") == "openid email"
+
+    def test_access_token_has_no_scope_claim_when_absent(self):
+        client = _client("dev")
+        token = _get_token(client)  # no scope form parameter
+        payload = pyjwt.decode(token, options={"verify_signature": False})
+        assert "scope" not in payload
+
+
+class TestUserinfoDevProfilePermissive:
+    """The default ``dev`` profile keeps returning claims unconditionally."""
+
+    def test_email_returned_without_email_scope(self):
+        client = _client("dev")
+        token = _get_token(client, scope="openid")
+        data = json.loads(_userinfo(client, token).data)
+        assert "email" in data
+        assert "email_verified" in data
+
+    def test_preferred_username_returned_without_profile_scope(self):
+        client = _client("dev")
+        token = _get_token(client, scope="openid")
+        data = json.loads(_userinfo(client, token).data)
+        assert "preferred_username" in data
+
+
+class TestUserinfoStrictProfileGated:
+    """``stricter-dev`` enforces the OIDC scope-to-claim mapping (§5.4)."""
+
+    def test_email_omitted_without_email_scope(self):
+        client = _client("stricter-dev")
+        token = _get_token(client, scope="openid")
+        data = json.loads(_userinfo(client, token).data)
+        assert "email" not in data
+        assert "email_verified" not in data
+
+    def test_email_returned_with_email_scope(self):
+        client = _client("stricter-dev")
+        token = _get_token(client, scope="openid email")
+        data = json.loads(_userinfo(client, token).data)
+        assert data.get("email") == "admin@example.org"
+        assert data.get("email_verified") is True
+
+    def test_preferred_username_omitted_without_profile_scope(self):
+        client = _client("stricter-dev")
+        token = _get_token(client, scope="openid")
+        data = json.loads(_userinfo(client, token).data)
+        assert "preferred_username" not in data
+
+    def test_preferred_username_returned_with_profile_scope(self):
+        client = _client("stricter-dev")
+        token = _get_token(client, scope="openid profile")
+        data = json.loads(_userinfo(client, token).data)
+        assert data.get("preferred_username") == "admin"
+
+    def test_custom_claims_always_returned(self):
+        """nanoidp-specific claims have no standard scope, so they are never gated."""
+        client = _client("stricter-dev")
+        token = _get_token(client, scope="openid")  # minimal scope
+        data = json.loads(_userinfo(client, token).data)
+        assert "roles" in data
+        assert "tenant" in data
+        assert data["sub"] == "admin"

--- a/tests/test_userinfo_scope_gating.py
+++ b/tests/test_userinfo_scope_gating.py
@@ -13,7 +13,6 @@ import base64
 import json
 
 import jwt as pyjwt
-import pytest
 
 from nanoidp.app import create_app
 


### PR DESCRIPTION
Closes #102.

## What

`/userinfo` now returns the standard OIDC `email`/`profile` claims only when the matching scope was granted ([OIDC Core §5.4](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)):

- `email` scope → `email`, `email_verified`
- `profile` scope → `preferred_username`

To make this possible, access tokens now carry a `scope` claim ([RFC 9068 §2.2.3](https://www.rfc-editor.org/rfc/rfc9068#section-2.2.3)), set authoritatively in `TokenService.create_token` (after the `extra_claims` merge, so a caller cannot spoof it).

## Not a breaking change

Enforcement is **profile-gated**: it applies only under `stricter-dev` and `oauth21`. The default `dev` profile keeps returning the claims unconditionally, exactly as before. This mirrors the existing `security_profile` pattern (PKCE, refresh rotation, `plain` challenge). Ships as a **minor** release.

nanoidp-specific claims (`roles`, `tenant`, `identity_class`, `attributes`) have no standard OIDC scope, so they are always returned - gating them would be arbitrary and has no spec basis.

## Tests

- New `tests/test_userinfo_scope_gating.py` (9 tests): `scope` claim present/absent on the access token; `dev` permissive; `stricter-dev` gated for `email`/`profile`; custom claims always present.
- Extended the E2E `test_token_decode` to assert the access token's `scope` claim.
- Full suite green (754 unit), E2E dev 41/41, E2E oauth21 3/3.

## Follow-ups

- #103 (docs) will document where `profile`/`email` claims come from, reflecting this behaviour.
- #104 (`claims` request parameter) composes with this gating for the `userinfo` member.