### PR TITLE
docs: refresh container tag example to v2.4.0

### DIFF
--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -24,7 +24,7 @@ docker run --rm -p 8000:8000 \
   ghcr.io/cdelmonte-zg/nanoidp:latest
 ```
 
-Container tags are derived from release tags (for example `v2.2.0`);
+Container tags are derived from release tags (for example `v2.4.0`);
 `latest` points at the newest non-prerelease.
 
 ## From source


### PR DESCRIPTION
Small follow-up to the 2.4.0 release: the install page still showed `v2.2.0` as the container-tag example. Bump it to the current `v2.4.0` so the docs example matches the latest release.

Docs only; the change was prepared during the release but landed after #108 was merged.