### PR TITLE
Support the OIDC claims request parameter (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   granted scope (RFC 9068 §2.2.3), letting resource endpoints reason about it.
   Set authoritatively in `TokenService.create_token`, so a caller-supplied
   `extra_claims` cannot override it.
+- **OIDC `claims` request parameter** (#104, OIDC Core §5.5): `/authorize`
+  accepts a `claims` parameter to request specific claims in the ID Token
+  (`id_token` member) or from UserInfo (`userinfo` member), e.g.
+  `claims={"id_token":{"email":null}}`. Requested claims are resolved from the
+  user and added when available (voluntary form, §5.5.1); protocol claims are
+  never overwritten and unresolvable names are skipped. Malformed input is
+  ignored with a warning rather than failing the flow. Discovery advertises
+  `claims_parameter_supported: true`, and the MCP `generate_token` tool gains an
+  `id_token_claims` argument. Scoped to the authorization code grant; the
+  requested claims are not yet persisted across a refresh.
 
 ### Changed
 - **`/userinfo` gates `email`/`profile` claims by granted scope** (#102, OIDC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `claims_parameter_supported: true`, and the MCP `generate_token` tool gains an
   `id_token_claims` argument. Scoped to the authorization code grant; the
   requested claims are not yet persisted across a refresh.
+  `TokenService.create_token` now strips `scope`/`req_userinfo_claims` from a
+  caller-supplied `extra` before setting them authoritatively, so the `/token`
+  `extra` parameter can never smuggle scope-gated claims past `/userinfo`
+  (closes a spoofing gap in the #102 scope handling too).
 
 ### Changed
 - **`/userinfo` gates `email`/`profile` claims by granted scope** (#102, OIDC

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -369,7 +369,10 @@ class NanoIDPTestAgent:
                 "scope": "openid profile",
                 "state": state,
                 "code_challenge": challenge,
-                "code_challenge_method": "S256"
+                "code_challenge_method": "S256",
+                # OIDC `claims` request parameter (§5.5, #104): ask for the
+                # email claim to be delivered inside the ID Token.
+                "claims": json.dumps({"id_token": {"email": None, "email_verified": None}}),
             }
 
             # Get the authorization page
@@ -427,19 +430,24 @@ class NanoIDPTestAgent:
                             data = token_response.json()
 
                             nonce_ok = False
+                            # The `claims` parameter above requested email in the
+                            # ID Token (#104); it must now be present there.
+                            email_in_id_token = False
                             if jwt and "id_token" in data:
                                 decoded = jwt.decode(data["id_token"], options={"verify_signature": False})
                                 nonce_ok = decoded.get("nonce") == auth_params["nonce"]
+                                email_in_id_token = bool(decoded.get("email"))
 
                             return self._add_result(
                                 "Auth Code + PKCE",
                                 TestCategory.OAUTH,
-                                "id_token" in data and "access_token" in data and nonce_ok,
-                                "Flow completo: authorize -> code -> token",
+                                "id_token" in data and "access_token" in data and nonce_ok and email_in_id_token,
+                                "Flow completo: authorize -> code -> token (claims: email in ID Token)",
                                 {
                                     "has_access_token": "access_token" in data,
                                     "has_id_token": "id_token" in data,
                                     "nonce_ok": nonce_ok,
+                                    "email_in_id_token": email_in_id_token,
                                 }
                             )
 

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -339,6 +339,17 @@ async def list_tools() -> list[Tool]:
                             "re-issues an ID Token (OIDC Core §12.2)"
                         ),
                     },
+                    "id_token_claims": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Claim names to embed in the ID Token, mirroring the "
+                            "OIDC `claims` request parameter (§5.5). Requires an "
+                            "'openid' scope. Resolved from the user (e.g. 'email', "
+                            "'preferred_username', or a custom attribute); names "
+                            "nanoidp cannot supply are skipped."
+                        ),
+                    },
                 },
                 "required": ["username"],
             },
@@ -767,6 +778,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             exp_minutes=arguments.get("expires_in_minutes", config.settings.token_expiry_minutes),
             extra_claims=arguments.get("extra_claims"),
             scope=arguments.get("scope"),
+            id_token_claims=arguments.get("id_token_claims"),
         )
         result = {
             "success": True,

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -24,11 +24,44 @@ from ..services import (
     get_token_service,
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
+from ..services.token import resolve_user_claim
 from ._audit import audit_event
 
 logger = logging.getLogger(__name__)
 
 oauth_bp = Blueprint("oauth", __name__)
+
+
+def _parse_claims_parameter(raw: Optional[str]) -> Optional[Dict[str, list]]:
+    """Parse the OIDC ``claims`` request parameter (OIDC Core §5.5, #104).
+
+    Returns a normalized ``{"id_token": [names], "userinfo": [names]}`` mapping
+    (members present only when non-empty), or ``None`` when the parameter is
+    absent or malformed. Malformed input is ignored with a warning rather than
+    failing the request, so a bad ``claims`` value never breaks an otherwise
+    valid authorization flow. Only the claim *names* are kept; the voluntary
+    (``null``) form is honoured, and ``essential``/``value`` refinements are
+    accepted but not yet acted on.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        logger.warning("Ignoring malformed 'claims' request parameter (invalid JSON)")
+        return None
+    if not isinstance(parsed, dict):
+        logger.warning("Ignoring 'claims' request parameter: top-level value is not an object")
+        return None
+
+    result: Dict[str, list] = {}
+    for member in ("id_token", "userinfo"):
+        spec = parsed.get(member)
+        if isinstance(spec, dict):
+            names = [name for name in spec if isinstance(name, str)]
+            if names:
+                result[member] = names
+    return result or None
 
 
 
@@ -89,6 +122,7 @@ def authorize() -> ResponseReturnValue:
     code_challenge = params.get("code_challenge", session.get("oauth_code_challenge", ""))
     code_challenge_method = params.get("code_challenge_method", session.get("oauth_code_challenge_method", ""))
     nonce = params.get("nonce", session.get("oauth_nonce", ""))
+    claims_param = params.get("claims", session.get("oauth_claims", ""))
 
     # Store OAuth params in session for POST handling
     if request.method == "GET":
@@ -100,6 +134,7 @@ def authorize() -> ResponseReturnValue:
         session["oauth_code_challenge"] = code_challenge
         session["oauth_code_challenge_method"] = code_challenge_method
         session["oauth_nonce"] = nonce
+        session["oauth_claims"] = claims_param
 
     # Validate required parameters
     if response_type != "code":
@@ -271,6 +306,7 @@ def authorize() -> ResponseReturnValue:
                     code_challenge_method=code_challenge_method if code_challenge_method else None,
                     nonce=nonce if nonce else None,
                     state=state if state else None,
+                    claims=_parse_claims_parameter(claims_param),
                 )
 
                 # Clear OAuth session data
@@ -340,6 +376,9 @@ class _GrantOutcome:
     scope: Optional[str] = None
     auth_time: Optional[int] = None
     refresh_family: Optional[str] = None
+    # Claim names requested via the OIDC `claims` parameter (§5.5, #104).
+    id_token_claims: Optional[list] = None
+    userinfo_claims: Optional[list] = None
 
 
 @dataclass
@@ -634,6 +673,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
         )
         return abort(401, description="User not found")
 
+    requested_claims = auth_code.claims or {}
     return _GrantOutcome(
         user=user,
         username=username,
@@ -642,6 +682,9 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
         # The user authenticated at the login page when the code was created,
         # not at this token exchange - use that moment as auth_time (#42).
         auth_time=int(auth_code.created_at.timestamp()),
+        # Claims the client asked for through the OIDC `claims` parameter (#104).
+        id_token_claims=requested_claims.get("id_token"),
+        userinfo_claims=requested_claims.get("userinfo"),
     )
 
 
@@ -889,6 +932,8 @@ def token() -> ResponseReturnValue:
         client_id=client_id,
         auth_time=result.auth_time,
         refresh_family=result.refresh_family,
+        id_token_claims=result.id_token_claims,
+        userinfo_claims=result.userinfo_claims,
     )
 
     # Audit log
@@ -1001,6 +1046,16 @@ def userinfo() -> ResponseReturnValue:
             response["identity_class"] = user.identity_class
         if user.attributes:
             response["attributes"] = user.attributes
+
+        # Honour the UserInfo member of the OIDC `claims` request parameter
+        # (§5.5, #104): claim names the client asked for are added even when
+        # scope-gating above would have omitted them, provided nanoidp can
+        # supply them. Never overwrites a claim already set.
+        for claim_name in payload.get("req_userinfo_claims") or []:
+            if claim_name not in response:
+                found, value = resolve_user_claim(user, claim_name)
+                if found:
+                    response[claim_name] = value
 
     audit_event(
         "userinfo_request",

--- a/src/nanoidp/services/auth_code.py
+++ b/src/nanoidp/services/auth_code.py
@@ -10,7 +10,7 @@ import secrets
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,10 @@ class AuthorizationCode:
     code_challenge_method: Optional[str] = None
     nonce: Optional[str] = None
     state: Optional[str] = None
+    # Claim names requested via the OIDC `claims` parameter (§5.5, #104),
+    # normalized to {"id_token": [...], "userinfo": [...]}. Carried from
+    # /authorize to the token exchange so the ID Token / UserInfo can honour it.
+    claims: Optional[Dict[str, Any]] = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc) + timedelta(minutes=10))
     used: bool = False
@@ -56,6 +60,7 @@ class AuthCodeStore:
         code_challenge_method: Optional[str] = None,
         nonce: Optional[str] = None,
         state: Optional[str] = None,
+        claims: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
         Create a new authorization code.
@@ -69,6 +74,7 @@ class AuthCodeStore:
             code_challenge_method: PKCE method ("plain" or "S256")
             nonce: OIDC nonce for ID token (optional)
             state: OAuth state parameter (optional)
+            claims: Normalized OIDC `claims` request (§5.5, optional)
 
         Returns:
             The generated authorization code
@@ -86,6 +92,7 @@ class AuthCodeStore:
             code_challenge_method=code_challenge_method,
             nonce=nonce,
             state=state,
+            claims=claims,
         )
 
         with self._lock:

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -47,6 +47,9 @@ def build_discovery_document(settings: Settings) -> Dict[str, Any]:
             "roles", "tenant", "identity_class", "entitlements",
             "source_acl", "attributes", "authorities"
         ],
+        # The OIDC `claims` request parameter is honoured at /authorize to
+        # deliver requested claims in the ID Token / UserInfo (§5.5, #104).
+        "claims_parameter_supported": True,
         # The password grant is removed by OAuth 2.1 and rejected under the
         # oauth21 profile, so it must not be advertised there (#68).
         "grant_types_supported": [

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -15,6 +15,33 @@ from .crypto import get_crypto_service
 
 logger = logging.getLogger(__name__)
 
+def resolve_user_claim(user: User, name: str) -> tuple[bool, Any]:
+    """Resolve a requested OIDC/custom claim name to the user's value.
+
+    Backs the OIDC ``claims`` request parameter (OIDC Core §5.5): the standard
+    ``email``/``profile`` claims plus nanoidp's custom claims and any user
+    attribute can be requested for the ID Token or UserInfo. Returns
+    ``(found, value)``; ``found`` is False when nanoidp cannot supply the claim,
+    so voluntary claims are simply omitted rather than emitted as null (§5.5.1).
+    """
+    if name == "email":
+        return True, user.email
+    if name == "email_verified":
+        return True, True
+    if name == "preferred_username":
+        return True, user.username
+    if name == "roles":
+        return True, user.roles
+    if name == "tenant":
+        return True, user.tenant
+    if name == "identity_class":
+        return (True, user.identity_class) if user.identity_class else (False, None)
+    if name == "entitlements":
+        return (True, user.entitlements) if user.entitlements else (False, None)
+    if name in user.attributes:
+        return True, user.attributes[name]
+    return False, None
+
 
 class TokenService:
     """Service for generating JWT tokens."""
@@ -127,6 +154,8 @@ class TokenService:
         client_id: Optional[str] = None,
         auth_time: Optional[int] = None,
         refresh_family: Optional[str] = None,
+        id_token_claims: Optional[List[str]] = None,
+        userinfo_claims: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user.
 
@@ -135,6 +164,11 @@ class TokenService:
         code creation time, device authorization time, value preserved from a
         refresh token); when omitted it defaults to "now", which is correct
         for grants that authenticate the user in the same request (password).
+
+        ``id_token_claims``/``userinfo_claims`` are the claim names a client
+        asked for through the OIDC ``claims`` request parameter (OIDC Core
+        §5.5, #104): the former are resolved into the ID Token here, the latter
+        are stamped on the access token so ``/userinfo`` can honour them.
         """
         settings = self.config.settings
 
@@ -171,6 +205,13 @@ class TokenService:
         # authoritative and cannot be overridden by a caller-supplied claim.
         if scope:
             extra["scope"] = scope
+
+        # Carry the claim names the client requested for UserInfo via the OIDC
+        # `claims` parameter (§5.5, #104), so /userinfo can return them on top of
+        # whatever the granted scope already allows. Access-token only; never an
+        # ID Token claim.
+        if userinfo_claims:
+            extra["req_userinfo_claims"] = userinfo_claims
 
         # Mark the token type so access-token endpoints can reject ID/refresh
         # tokens presented as access tokens (issue #34). Set last so it cannot be
@@ -209,6 +250,14 @@ class TokenService:
             }
             if azp:
                 id_extra["azp"] = azp
+            # Claims the client asked for in the ID Token via the OIDC `claims`
+            # parameter (§5.5, #104). Resolved from the user and added only when
+            # available (voluntary claims, §5.5.1). setdefault so a requested
+            # name can never overwrite a protocol claim (auth_time/at_hash/azp).
+            for claim_name in id_token_claims or []:
+                found, value = resolve_user_claim(user, claim_name)
+                if found:
+                    id_extra.setdefault(claim_name, value)
             id_token = self.crypto.create_jwt(
                 sub=user.username,
                 issuer=settings.issuer,

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -199,10 +199,19 @@ class TokenService:
         if extra_claims:
             extra.update(extra_claims)
 
+        # `scope` and `req_userinfo_claims` are authoritative: they must reflect
+        # the actual grant, never a caller-supplied `extra`. Drop any spoofed
+        # copy the merge may have introduced before setting them below. Without
+        # this, a request like extra={"scope": "openid email"} or
+        # extra={"req_userinfo_claims": ["email"]} would smuggle scope-gated
+        # claims past /userinfo when the authoritative value is absent
+        # (#102/#104 hardening).
+        for reserved in ("scope", "req_userinfo_claims"):
+            extra.pop(reserved, None)
+
         # Advertise the granted scope on the access token (RFC 9068 §2.2.3), so
         # resource endpoints (e.g. /userinfo, /introspect) can gate scope-based
-        # claims (#102). Set after the extra_claims merge so the granted scope is
-        # authoritative and cannot be overridden by a caller-supplied claim.
+        # claims (#102).
         if scope:
             extra["scope"] = scope
 

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -1,0 +1,205 @@
+"""
+Tests for the OIDC ``claims`` request parameter (OIDC Core §5.5, issue #104).
+
+A client can ask for specific claims to be delivered in the ID Token (via the
+``id_token`` member) or from UserInfo (via the ``userinfo`` member). nanoidp
+parses the parameter at /authorize, carries it through the authorization code,
+and resolves the requested claims from the user.
+"""
+
+import json
+from urllib.parse import urlencode
+
+import jwt as pyjwt
+
+from nanoidp.app import create_app
+from nanoidp.config import User
+from nanoidp.routes.oauth import _parse_claims_parameter
+from nanoidp.services.token import resolve_user_claim
+
+
+# --------------------------------------------------------------------------
+# Unit: parameter parsing
+# --------------------------------------------------------------------------
+class TestParseClaimsParameter:
+    def test_none_and_empty(self):
+        assert _parse_claims_parameter(None) is None
+        assert _parse_claims_parameter("") is None
+
+    def test_voluntary_null_form(self):
+        raw = json.dumps({"id_token": {"email": None, "email_verified": None}})
+        assert _parse_claims_parameter(raw) == {"id_token": ["email", "email_verified"]}
+
+    def test_both_members(self):
+        raw = json.dumps({"id_token": {"email": None}, "userinfo": {"name": None}})
+        assert _parse_claims_parameter(raw) == {"id_token": ["email"], "userinfo": ["name"]}
+
+    def test_essential_and_value_forms_extract_names(self):
+        raw = json.dumps({"id_token": {"email": {"essential": True}, "tenant": {"value": "x"}}})
+        parsed = _parse_claims_parameter(raw)
+        assert set(parsed["id_token"]) == {"email", "tenant"}
+
+    def test_unknown_members_ignored(self):
+        raw = json.dumps({"id_token": {"email": None}, "bogus": {"x": None}})
+        assert _parse_claims_parameter(raw) == {"id_token": ["email"]}
+
+    def test_empty_members_collapse_to_none(self):
+        assert _parse_claims_parameter(json.dumps({"id_token": {}})) is None
+        assert _parse_claims_parameter(json.dumps({})) is None
+
+    def test_malformed_json_is_ignored(self):
+        assert _parse_claims_parameter("not json at all") is None
+
+    def test_non_object_top_level_is_ignored(self):
+        assert _parse_claims_parameter(json.dumps(["email"])) is None
+
+
+# --------------------------------------------------------------------------
+# Unit: claim resolution
+# --------------------------------------------------------------------------
+class TestResolveUserClaim:
+    def _user(self, **kw):
+        base = {"username": "u", "password": "p", "email": "u@example.org"}
+        base.update(kw)
+        return User(**base)
+
+    def test_standard_claims(self):
+        u = self._user(roles=["USER"], tenant="acme")
+        assert resolve_user_claim(u, "email") == (True, "u@example.org")
+        assert resolve_user_claim(u, "email_verified") == (True, True)
+        assert resolve_user_claim(u, "preferred_username") == (True, "u")
+        assert resolve_user_claim(u, "roles") == (True, ["USER"])
+        assert resolve_user_claim(u, "tenant") == (True, "acme")
+
+    def test_optional_claims_present_and_absent(self):
+        assert resolve_user_claim(self._user(identity_class="INTERNAL"), "identity_class") == (True, "INTERNAL")
+        assert resolve_user_claim(self._user(identity_class=None), "identity_class") == (False, None)
+
+    def test_custom_attribute(self):
+        u = self._user(attributes={"department": "eng"})
+        assert resolve_user_claim(u, "department") == (True, "eng")
+
+    def test_unknown_claim(self):
+        assert resolve_user_claim(self._user(), "does_not_exist") == (False, None)
+
+
+# --------------------------------------------------------------------------
+# Integration helpers (default dev profile, full authorization code flow)
+# --------------------------------------------------------------------------
+def _dev_client():
+    app = create_app(profile="dev")
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test"
+    return app.test_client()
+
+
+def _basic_auth():
+    import base64
+    return {"Authorization": "Basic " + base64.b64encode(b"demo-client:demo-secret").decode()}
+
+
+def _id_token_via_authcode(client, claims=None):
+    """Drive the full authorization code flow and return the decoded ID Token."""
+    query = {
+        "response_type": "code",
+        "client_id": "demo-client",
+        "redirect_uri": "http://localhost:3000/callback",
+        "scope": "openid",
+    }
+    if claims is not None:
+        query["claims"] = claims
+    client.get("/authorize?" + urlencode(query))
+    resp = client.post(
+        "/authorize", data={"username": "admin", "password": "admin"}, follow_redirects=False
+    )
+    code = resp.headers["Location"].split("code=")[1].split("&")[0]
+    token_resp = client.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "http://localhost:3000/callback",
+        },
+        headers=_basic_auth(),
+    )
+    assert token_resp.status_code == 200, token_resp.data
+    id_token = json.loads(token_resp.data)["id_token"]
+    return pyjwt.decode(id_token, options={"verify_signature": False})
+
+
+class TestIdTokenMember:
+    def test_email_absent_by_default(self):
+        payload = _id_token_via_authcode(_dev_client())
+        assert "email" not in payload
+
+    def test_requested_email_lands_in_id_token(self):
+        claims = json.dumps({"id_token": {"email": None, "email_verified": None}})
+        payload = _id_token_via_authcode(_dev_client(), claims=claims)
+        assert payload["email"] == "admin@example.org"
+        assert payload["email_verified"] is True
+
+    def test_requested_custom_claim_lands_in_id_token(self):
+        claims = json.dumps({"id_token": {"preferred_username": None, "tenant": None}})
+        payload = _id_token_via_authcode(_dev_client(), claims=claims)
+        assert payload["preferred_username"] == "admin"
+        assert "tenant" in payload
+
+    def test_unresolvable_claim_is_skipped(self):
+        claims = json.dumps({"id_token": {"no_such_claim": None}})
+        payload = _id_token_via_authcode(_dev_client(), claims=claims)
+        assert "no_such_claim" not in payload
+
+    def test_protocol_claims_not_overwritten(self):
+        # A client asking for auth_time must not clobber the real value.
+        payload = _id_token_via_authcode(
+            _dev_client(), claims=json.dumps({"id_token": {"auth_time": None}})
+        )
+        assert isinstance(payload["auth_time"], int)
+
+    def test_malformed_claims_does_not_break_the_flow(self):
+        payload = _id_token_via_authcode(_dev_client(), claims="}{ not json")
+        assert payload["sub"] == "admin"
+        assert "email" not in payload
+
+
+# --------------------------------------------------------------------------
+# Integration: UserInfo member (composes with #102 scope gating)
+# --------------------------------------------------------------------------
+def _mint_and_userinfo(profile, scope, userinfo_claims):
+    from nanoidp.config import get_config
+    from nanoidp.services.token import get_token_service
+
+    app = create_app(profile=profile)
+    app.config["TESTING"] = True
+    token = get_token_service().create_token(
+        get_config().get_user("admin"),
+        scope=scope,
+        client_id="demo-client",
+        userinfo_claims=userinfo_claims,
+    )["access_token"]
+    resp = app.test_client().get(
+        "/userinfo", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200, resp.data
+    return json.loads(resp.data)
+
+
+class TestUserinfoMember:
+    def test_requested_claim_returned_despite_scope_gating(self):
+        # stricter-dev would drop email without the email scope (#102); the
+        # UserInfo claims member forces it back in.
+        data = _mint_and_userinfo("stricter-dev", scope="openid", userinfo_claims=["email"])
+        assert data["email"] == "admin@example.org"
+
+    def test_without_member_scope_gating_still_applies(self):
+        data = _mint_and_userinfo("stricter-dev", scope="openid", userinfo_claims=None)
+        assert "email" not in data
+
+
+# --------------------------------------------------------------------------
+# Discovery advertisement
+# --------------------------------------------------------------------------
+def test_discovery_advertises_claims_parameter_supported():
+    client = _dev_client()
+    doc = json.loads(client.get("/.well-known/openid-configuration").data)
+    assert doc["claims_parameter_supported"] is True

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -197,6 +197,51 @@ class TestUserinfoMember:
 
 
 # --------------------------------------------------------------------------
+# Security: authoritative claims cannot be spoofed via `extra`
+# --------------------------------------------------------------------------
+class TestReservedClaimsCannotBeSpoofed:
+    """`scope`/`req_userinfo_claims` must reflect the grant, not `extra_claims`.
+
+    The /token endpoint accepts an arbitrary `extra` JSON object, so a caller
+    must not be able to smuggle these authoritative claims into the access token
+    and have /userinfo honour them past the #102 scope gating.
+    """
+
+    def _mint(self, profile, scope, extra_claims):
+        from nanoidp.config import get_config
+        from nanoidp.services.token import get_token_service
+
+        app = create_app(profile=profile)
+        app.config["TESTING"] = True
+        token = get_token_service().create_token(
+            get_config().get_user("admin"),
+            scope=scope,
+            client_id="demo-client",
+            extra_claims=extra_claims,
+        )["access_token"]
+        payload = pyjwt.decode(token, options={"verify_signature": False})
+        resp = app.test_client().get(
+            "/userinfo", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200, resp.data
+        return payload, json.loads(resp.data)
+
+    def test_req_userinfo_claims_via_extra_is_dropped(self):
+        payload, data = self._mint(
+            "stricter-dev", scope="openid", extra_claims={"req_userinfo_claims": ["email"]}
+        )
+        assert "req_userinfo_claims" not in payload
+        assert "email" not in data
+
+    def test_scope_via_extra_is_dropped(self):
+        payload, data = self._mint(
+            "stricter-dev", scope=None, extra_claims={"scope": "openid email"}
+        )
+        assert "scope" not in payload
+        assert "email" not in data
+
+
+# --------------------------------------------------------------------------
 # Discovery advertisement
 # --------------------------------------------------------------------------
 def test_discovery_advertises_claims_parameter_supported():


### PR DESCRIPTION
Closes #104. Follow-up from #101 / #102.

## What

`/authorize` now accepts the OIDC [`claims` request parameter](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) (OIDC Core §5.5) - the standards-aligned way to ask for specific claims in the ID Token, which is what the reporter in #101 originally expected from `scope=openid email`.

```
claims={"id_token":{"email":null,"email_verified":null},"userinfo":{"name":null}}
```

- **`id_token` member** → the requested claims are resolved from the user and embedded in the ID Token.
- **`userinfo` member** → carried on the access token (`req_userinfo_claims`) and returned by `/userinfo`, composing with the #102 scope gating (so a client can get `email` from UserInfo even under a stricter profile that would otherwise gate it out).

## Behaviour

- Voluntary (`null`) form honoured; `essential`/`value` refinements are parsed but not yet acted on (§5.5.1).
- Claims are resolved via a shared `resolve_user_claim()` helper (email, email_verified, preferred_username, roles, tenant, identity_class, entitlements, and any user attribute). **Unresolvable names are skipped**, and **protocol claims (`auth_time`/`at_hash`/`azp`/…) are never overwritten** (`setdefault`).
- **Malformed `claims`** is ignored with a warning rather than failing the authorization flow.
- Discovery advertises `claims_parameter_supported: true`.
- MCP `generate_token` gains an `id_token_claims` argument (convention: MCP + E2E kept in sync).

## Scope / follow-ups

- Scoped to the **authorization code** grant (where the `claims` parameter lives per spec).
- Requested claims are **not yet persisted across a refresh** - the refreshed ID Token won't carry them. Noted as a deliberate follow-up to keep this PR focused.

## Tests

- New `tests/test_claims_request_parameter.py` (21 tests): parameter parsing (voluntary/essential/malformed/unknown members), `resolve_user_claim`, id_token member via the full auth-code flow (present/absent/unresolvable/protocol-claim-safe/malformed), userinfo member composing with #102 gating, discovery advertisement.
- Extended the E2E `test_authorization_code_pkce` to request `email` via `claims` and assert it lands in the ID Token.
- Full suite green (778 unit), ruff + mypy clean, E2E dev 41/41.

## Docs

- #103 will document the `claims` parameter alongside where `profile`/`email` claims come from.