### PR TITLE
Refuse reserved claim names in the OIDC claims parameter (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`claims` parameter could overwrite registered ID Token claims** (#110): a
+  requested claim name that collided with a user attribute (e.g. an attribute
+  named `aud` or `exp`) could hijack the corresponding registered claim, because
+  `create_jwt` applies `extra` after setting the registered claims and the
+  `setdefault` guard only covered the protocol claims. `resolve_user_claim` now
+  refuses reserved registered/protocol names outright (`iss`, `sub`, `aud`,
+  `exp`, `iat`, `nbf`, `jti`, `token_use`, `auth_time`, `at_hash`, `azp`,
+  `nonce`, `scope`, `req_userinfo_claims`), protecting both the ID Token and
+  `/userinfo` paths at a single choke point.
+
 ## [2.4.0] - 2026-07-08
 
 ### Added

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -15,6 +15,22 @@ from .crypto import get_crypto_service
 
 logger = logging.getLogger(__name__)
 
+# Claim names a client must never be able to request through the OIDC ``claims``
+# parameter (#110). Registered JWT claims are set by ``create_jwt`` and the
+# protocol claims are set authoritatively by ``create_token``; letting a
+# requested name resolve to a user attribute of the same name would overwrite
+# them (``create_jwt`` applies ``payload.update(extra)`` after the registered
+# claims), e.g. a user attribute ``aud``/``exp`` hijacking the ID Token. None of
+# these are legitimately requestable, so the resolver refuses them outright.
+_RESERVED_CLAIMS = frozenset({
+    # registered JWT claims (RFC 7519)
+    "iss", "sub", "aud", "exp", "iat", "nbf", "jti",
+    # nanoidp protocol claims
+    "token_use", "auth_time", "at_hash", "azp", "nonce", "scope",
+    "req_userinfo_claims",
+})
+
+
 def resolve_user_claim(user: User, name: str) -> tuple[bool, Any]:
     """Resolve a requested OIDC/custom claim name to the user's value.
 
@@ -23,7 +39,12 @@ def resolve_user_claim(user: User, name: str) -> tuple[bool, Any]:
     attribute can be requested for the ID Token or UserInfo. Returns
     ``(found, value)``; ``found`` is False when nanoidp cannot supply the claim,
     so voluntary claims are simply omitted rather than emitted as null (§5.5.1).
+
+    Reserved registered/protocol claim names (``_RESERVED_CLAIMS``) are always
+    refused so a requested name can never overwrite them (#110).
     """
+    if name in _RESERVED_CLAIMS:
+        return False, None
     if name == "email":
         return True, user.email
     if name == "email_verified":
@@ -261,8 +282,11 @@ class TokenService:
                 id_extra["azp"] = azp
             # Claims the client asked for in the ID Token via the OIDC `claims`
             # parameter (§5.5, #104). Resolved from the user and added only when
-            # available (voluntary claims, §5.5.1). setdefault so a requested
-            # name can never overwrite a protocol claim (auth_time/at_hash/azp).
+            # available (voluntary claims, §5.5.1). resolve_user_claim refuses
+            # reserved registered/protocol names (#110), so a requested claim can
+            # never overwrite iss/sub/aud/exp/... (which create_jwt sets after
+            # applying `extra`) nor the id_extra protocol claims; setdefault is a
+            # belt-and-suspenders guard for the id_extra keys.
             for claim_name in id_token_claims or []:
                 found, value = resolve_user_claim(user, claim_name)
                 if found:

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -242,6 +242,50 @@ class TestReservedClaimsCannotBeSpoofed:
 
 
 # --------------------------------------------------------------------------
+# Security: reserved claim names cannot be requested/overwritten (#110)
+# --------------------------------------------------------------------------
+_RESERVED = [
+    "iss", "sub", "aud", "exp", "iat", "nbf", "jti",
+    "token_use", "auth_time", "at_hash", "azp", "nonce", "scope",
+    "req_userinfo_claims",
+]
+
+
+class TestReservedClaimNames:
+    def test_resolver_refuses_reserved_names_even_with_colliding_attribute(self):
+        user = User(
+            username="u", password="p", email="u@example.org",
+            attributes={"exp": 111, "aud": "evil", "sub": "spoof", "department": "eng"},
+        )
+        for name in _RESERVED:
+            assert resolve_user_claim(user, name) == (False, None), name
+        # a non-reserved attribute still resolves normally
+        assert resolve_user_claim(user, "department") == (True, "eng")
+
+    def test_id_token_registered_claims_not_overwritable(self):
+        """A requested claim colliding with a user attribute must not hijack the
+        registered ID Token claims (create_jwt applies `extra` last)."""
+        from nanoidp.services.token import get_token_service
+
+        app = create_app(profile="dev")
+        app.config["TESTING"] = True
+        user = User(
+            username="attacker", password="p", email="a@example.org",
+            attributes={"exp": 111, "aud": "https://evil.example", "iss": "https://evil"},
+        )
+        resp = get_token_service().create_token(
+            user, scope="openid", client_id="demo-client",
+            id_token_claims=["exp", "aud", "iss", "email"],
+        )
+        payload = pyjwt.decode(resp["id_token"], options={"verify_signature": False})
+        assert payload["exp"] > 111  # real future expiry, not the attribute
+        assert "evil" not in str(payload["aud"])  # real audience, not attacker value
+        assert "evil" not in payload["iss"]
+        # a legitimate requested claim still lands
+        assert payload["email"] == "a@example.org"
+
+
+# --------------------------------------------------------------------------
 # Discovery advertisement
 # --------------------------------------------------------------------------
 def test_discovery_advertises_claims_parameter_supported():


### PR DESCRIPTION
Closes #110. Found in a post-release review of 2.4.0.

## Problem

`create_token` resolved the `claims` `id_token` member with `resolve_user_claim` and added each value with `id_extra.setdefault(...)`. The comment claimed protocol claims were safe, but:

- `setdefault` only guarded the `id_extra` keys (`token_use`/`auth_time`/`at_hash`/`azp`).
- The **registered JWT claims** (`iss`/`sub`/`aud`/`exp`/`iat`/`nbf`/`jti`) are set by `create_jwt`, which does `payload.update(extra)` **after** them (`crypto.py:328`).

`resolve_user_claim` has a catch-all `user.attributes` branch, so a user configured with an attribute named e.g. `aud` or `exp` could have that registered claim overwritten when a client requested it via `claims={"id_token":{"aud":null}}`. The value is admin-configured (not attacker-chosen), so impact is limited, but it is a real hole opened by #104 and the documented guarantee did not hold.

## Fix

`resolve_user_claim` now refuses reserved names outright (`_RESERVED_CLAIMS`: the registered claims plus nanoidp's protocol claims `token_use`, `auth_time`, `at_hash`, `azp`, `nonce`, `scope`, `req_userinfo_claims`). None are legitimately requestable via the `claims` parameter, so skipping them is safe and protects both the ID Token and `/userinfo` paths at one choke point. The inaccurate comment is corrected.

## Tests

- Resolver unit test: every reserved name returns `(False, None)` even when the user has a colliding attribute; a non-reserved attribute still resolves.
- End-to-end: a user with `attributes={"exp":111,"aud":"https://evil.example","iss":"https://evil"}` requesting those in the ID Token still gets the real registered claims (`exp` in the future, real `aud`/`iss`), while a legitimate `email` request still lands.
- Full suite green (782), ruff + mypy clean.

## Note

The issue also flags the anti-spoofing `extra.pop(...)` denylist as a hand-maintained list (same root cause class). Left as a separate consideration; this PR closes the concrete overwrite hole.