### PR TITLE
Docs: where profile/email claims come from + claims parameter (#103)

### DIFF
--- a/book/src/guides/token-requests.md
+++ b/book/src/guides/token-requests.md
@@ -65,6 +65,20 @@ curl -X POST 'http://localhost:8000/token' \
   -d 'grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=YOUR_DEVICE_CODE'
 ```
 
+## UserInfo
+
+The `email` / `profile` claims (`email`, `email_verified`,
+`preferred_username`, ...) are returned here, using the access token - not
+embedded in the ID Token. See
+[Tokens and claims](../reference/tokens.md#where-do-the-email--profile-claims-come-from)
+for the details and for the `claims` request parameter that can put a
+claim inside the ID Token.
+
+```bash
+curl 'http://localhost:8000/userinfo' \
+  -H 'Authorization: Bearer YOUR_ACCESS_TOKEN'
+```
+
 ## Token introspection
 
 ```bash

--- a/book/src/reference/endpoints.md
+++ b/book/src/reference/endpoints.md
@@ -18,6 +18,10 @@
 curl examples for every grant are in
 [Requesting tokens](../guides/token-requests.md).
 
+The standard OIDC `profile` / `email` claims (`email`, `email_verified`,
+`preferred_username`, ...) are served from `GET /userinfo`, not embedded
+in the tokens - see [Tokens and claims](tokens.md#where-do-the-email--profile-claims-come-from).
+
 ## SAML
 
 | Endpoint | Description |

--- a/book/src/reference/tokens.md
+++ b/book/src/reference/tokens.md
@@ -85,13 +85,14 @@ A common surprise: you request `scope=openid email`, then look for an
 `email` claim inside the ID Token or access token and don't find it.
 
 That is expected. The **standard OpenID Connect profile/email claims**
-(`email`, `email_verified`, `preferred_username`, `name`, ...) are **not
-embedded in the tokens**. For the authorization code flow they are served
-from the **UserInfo endpoint**, using the access token (OpenID Connect
-Core 1.0 §5.4). The discovery document advertises what is available -
-`scopes_supported` (`openid`, `profile`, `email`, `offline_access`) and
-`claims_supported` - but those scope-based claims are returned from
-`GET /userinfo`, not from the tokens themselves.
+(`email`, `email_verified`, `preferred_username`; plus NanoIDP-specific and
+custom claims where configured) are **not embedded in the tokens**. For the
+authorization code flow they are served from the **UserInfo endpoint**,
+using the access token (OpenID Connect Core 1.0 §5.4). The discovery
+document advertises what is available - `scopes_supported` (`openid`,
+`profile`, `email`, `offline_access`) and `claims_supported` - but those
+scope-based claims are returned from `GET /userinfo`, not from the tokens
+themselves.
 
 ```bash
 curl 'http://localhost:8000/userinfo' \

--- a/book/src/reference/tokens.md
+++ b/book/src/reference/tokens.md
@@ -60,7 +60,10 @@ Issued when the `openid` scope is requested. Its `aud` is the client's
 
 ID Tokens also carry `auth_time` (when the end-user actually
 authenticated, preserved across refreshes, OIDC Core §12.2) and `at_hash`
-(binding to the access token issued alongside, §3.1.3.6).
+(binding to the access token issued alongside, §3.1.3.6). By default they
+do **not** carry `email` or other profile claims - see [Where do the
+`email` / `profile` claims come from?](#where-do-the-email--profile-claims-come-from)
+below.
 
 If `additional_audiences` produces more than one distinct audience value,
 `aud` becomes an array and `azp` is added:
@@ -75,6 +78,84 @@ If `additional_audiences` produces more than one distinct audience value,
   "exp": 1704103600
 }
 ```
+
+## Where do the `email` / `profile` claims come from?
+
+A common surprise: you request `scope=openid email`, then look for an
+`email` claim inside the ID Token or access token and don't find it.
+
+That is expected. The **standard OpenID Connect profile/email claims**
+(`email`, `email_verified`, `preferred_username`, `name`, ...) are **not
+embedded in the tokens**. For the authorization code flow they are served
+from the **UserInfo endpoint**, using the access token (OpenID Connect
+Core 1.0 §5.4). The discovery document advertises what is available -
+`scopes_supported` (`openid`, `profile`, `email`, `offline_access`) and
+`claims_supported` - but those scope-based claims are returned from
+`GET /userinfo`, not from the tokens themselves.
+
+```bash
+curl 'http://localhost:8000/userinfo' \
+  -H 'Authorization: Bearer YOUR_ACCESS_TOKEN'
+```
+
+```json
+{
+  "sub": "admin",
+  "email": "admin@example.org",
+  "email_verified": true,
+  "preferred_username": "admin",
+  "roles": ["USER", "ADMIN"],
+  "tenant": "default",
+  "identity_class": "INTERNAL"
+}
+```
+
+### Scope gating
+
+Under the default `dev` profile, `/userinfo` returns these claims
+unconditionally. Under the `stricter-dev` and `oauth21` profiles the
+standard OIDC claims are gated by the granted scope (OIDC Core §5.4):
+`email` / `email_verified` require the `email` scope and
+`preferred_username` requires the `profile` scope. The granted scope is
+carried on the access token as the `scope` claim (RFC 9068 §2.2.3).
+NanoIDP-specific claims (`roles`, `tenant`, `identity_class`,
+`attributes`) have no standard scope and are always returned.
+
+## Requesting claims in the ID Token (`claims` parameter)
+
+If your client specifically needs a claim **inside the ID Token**, use the
+OpenID Connect `claims` request parameter at `/authorize` (OIDC Core §5.5)
+- the standards-aligned way to ask for it. Discovery advertises
+`claims_parameter_supported: true`.
+
+```
+GET /authorize?response_type=code&client_id=demo-client
+  &redirect_uri=http://localhost:3000/callback&scope=openid
+  &claims={"id_token":{"email":null,"email_verified":null}}
+```
+
+(URL-encode the `claims` value in a real request.) After the code
+exchange, the ID Token then carries the requested claims:
+
+```json
+{
+  "iss": "http://localhost:8000",
+  "sub": "admin",
+  "aud": "demo-client",
+  "iat": 1704100000,
+  "exp": 1704103600,
+  "email": "admin@example.org",
+  "email_verified": true
+}
+```
+
+The `userinfo` member (e.g. `{"userinfo":{"email":null}}`) works the same
+way for `/userinfo` and composes with the scope gating above, so a client
+can pull a specific claim even under a stricter profile that would
+otherwise gate it out. Claims are resolved from the user and added only
+when available (voluntary form, §5.5.1); protocol claims are never
+overwritten and unknown names are skipped. This is currently honoured for
+the authorization code grant.
 
 All tokens are signed with RS256; verify them against the JWKS at
 `/.well-known/jwks.json` (see [Endpoints](endpoints.md)).


### PR DESCRIPTION
Closes #103. Follow-up from #101, documenting the behaviour shipped in #102 and #104.

## What

Explains the point of confusion from #101: the standard OIDC `profile` / `email` claims (`email`, `email_verified`, `preferred_username`, ...) are **served from `GET /userinfo`** using the access token, **not embedded in the ID Token or access token** (OIDC Core §5.4).

- **`book/src/reference/tokens.md`**: new "Where do the `email` / `profile` claims come from?" section with a `/userinfo` request/response example; documents the #102 scope gating (dev permissive; `stricter-dev`/`oauth21` gate `email` behind the `email` scope and `preferred_username` behind `profile`; custom claims always returned); new "Requesting claims in the ID Token (`claims` parameter)" section for the #104 feature. The ID Token section now points here.
- **`book/src/reference/endpoints.md`**: note on `/userinfo` cross-linking to the claims explanation.
- **`book/src/guides/token-requests.md`**: a UserInfo section with a curl example.

## Notes

- Docs only - no code changes.
- `mdbook build` is clean; all internal anchor links resolve (verified against the generated HTML).