### PR TITLE
chore: release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.0] - 2026-07-08
 
 ### Added
 - **`scope` claim on access tokens** (#102): access tokens now advertise the
@@ -433,6 +433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Key rotation with JWKS support for multiple keys
 - External key import support
 
+[2.4.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.0.0...v2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.3.0"
+version = "2.4.0"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release **2.4.0** (minor) - bundles the #101 follow-ups.

- **#102** - `scope` claim on access tokens (RFC 9068 §2.2.3) and scope-gated `email`/`profile` claims on `/userinfo` under `stricter-dev`/`oauth21` (non-breaking: `dev` stays permissive).
- **#104** - OIDC `claims` request parameter (OIDC Core §5.5) to deliver claims in the ID Token / UserInfo, plus the `extra`-spoofing hardening.
- **#103** - docs explaining where `profile`/`email` claims come from and how to request them.

Bumps `pyproject.toml` to 2.4.0 and dates the CHANGELOG section with the compare link. Pushing the `v2.4.0` tag after merge publishes to PyPI + GHCR.