### PR TITLE
Persist OIDC claims requests across refresh and close the #104 coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `userinfo` member for the refreshed access token. Refresh tokens minted
   before this change carry neither claim and refresh as before. Both names are
   reserved: they cannot be requested via the `claims` parameter nor injected
-  through the `/token` `extra` parameter.
+  through the `/token` `extra` parameter. Requested-claims values are
+  sanitized at the token service (`sanitize_claim_names`): a hand-crafted
+  refresh or access token carrying a non-list value (or non-string entries)
+  refreshes and serves `/userinfo` cleanly instead of failing token issuance
+  after the refresh token was consumed. A claims request deliberately
+  survives scope narrowing on refresh (OIDC Core §5.5 is orthogonal to
+  scope); see the token reference docs.
 - **MCP `generate_token` gains `userinfo_claims`** (#113): parity with the
   HTTP `claims` flow's `userinfo` member; the names are stamped on the access
-  token as `req_userinfo_claims` and honoured by `/userinfo`.
+  token as `req_userinfo_claims` and honoured by `/userinfo`. Both
+  `id_token_claims` and `userinfo_claims` are now validated like
+  `additional_audiences`: a non-list value is rejected with a clean error
+  instead of being minted into the token.
 
 ### Changed
 - **`/userinfo` reuses `resolve_user_claim` for its default claim assembly**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`claims` parameter requests persist across token refresh** (#112, OIDC
+  Core §12.2): the claim names requested via the OIDC `claims` parameter are
+  now persisted in the refresh token (`req_id_token_claims` /
+  `req_userinfo_claims`, alongside `scope` and `auth_time`), so a refreshed ID
+  Token keeps the requested claims and `/userinfo` keeps honouring the
+  `userinfo` member for the refreshed access token. Refresh tokens minted
+  before this change carry neither claim and refresh as before. Both names are
+  reserved: they cannot be requested via the `claims` parameter nor injected
+  through the `/token` `extra` parameter.
+- **MCP `generate_token` gains `userinfo_claims`** (#113): parity with the
+  HTTP `claims` flow's `userinfo` member; the names are stamped on the access
+  token as `req_userinfo_claims` and honoured by `/userinfo`.
+
+### Changed
+- **`/userinfo` reuses `resolve_user_claim` for its default claim assembly**
+  (#113): the scope-gated standard claims and the nanoidp-specific claims now
+  come from the same resolver that backs the `claims` request parameter, so
+  the two mappings cannot diverge. No behavior change.
+
 ### Fixed
 - **`claims` parameter could overwrite registered ID Token claims** (#110): a
   requested claim name that collided with a user attribute (e.g. an attribute

--- a/book/src/guides/token-requests.md
+++ b/book/src/guides/token-requests.md
@@ -37,7 +37,7 @@ curl -X POST 'http://localhost:8000/token' \
 If the original grant included the `openid` scope, the refresh re-issues
 an ID Token as well. A `scope` parameter may narrow, but never broaden,
 the originally granted scope (RFC 6749 §6). Claims requested via the
-OIDC `claims` parameter persist across the refresh — including a
+OIDC `claims` parameter persist across the refresh, including a
 narrowed one; see
 [Tokens and claims](../reference/tokens.md#requesting-claims-in-the-id-token-claims-parameter).
 With `oauth.refresh_token_rotation: true`, each refresh invalidates the

--- a/book/src/guides/token-requests.md
+++ b/book/src/guides/token-requests.md
@@ -36,8 +36,11 @@ curl -X POST 'http://localhost:8000/token' \
 
 If the original grant included the `openid` scope, the refresh re-issues
 an ID Token as well. A `scope` parameter may narrow, but never broaden,
-the originally granted scope (RFC 6749 §6). With
-`oauth.refresh_token_rotation: true`, each refresh invalidates the
+the originally granted scope (RFC 6749 §6). Claims requested via the
+OIDC `claims` parameter persist across the refresh — including a
+narrowed one; see
+[Tokens and claims](../reference/tokens.md#requesting-claims-in-the-id-token-claims-parameter).
+With `oauth.refresh_token_rotation: true`, each refresh invalidates the
 consumed refresh token; reuse revokes the whole rotation family
 (RFC 9700 §4.14.2).
 

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -16,7 +16,7 @@ readonly mode, and the exposure warnings, see the
 | `create_user` | Create a new user |
 | `update_user` | Update an existing user (password, email, roles, …) |
 | `delete_user` | Delete a user |
-| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token) |
+| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter) |
 | `decode_token` | Decode JWT token (without verification) |
 | `verify_token` | Verify JWT token signature and expiration |
 | `list_clients` | List OAuth clients |

--- a/book/src/reference/tokens.md
+++ b/book/src/reference/tokens.md
@@ -158,5 +158,12 @@ when available (voluntary form, §5.5.1); protocol claims are never
 overwritten and unknown names are skipped. This is currently honoured for
 the authorization code grant.
 
+The requested claim names are persisted in the refresh token (like the
+granted scope and `auth_time`), so a refreshed ID Token keeps carrying
+the requested claims and `/userinfo` keeps honouring the `userinfo`
+member for the refreshed access token (OIDC Core §12.2). The `nonce` is
+the deliberate exception: it binds the original authentication request
+and is never re-issued on refresh.
+
 All tokens are signed with RS256; verify them against the JWKS at
 `/.well-known/jwks.json` (see [Endpoints](endpoints.md)).

--- a/book/src/reference/tokens.md
+++ b/book/src/reference/tokens.md
@@ -155,15 +155,22 @@ way for `/userinfo` and composes with the scope gating above, so a client
 can pull a specific claim even under a stricter profile that would
 otherwise gate it out. Claims are resolved from the user and added only
 when available (voluntary form, §5.5.1); protocol claims are never
-overwritten and unknown names are skipped. This is currently honoured for
-the authorization code grant.
+overwritten and unknown names are skipped. The `claims` parameter is
+accepted on the authorization code grant, carried through the
+refresh_token grant (below), and mirrored by the MCP `generate_token`
+tool (`id_token_claims` / `userinfo_claims`).
 
 The requested claim names are persisted in the refresh token (like the
 granted scope and `auth_time`), so a refreshed ID Token keeps carrying
 the requested claims and `/userinfo` keeps honouring the `userinfo`
 member for the refreshed access token (OIDC Core §12.2). The `nonce` is
 the deliberate exception: it binds the original authentication request
-and is never re-issued on refresh.
+and is never re-issued on refresh. Note that a claims request binds to
+the original authorization and is orthogonal to scope (§5.5), so it is
+**not** shed by narrowing the scope on refresh: under a stricter profile,
+a claim requested via the `userinfo` member keeps being returned by
+`/userinfo` even after the client drops the scope that would otherwise
+gate it. To shed a claims request, start a new authorization.
 
 All tokens are signed with RS256; verify them against the JWKS at
 `/.well-known/jwks.json` (see [Endpoints](endpoints.md)).

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -429,6 +429,9 @@ class NanoIDPTestAgent:
                         if token_response.status_code == 200:
                             data = token_response.json()
 
+                            # Kept for test_claims_persist_across_refresh (#112).
+                            self._authcode_refresh_token = data.get("refresh_token")
+
                             nonce_ok = False
                             # The `claims` parameter above requested email in the
                             # ID Token (#104); it must now be present there.
@@ -1069,6 +1072,68 @@ class NanoIDPTestAgent:
             )
         except Exception as e:
             return self._add_result("Refresh Token", TestCategory.OAUTH, False, str(e))
+
+    def test_claims_persist_across_refresh(self) -> TestResult:
+        """Requested `claims` survive a token refresh (OIDC Core §12.2, #112).
+
+        The auth-code flow above requested email in the ID Token via the
+        `claims` parameter; refreshing that grant's token must re-issue an
+        ID Token that still carries it.
+        """
+        refresh_token = getattr(self, "_authcode_refresh_token", None)
+        if not refresh_token:
+            return self._add_result(
+                "Claims across refresh",
+                TestCategory.OAUTH,
+                False,
+                "No refresh token from the auth-code flow"
+            )
+
+        try:
+            response = self.session.post(
+                f"{self.base_url}/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token
+                },
+                timeout=5
+            )
+            if response.status_code != 200:
+                error = response.json().get("error", "unknown")
+                return self._add_result(
+                    "Claims across refresh",
+                    TestCategory.OAUTH,
+                    False,
+                    f"Refresh failed: {error}"
+                )
+
+            data = response.json()
+            has_id_token = "id_token" in data
+            email_in_refreshed = False
+            unrequested_absent = True
+            if jwt and has_id_token:
+                decoded = jwt.decode(data["id_token"], options={"verify_signature": False})
+                email_in_refreshed = bool(decoded.get("email"))
+                # Negative check: an attribute that was never requested must
+                # not leak into the refreshed ID Token.
+                unrequested_absent = "department" not in decoded
+
+            return self._add_result(
+                "Claims across refresh",
+                TestCategory.OAUTH,
+                has_id_token and email_in_refreshed and unrequested_absent,
+                f"Refreshed ID Token keeps requested claims: email={email_in_refreshed}, "
+                f"unrequested absent={unrequested_absent}",
+                {
+                    "has_id_token": has_id_token,
+                    "email_in_refreshed_id_token": email_in_refreshed,
+                    "unrequested_claim_absent": unrequested_absent,
+                }
+            )
+        except Exception as e:
+            return self._add_result(
+                "Claims across refresh", TestCategory.OAUTH, False, str(e)
+            )
 
     def test_token_revocation(self) -> TestResult:
         """Token revocation (RFC 7009)."""
@@ -2844,6 +2909,7 @@ class NanoIDPTestAgent:
                 self.test_introspection,
                 self.test_userinfo,
                 self.test_refresh_token,
+                self.test_claims_persist_across_refresh,
                 self.test_token_revocation,
                 self.test_logout,
             ]),

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -153,6 +153,9 @@ class NanoIDPTestAgent:
         self._pkce_verifier: Optional[str] = None
         self._device_code: Optional[str] = None
         self._initial_kid: Optional[str] = None
+        # Refresh token from the auth-code flow, whose grant carried a
+        # `claims` request (consumed by test_claims_persist_across_refresh).
+        self._authcode_refresh_token: Optional[str] = None
 
     def _log(self, msg: str):
         """Log verbose output."""
@@ -1080,7 +1083,7 @@ class NanoIDPTestAgent:
         `claims` parameter; refreshing that grant's token must re-issue an
         ID Token that still carries it.
         """
-        refresh_token = getattr(self, "_authcode_refresh_token", None)
+        refresh_token = self._authcode_refresh_token
         if not refresh_token:
             return self._add_result(
                 "Claims across refresh",

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -790,8 +790,16 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             exp_minutes=arguments.get("expires_in_minutes", config.settings.token_expiry_minutes),
             extra_claims=arguments.get("extra_claims"),
             scope=arguments.get("scope"),
-            id_token_claims=arguments.get("id_token_claims"),
-            userinfo_claims=arguments.get("userinfo_claims"),
+            # The SDK does not enforce inputSchema types server-side; reject a
+            # non-list with a clean error instead of minting a token whose
+            # malformed claim only misbehaves later at /userinfo (same
+            # precedent as additional_audiences, #37).
+            id_token_claims=_normalize_str_list(
+                arguments.get("id_token_claims"), "id_token_claims"
+            ) or None,
+            userinfo_claims=_normalize_str_list(
+                arguments.get("userinfo_claims"), "userinfo_claims"
+            ) or None,
         )
         result = {
             "success": True,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -350,6 +350,18 @@ async def list_tools() -> list[Tool]:
                             "nanoidp cannot supply are skipped."
                         ),
                     },
+                    "userinfo_claims": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Claim names /userinfo should return for this access "
+                            "token, mirroring the `userinfo` member of the OIDC "
+                            "`claims` request parameter (§5.5). Stamped on the "
+                            "access token as `req_userinfo_claims` and honoured "
+                            "by /userinfo even under a stricter profile that "
+                            "would scope-gate them out."
+                        ),
+                    },
                 },
                 "required": ["username"],
             },
@@ -779,6 +791,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             extra_claims=arguments.get("extra_claims"),
             scope=arguments.get("scope"),
             id_token_claims=arguments.get("id_token_claims"),
+            userinfo_claims=arguments.get("userinfo_claims"),
         )
         result = {
             "success": True,

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -510,6 +510,14 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
     # (OIDC Core §12.2), persisted in the refresh token claims (#42).
     auth_time = payload.get("auth_time")
 
+    # Claim names requested via the OIDC `claims` parameter are persisted in
+    # the refresh token like scope/auth_time (#112), so the refreshed ID Token
+    # keeps the requested claims and the refreshed access token keeps its
+    # `req_userinfo_claims` for /userinfo. Tokens minted before #112 carry
+    # neither claim and simply refresh without them.
+    id_token_claims = payload.get("req_id_token_claims")
+    userinfo_claims = payload.get("req_userinfo_claims")
+
     # The family id survives rotation so descendants share it (#56).
     refresh_family = payload.get("rt_family")
 
@@ -547,6 +555,8 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         scope=scope,
         auth_time=auth_time,
         refresh_family=refresh_family,
+        id_token_claims=id_token_claims,
+        userinfo_claims=userinfo_claims,
     )
 
 
@@ -1031,19 +1041,26 @@ def userinfo() -> ResponseReturnValue:
         granted_scopes = set((payload.get("scope") or "").split())
         strict_scopes = config.settings.security_profile in ("stricter-dev", "oauth21")
 
+        # All claim values come from resolve_user_claim, the same resolver that
+        # backs the `claims` request parameter, so the two mappings cannot
+        # diverge (#113). A claim the resolver cannot supply is omitted.
+        def _put(claim_name: str) -> None:
+            found, value = resolve_user_claim(user, claim_name)
+            if found:
+                response[claim_name] = value
+
         if not strict_scopes or "email" in granted_scopes:
-            response["email"] = user.email
-            response["email_verified"] = True
+            _put("email")
+            _put("email_verified")
         if not strict_scopes or "profile" in granted_scopes:
-            response["preferred_username"] = user.username
+            _put("preferred_username")
 
         # nanoidp-specific claims have no standard OIDC scope, so they are always
         # returned for a valid token; gating them would be arbitrary and has no
         # spec basis (#102).
-        response["roles"] = user.roles
-        response["tenant"] = user.tenant
-        if user.identity_class:
-            response["identity_class"] = user.identity_class
+        _put("roles")
+        _put("tenant")
+        _put("identity_class")
         if user.attributes:
             response["attributes"] = user.attributes
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -24,7 +24,7 @@ from ..services import (
     get_token_service,
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
-from ..services.token import resolve_user_claim
+from ..services.token import resolve_user_claim, sanitize_claim_names
 from ._audit import audit_event
 
 logger = logging.getLogger(__name__)
@@ -514,7 +514,13 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
     # the refresh token like scope/auth_time (#112), so the refreshed ID Token
     # keeps the requested claims and the refreshed access token keeps its
     # `req_userinfo_claims` for /userinfo. Tokens minted before #112 carry
-    # neither claim and simply refresh without them.
+    # neither claim and simply refresh without them. Deliberately NOT
+    # intersected with a narrowed scope: a claims request binds to the
+    # original authorization and §5.5 is orthogonal to scope, so it keeps
+    # being honoured when the client narrows the scope on refresh — narrowing
+    # sheds scope-derived claims, not claims requested by name. The values are
+    # taken as-is here; create_token sanitizes them (a hand-crafted refresh
+    # token may carry anything), so issuance below cannot fail on them.
     id_token_claims = payload.get("req_id_token_claims")
     userinfo_claims = payload.get("req_userinfo_claims")
 
@@ -1041,9 +1047,12 @@ def userinfo() -> ResponseReturnValue:
         granted_scopes = set((payload.get("scope") or "").split())
         strict_scopes = config.settings.security_profile in ("stricter-dev", "oauth21")
 
-        # All claim values come from resolve_user_claim, the same resolver that
-        # backs the `claims` request parameter, so the two mappings cannot
-        # diverge (#113). A claim the resolver cannot supply is omitted.
+        # The scope-gated standard claims and the nanoidp-specific claims below
+        # all resolve through resolve_user_claim — the same resolver that backs
+        # the `claims` request parameter — so those two mappings cannot diverge
+        # (#113). A claim the resolver cannot supply is omitted. The raw
+        # `attributes` passthrough further down is the one deliberate
+        # exception: the whole dict is not a resolvable claim name.
         def _put(claim_name: str) -> None:
             found, value = resolve_user_claim(user, claim_name)
             if found:
@@ -1067,12 +1076,12 @@ def userinfo() -> ResponseReturnValue:
         # Honour the UserInfo member of the OIDC `claims` request parameter
         # (§5.5, #104): claim names the client asked for are added even when
         # scope-gating above would have omitted them, provided nanoidp can
-        # supply them. Never overwrites a claim already set.
-        for claim_name in payload.get("req_userinfo_claims") or []:
+        # supply them. Never overwrites a claim already set. Sanitized because
+        # the value comes straight from the token payload, which may be
+        # hand-crafted (a malformed value must not 500 the endpoint).
+        for claim_name in sanitize_claim_names(payload.get("req_userinfo_claims")) or []:
             if claim_name not in response:
-                found, value = resolve_user_claim(user, claim_name)
-                if found:
-                    response[claim_name] = value
+                _put(claim_name)
 
     audit_event(
         "userinfo_request",

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -517,7 +517,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
     # neither claim and simply refresh without them. Deliberately NOT
     # intersected with a narrowed scope: a claims request binds to the
     # original authorization and §5.5 is orthogonal to scope, so it keeps
-    # being honoured when the client narrows the scope on refresh — narrowing
+    # being honoured when the client narrows the scope on refresh - narrowing
     # sheds scope-derived claims, not claims requested by name. The values are
     # taken as-is here; create_token sanitizes them (a hand-crafted refresh
     # token may carry anything), so issuance below cannot fail on them.
@@ -1048,8 +1048,8 @@ def userinfo() -> ResponseReturnValue:
         strict_scopes = config.settings.security_profile in ("stricter-dev", "oauth21")
 
         # The scope-gated standard claims and the nanoidp-specific claims below
-        # all resolve through resolve_user_claim — the same resolver that backs
-        # the `claims` request parameter — so those two mappings cannot diverge
+        # all resolve through resolve_user_claim - the same resolver that backs
+        # the `claims` request parameter - so those two mappings cannot diverge
         # (#113). A claim the resolver cannot supply is omitted. The raw
         # `attributes` passthrough further down is the one deliberate
         # exception: the whole dict is not a resolvable claim name.

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -15,6 +15,13 @@ from .crypto import get_crypto_service
 
 logger = logging.getLogger(__name__)
 
+# Claims ``create_token`` sets authoritatively from the grant and therefore
+# strips from caller-supplied ``extra`` before setting them (#102/#104/#112).
+# ``_RESERVED_CLAIMS`` is derived from this tuple, so a claim added here is
+# automatically refused by ``resolve_user_claim`` as well — the strip list and
+# the reserved list cannot drift apart.
+_AUTHORITATIVE_CLAIMS = ("scope", "req_userinfo_claims", "req_id_token_claims")
+
 # Claim names a client must never be able to request through the OIDC ``claims``
 # parameter (#110). Registered JWT claims are set by ``create_jwt`` and the
 # protocol claims are set authoritatively by ``create_token``; letting a
@@ -26,9 +33,34 @@ _RESERVED_CLAIMS = frozenset({
     # registered JWT claims (RFC 7519)
     "iss", "sub", "aud", "exp", "iat", "nbf", "jti",
     # nanoidp protocol claims
-    "token_use", "auth_time", "at_hash", "azp", "nonce", "scope",
-    "req_userinfo_claims", "req_id_token_claims",
+    "token_use", "auth_time", "at_hash", "azp", "nonce",
+    *_AUTHORITATIVE_CLAIMS,
 })
+
+
+def sanitize_claim_names(value: Any) -> Optional[List[str]]:
+    """Coerce a requested-claims value to a list of claim names, or ``None``.
+
+    The requested-claims lists cross trust boundaries: MCP arguments reach
+    ``create_token`` without SDK-side schema enforcement, and on refresh the
+    names are recovered from the refresh-token payload, which may be
+    hand-crafted with the IdP key (a first-class dev workflow). Anything but a
+    list is ignored and non-string entries are dropped, always with a warning
+    and never an exception — token issuance must not be able to fail on a
+    malformed value after the refresh token has been consumed.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        logger.warning(
+            "Ignoring malformed requested-claims value: expected a list of "
+            "claim names, got %s", type(value).__name__
+        )
+        return None
+    names = [name for name in value if isinstance(name, str)]
+    if len(names) != len(value):
+        logger.warning("Dropping non-string entries from requested-claims value")
+    return names or None
 
 
 def resolve_user_claim(user: User, name: str) -> tuple[bool, Any]:
@@ -198,6 +230,12 @@ class TokenService:
         if exp_minutes is None:
             exp_minutes = settings.token_expiry_minutes
 
+        # Defense in depth at the single choke point every issuance path goes
+        # through: requested-claims values may come from a hand-crafted refresh
+        # token or an unvalidated MCP call (see sanitize_claim_names).
+        id_token_claims = sanitize_claim_names(id_token_claims)
+        userinfo_claims = sanitize_claim_names(userinfo_claims)
+
         # Build extra claims
         extra: Dict[str, Any] = {}
 
@@ -222,16 +260,13 @@ class TokenService:
         if extra_claims:
             extra.update(extra_claims)
 
-        # `scope` and `req_userinfo_claims` are authoritative: they must reflect
-        # the actual grant, never a caller-supplied `extra`. Drop any spoofed
-        # copy the merge may have introduced before setting them below. Without
-        # this, a request like extra={"scope": "openid email"} or
-        # extra={"req_userinfo_claims": ["email"]} would smuggle scope-gated
-        # claims past /userinfo when the authoritative value is absent
-        # (#102/#104 hardening). req_id_token_claims is dropped too: it is a
-        # protocol claim of the refresh token (#112) and must never appear in
-        # an access token via caller-supplied extra.
-        for reserved in ("scope", "req_userinfo_claims", "req_id_token_claims"):
+        # The authoritative claims must reflect the actual grant, never a
+        # caller-supplied `extra`. Drop any spoofed copy the merge may have
+        # introduced before setting them below. Without this, a request like
+        # extra={"scope": "openid email"} or extra={"req_userinfo_claims":
+        # ["email"]} would smuggle scope-gated claims past /userinfo when the
+        # authoritative value is absent (#102/#104 hardening).
+        for reserved in _AUTHORITATIVE_CLAIMS:
             extra.pop(reserved, None)
 
         # Advertise the granted scope on the access token (RFC 9068 §2.2.3), so

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -27,7 +27,7 @@ _RESERVED_CLAIMS = frozenset({
     "iss", "sub", "aud", "exp", "iat", "nbf", "jti",
     # nanoidp protocol claims
     "token_use", "auth_time", "at_hash", "azp", "nonce", "scope",
-    "req_userinfo_claims",
+    "req_userinfo_claims", "req_id_token_claims",
 })
 
 
@@ -189,7 +189,9 @@ class TokenService:
         ``id_token_claims``/``userinfo_claims`` are the claim names a client
         asked for through the OIDC ``claims`` request parameter (OIDC Core
         §5.5, #104): the former are resolved into the ID Token here, the latter
-        are stamped on the access token so ``/userinfo`` can honour them.
+        are stamped on the access token so ``/userinfo`` can honour them. Both
+        lists are also persisted in the refresh token (like ``scope`` and
+        ``auth_time``), so refreshed tokens keep honouring the request (#112).
         """
         settings = self.config.settings
 
@@ -226,8 +228,10 @@ class TokenService:
         # this, a request like extra={"scope": "openid email"} or
         # extra={"req_userinfo_claims": ["email"]} would smuggle scope-gated
         # claims past /userinfo when the authoritative value is absent
-        # (#102/#104 hardening).
-        for reserved in ("scope", "req_userinfo_claims"):
+        # (#102/#104 hardening). req_id_token_claims is dropped too: it is a
+        # protocol claim of the refresh token (#112) and must never appear in
+        # an access token via caller-supplied extra.
+        for reserved in ("scope", "req_userinfo_claims", "req_id_token_claims"):
             extra.pop(reserved, None)
 
         # Advertise the granted scope on the access token (RFC 9068 §2.2.3), so
@@ -309,7 +313,11 @@ class TokenService:
         #   other client can spend it (RFC 9700 §4.14, #56) - which also keeps
         #   the refreshed ID Token aud identical to the original;
         # - rt_family, a stable id across rotations: reuse of a consumed token
-        #   revokes the whole family (RFC 9700 §4.14.2, #56).
+        #   revokes the whole family (RFC 9700 §4.14.2, #56);
+        # - req_id_token_claims/req_userinfo_claims, the claim names requested
+        #   via the OIDC `claims` parameter, so a refreshed ID Token keeps the
+        #   requested claims and /userinfo keeps honouring them for the
+        #   refreshed access token (OIDC Core §12.2, #112).
         refresh_extra: Dict[str, Any] = {"token_type": "refresh", "token_use": "refresh"}
         if scope:
             refresh_extra["scope"] = scope
@@ -317,6 +325,10 @@ class TokenService:
             refresh_extra["auth_time"] = effective_auth_time
         if client_id:
             refresh_extra["client_id"] = client_id
+        if id_token_claims:
+            refresh_extra["req_id_token_claims"] = id_token_claims
+        if userinfo_claims:
+            refresh_extra["req_userinfo_claims"] = userinfo_claims
         refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
         refresh_token = self.crypto.create_jwt(
             sub=user.username,

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # Claims ``create_token`` sets authoritatively from the grant and therefore
 # strips from caller-supplied ``extra`` before setting them (#102/#104/#112).
 # ``_RESERVED_CLAIMS`` is derived from this tuple, so a claim added here is
-# automatically refused by ``resolve_user_claim`` as well — the strip list and
+# automatically refused by ``resolve_user_claim`` as well - the strip list and
 # the reserved list cannot drift apart.
 _AUTHORITATIVE_CLAIMS = ("scope", "req_userinfo_claims", "req_id_token_claims")
 
@@ -46,7 +46,7 @@ def sanitize_claim_names(value: Any) -> Optional[List[str]]:
     names are recovered from the refresh-token payload, which may be
     hand-crafted with the IdP key (a first-class dev workflow). Anything but a
     list is ignored and non-string entries are dropped, always with a warning
-    and never an exception — token issuance must not be able to fail on a
+    and never an exception - token issuance must not be able to fail on a
     malformed value after the refresh token has been consumed.
     """
     if value is None:

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -232,26 +232,25 @@ class TestUserinfoMember:
     def test_no_overwrite_keeps_scope_gated_value(self, monkeypatch):
         # White-box check of the `claim_name not in response` guard. /userinfo
         # resolves every claim through resolve_user_claim (defaults and the
-        # req_userinfo_claims loop alike, #113), so a call-numbered sentinel
-        # tells the two apart: if the loop overwrote an already-present claim,
-        # its value would carry a LATER call number than the default assembly's.
+        # req_userinfo_claims loop alike, #113), so a resolver wrapper that
+        # records each resolved name proves the guard: a requested claim that
+        # is already present must be resolved exactly once (by the defaults),
+        # never re-resolved by the requested-claims loop.
         import nanoidp.routes.oauth as oauth_module
         from nanoidp.services.token import resolve_user_claim as real_resolver
 
-        calls = {"n": 0}
+        resolved_names = []
 
-        def numbering_resolver(user, name):
+        def recording_resolver(user, name):
             found, value = real_resolver(user, name)
-            if not found:
-                return found, value
-            calls["n"] += 1
-            return True, f"SENTINEL-{name}-{calls['n']}"
+            if found:
+                resolved_names.append(name)
+            return found, value
 
         from nanoidp.config import get_config
         from nanoidp.services.token import get_token_service
 
-        app = create_app(profile="dev")
-        app.config["TESTING"] = True
+        client = _dev_client()
         token = get_token_service().create_token(
             get_config().get_user("admin"),
             scope="openid",
@@ -260,17 +259,16 @@ class TestUserinfoMember:
         )["access_token"]
 
         # Patch AFTER minting, and only where /userinfo resolves claims.
-        monkeypatch.setattr(oauth_module, "resolve_user_claim", numbering_resolver)
-        resp = app.test_client().get(
-            "/userinfo", headers={"Authorization": f"Bearer {token}"}
-        )
+        monkeypatch.setattr(oauth_module, "resolve_user_claim", recording_resolver)
+        resp = client.get("/userinfo", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200, resp.data
         data = json.loads(resp.data)
-        # email is resolved first by the permissive dev defaults; the requested
-        # duplicate must NOT re-resolve it (an overwrite would bump the number).
-        assert data["email"] == "SENTINEL-email-1"
+        # email was already placed by the permissive dev defaults: the
+        # requested duplicate must not have re-resolved it.
+        assert resolved_names.count("email") == 1
+        assert data["email"] == "admin@example.org"
         # department was not among the defaults -> added by the requested loop
-        assert data["department"].startswith("SENTINEL-department-")
+        assert data["department"] == "IT"
 
 
 # --------------------------------------------------------------------------
@@ -356,6 +354,79 @@ class TestClaimsPersistAcrossRefresh:
             refreshed["access_token"], options={"verify_signature": False}
         )
         assert "req_userinfo_claims" not in access_payload
+
+    def test_forged_refresh_token_with_malformed_claims_refreshes_cleanly(self):
+        # Hand-crafting tokens with the IdP key is a first-class dev workflow:
+        # a refresh token carrying garbage requested-claims values (an int, the
+        # raw §5.5 object instead of names, a bare string) must not 500 after
+        # the token has been consumed — sanitize_claim_names drops the garbage
+        # and the refresh succeeds without it.
+        from nanoidp.config import get_config
+        from nanoidp.services.crypto import get_crypto_service
+
+        client = _dev_client()
+        config = get_config()
+        crypto = get_crypto_service(config.settings.keys_dir)
+        forged = crypto.create_jwt(
+            sub="admin",
+            issuer=config.settings.issuer,
+            audience=config.settings.audience,
+            exp_minutes=60,
+            extra={
+                "token_type": "refresh",
+                "token_use": "refresh",
+                "scope": "openid",
+                "rt_family": "forged-family",
+                "req_id_token_claims": 42,  # non-iterable
+                "req_userinfo_claims": "email",  # bare string, not a list
+            },
+        )
+
+        refreshed = self._refresh(client, forged)
+        id_payload = pyjwt.decode(refreshed["id_token"], options={"verify_signature": False})
+        assert "email" not in id_payload  # the garbage resolved nothing
+        access_payload = pyjwt.decode(
+            refreshed["access_token"], options={"verify_signature": False}
+        )
+        assert "req_userinfo_claims" not in access_payload
+        # ...and a list with mixed entries keeps only the string names
+        forged_mixed = crypto.create_jwt(
+            sub="admin",
+            issuer=config.settings.issuer,
+            audience=config.settings.audience,
+            exp_minutes=60,
+            extra={
+                "token_type": "refresh",
+                "token_use": "refresh",
+                "scope": "openid",
+                "rt_family": "forged-family-2",
+                "req_id_token_claims": ["email", {"essential": True}],
+            },
+        )
+        refreshed = self._refresh(client, forged_mixed)
+        id_payload = pyjwt.decode(refreshed["id_token"], options={"verify_signature": False})
+        assert id_payload["email"] == "admin@example.org"
+
+    def test_userinfo_tolerates_malformed_req_claims_on_access_token(self):
+        # A hand-crafted ACCESS token with a non-list req_userinfo_claims must
+        # not 500 /userinfo (nor leak single-character attribute lookups from
+        # iterating a string).
+        from nanoidp.config import get_config
+        from nanoidp.services.crypto import get_crypto_service
+
+        client = _dev_client()
+        config = get_config()
+        crypto = get_crypto_service(config.settings.keys_dir)
+        for bad in (5, "email", {"email": None}):
+            token = crypto.create_jwt(
+                sub="admin",
+                issuer=config.settings.issuer,
+                audience=config.settings.audience,
+                exp_minutes=5,
+                extra={"req_userinfo_claims": bad},
+            )
+            resp = client.get("/userinfo", headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 200, (bad, resp.data)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -355,11 +355,68 @@ class TestClaimsPersistAcrossRefresh:
         )
         assert "req_userinfo_claims" not in access_payload
 
+    def test_claims_request_survives_scope_narrowing(self):
+        # Deliberate semantic decision (documented in _grant_refresh_token and
+        # tokens.md): a claims request binds to the original authorization and
+        # is orthogonal to scope (OIDC Core 5.5), so narrowing the scope on
+        # refresh does NOT shed it. Under stricter-dev this is observable:
+        # email would be scope-gated out after dropping the email scope, yet
+        # the persisted userinfo claims request keeps forcing it back in.
+        from nanoidp.config import get_config
+        from nanoidp.services.token import get_token_service
+
+        app = create_app(profile="stricter-dev")
+        app.config["TESTING"] = True
+        client = app.test_client()
+
+        # 1. original grant: scope "openid email" + userinfo claims request
+        original = get_token_service().create_token(
+            get_config().get_user("admin"),
+            scope="openid email",
+            client_id="demo-client",
+            userinfo_claims=["email"],
+        )
+
+        # 2. refresh narrowing the scope to "openid" (drops email)
+        narrowed = self._refresh(
+            client, original["refresh_token"], extra_form={"scope": "openid"}
+        )
+        assert narrowed["scope"] == "openid"
+
+        # 3. the narrowed access token still carries the claims request
+        access_payload = pyjwt.decode(
+            narrowed["access_token"], options={"verify_signature": False}
+        )
+        assert access_payload["scope"] == "openid"
+        assert access_payload["req_userinfo_claims"] == ["email"]
+
+        # 4. /userinfo keeps honouring it despite the dropped email scope
+        resp = client.get(
+            "/userinfo",
+            headers={"Authorization": "Bearer " + narrowed["access_token"]},
+        )
+        assert resp.status_code == 200, resp.data
+        assert json.loads(resp.data)["email"] == "admin@example.org"
+
+        # 5. a second refresh after the narrowing keeps the request through
+        #    rotation as well
+        narrowed2 = self._refresh(client, narrowed["refresh_token"])
+        access_payload2 = pyjwt.decode(
+            narrowed2["access_token"], options={"verify_signature": False}
+        )
+        assert access_payload2["req_userinfo_claims"] == ["email"]
+        resp2 = client.get(
+            "/userinfo",
+            headers={"Authorization": "Bearer " + narrowed2["access_token"]},
+        )
+        assert resp2.status_code == 200, resp2.data
+        assert json.loads(resp2.data)["email"] == "admin@example.org"
+
     def test_forged_refresh_token_with_malformed_claims_refreshes_cleanly(self):
         # Hand-crafting tokens with the IdP key is a first-class dev workflow:
         # a refresh token carrying garbage requested-claims values (an int, the
         # raw §5.5 object instead of names, a bare string) must not 500 after
-        # the token has been consumed — sanitize_claim_names drops the garbage
+        # the token has been consumed - sanitize_claim_names drops the garbage
         # and the refresh succeeds without it.
         from nanoidp.config import get_config
         from nanoidp.services.crypto import get_crypto_service

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -98,8 +98,8 @@ def _basic_auth():
     return {"Authorization": "Basic " + base64.b64encode(b"demo-client:demo-secret").decode()}
 
 
-def _id_token_via_authcode(client, claims=None):
-    """Drive the full authorization code flow and return the decoded ID Token."""
+def _tokens_via_authcode(client, claims=None):
+    """Drive the full authorization code flow and return the token response."""
     query = {
         "response_type": "code",
         "client_id": "demo-client",
@@ -123,7 +123,12 @@ def _id_token_via_authcode(client, claims=None):
         headers=_basic_auth(),
     )
     assert token_resp.status_code == 200, token_resp.data
-    id_token = json.loads(token_resp.data)["id_token"]
+    return json.loads(token_resp.data)
+
+
+def _id_token_via_authcode(client, claims=None):
+    """Drive the full authorization code flow and return the decoded ID Token."""
+    id_token = _tokens_via_authcode(client, claims=claims)["id_token"]
     return pyjwt.decode(id_token, options={"verify_signature": False})
 
 
@@ -161,6 +166,24 @@ class TestIdTokenMember:
         assert payload["sub"] == "admin"
         assert "email" not in payload
 
+    def test_custom_user_attribute_lands_in_id_token(self):
+        # admin carries department/cost_center in users.yaml attributes; a
+        # requested attribute name resolves like any standard claim (#113).
+        claims = json.dumps({"id_token": {"department": None}})
+        payload = _id_token_via_authcode(_dev_client(), claims=claims)
+        assert payload["department"] == "IT"
+
+    def test_essential_and_value_refinements_accepted_but_ignored(self):
+        # §5.5.1 refinements are parsed for the claim NAME only: essential
+        # claims are delivered as if voluntary, and a `value` constraint never
+        # overrides the user's real value.
+        claims = json.dumps(
+            {"id_token": {"email": {"essential": True}, "tenant": {"value": "spoofed"}}}
+        )
+        payload = _id_token_via_authcode(_dev_client(), claims=claims)
+        assert payload["email"] == "admin@example.org"
+        assert payload["tenant"] == "default"  # real value, not the requested one
+
 
 # --------------------------------------------------------------------------
 # Integration: UserInfo member (composes with #102 scope gating)
@@ -194,6 +217,145 @@ class TestUserinfoMember:
     def test_without_member_scope_gating_still_applies(self):
         data = _mint_and_userinfo("stricter-dev", scope="openid", userinfo_claims=None)
         assert "email" not in data
+
+    def test_requesting_already_present_claims_is_invariant_under_dev(self):
+        # Under the permissive dev profile email/preferred_username are already
+        # in the response; the no-overwrite branch must leave the response
+        # exactly as it would be without the request (#113).
+        with_claims = _mint_and_userinfo(
+            "dev", scope="openid", userinfo_claims=["email", "email_verified", "roles"]
+        )
+        without_claims = _mint_and_userinfo("dev", scope="openid", userinfo_claims=None)
+        assert with_claims == without_claims
+        assert with_claims["email"] == "admin@example.org"
+
+    def test_no_overwrite_keeps_scope_gated_value(self, monkeypatch):
+        # White-box check of the `claim_name not in response` guard. /userinfo
+        # resolves every claim through resolve_user_claim (defaults and the
+        # req_userinfo_claims loop alike, #113), so a call-numbered sentinel
+        # tells the two apart: if the loop overwrote an already-present claim,
+        # its value would carry a LATER call number than the default assembly's.
+        import nanoidp.routes.oauth as oauth_module
+        from nanoidp.services.token import resolve_user_claim as real_resolver
+
+        calls = {"n": 0}
+
+        def numbering_resolver(user, name):
+            found, value = real_resolver(user, name)
+            if not found:
+                return found, value
+            calls["n"] += 1
+            return True, f"SENTINEL-{name}-{calls['n']}"
+
+        from nanoidp.config import get_config
+        from nanoidp.services.token import get_token_service
+
+        app = create_app(profile="dev")
+        app.config["TESTING"] = True
+        token = get_token_service().create_token(
+            get_config().get_user("admin"),
+            scope="openid",
+            client_id="demo-client",
+            userinfo_claims=["email", "department"],
+        )["access_token"]
+
+        # Patch AFTER minting, and only where /userinfo resolves claims.
+        monkeypatch.setattr(oauth_module, "resolve_user_claim", numbering_resolver)
+        resp = app.test_client().get(
+            "/userinfo", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200, resp.data
+        data = json.loads(resp.data)
+        # email is resolved first by the permissive dev defaults; the requested
+        # duplicate must NOT re-resolve it (an overwrite would bump the number).
+        assert data["email"] == "SENTINEL-email-1"
+        # department was not among the defaults -> added by the requested loop
+        assert data["department"].startswith("SENTINEL-department-")
+
+
+# --------------------------------------------------------------------------
+# Integration: requested claims persist across token refresh (#112)
+# --------------------------------------------------------------------------
+class TestClaimsPersistAcrossRefresh:
+    def _refresh(self, client, refresh_token, extra_form=None):
+        form = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        if extra_form:
+            form.update(extra_form)
+        resp = client.post("/token", data=form, headers=_basic_auth())
+        assert resp.status_code == 200, resp.data
+        return json.loads(resp.data)
+
+    def test_refresh_token_carries_requested_claim_names(self):
+        client = _dev_client()
+        claims = json.dumps({"id_token": {"email": None}, "userinfo": {"department": None}})
+        tokens = _tokens_via_authcode(client, claims=claims)
+        rt = pyjwt.decode(tokens["refresh_token"], options={"verify_signature": False})
+        assert rt["req_id_token_claims"] == ["email"]
+        assert rt["req_userinfo_claims"] == ["department"]
+
+    def test_refreshed_id_token_keeps_requested_claims(self):
+        client = _dev_client()
+        claims = json.dumps({"id_token": {"email": None, "department": None}})
+        tokens = _tokens_via_authcode(client, claims=claims)
+
+        refreshed = self._refresh(client, tokens["refresh_token"])
+        payload = pyjwt.decode(refreshed["id_token"], options={"verify_signature": False})
+        assert payload["email"] == "admin@example.org"
+        assert payload["department"] == "IT"
+
+        # ...and across a SECOND refresh (rotation re-persists the names).
+        refreshed2 = self._refresh(client, refreshed["refresh_token"])
+        payload2 = pyjwt.decode(refreshed2["id_token"], options={"verify_signature": False})
+        assert payload2["email"] == "admin@example.org"
+
+    def test_refreshed_access_token_keeps_userinfo_claims(self):
+        # Under stricter-dev, /userinfo would gate email out without the email
+        # scope (#102); the persisted userinfo member must keep forcing it back
+        # in after a refresh. The refresh leg is driven over HTTP; the original
+        # grant is minted directly (the stricter-dev authorize leg would need
+        # PKCE, which is orthogonal here).
+        from nanoidp.config import get_config
+        from nanoidp.services.token import get_token_service
+
+        app = create_app(profile="stricter-dev")
+        app.config["TESTING"] = True
+        client = app.test_client()
+        original = get_token_service().create_token(
+            get_config().get_user("admin"),
+            scope="openid",
+            client_id="demo-client",
+            userinfo_claims=["email"],
+        )
+
+        refreshed = self._refresh(client, original["refresh_token"])
+        access_payload = pyjwt.decode(
+            refreshed["access_token"], options={"verify_signature": False}
+        )
+        assert access_payload["req_userinfo_claims"] == ["email"]
+
+        resp = client.get(
+            "/userinfo",
+            headers={"Authorization": "Bearer " + refreshed["access_token"]},
+        )
+        assert resp.status_code == 200, resp.data
+        assert json.loads(resp.data)["email"] == "admin@example.org"
+
+    def test_legacy_refresh_token_without_claims_still_works(self):
+        # Refresh tokens minted before #112 carry neither claim: the refresh
+        # succeeds and simply issues tokens without the requested-claims extras.
+        client = _dev_client()
+        tokens = _tokens_via_authcode(client)  # no claims parameter
+        rt = pyjwt.decode(tokens["refresh_token"], options={"verify_signature": False})
+        assert "req_id_token_claims" not in rt
+        assert "req_userinfo_claims" not in rt
+
+        refreshed = self._refresh(client, tokens["refresh_token"])
+        id_payload = pyjwt.decode(refreshed["id_token"], options={"verify_signature": False})
+        assert "email" not in id_payload
+        access_payload = pyjwt.decode(
+            refreshed["access_token"], options={"verify_signature": False}
+        )
+        assert "req_userinfo_claims" not in access_payload
 
 
 # --------------------------------------------------------------------------
@@ -247,7 +409,7 @@ class TestReservedClaimsCannotBeSpoofed:
 _RESERVED = [
     "iss", "sub", "aud", "exp", "iat", "nbf", "jti",
     "token_use", "auth_time", "at_hash", "azp", "nonce", "scope",
-    "req_userinfo_claims",
+    "req_userinfo_claims", "req_id_token_claims",
 ]
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -498,3 +498,105 @@ class TestMCPClientAdditionalAudiences:
         payload = json.loads(result[0].text)
         assert payload["tool"] == "create_client"
         assert "additional_audiences" in payload["error"]
+
+
+class TestGenerateTokenClaims:
+    """MCP ``generate_token`` claims arguments (#104/#113, parity #112).
+
+    The MCP half of the OIDC ``claims`` parameter: ``id_token_claims`` must
+    actually land the claims in the ID Token, ``userinfo_claims`` must be
+    stamped on the access token and honoured by ``/userinfo``, and both must
+    survive a token refresh like their HTTP counterparts.
+    """
+
+    async def _generate(self, arguments):
+        from nanoidp.config import get_config
+        from nanoidp.mcp_server import _execute_tool
+
+        result = await _execute_tool("generate_token", arguments, get_config())
+        assert result["success"] is True, result
+        return result
+
+    @pytest.mark.asyncio
+    async def test_id_token_claims_land_in_id_token(self, app):
+        import jwt as pyjwt
+
+        result = await self._generate(
+            {"username": "admin", "scope": "openid", "id_token_claims": ["email", "department"]}
+        )
+        payload = pyjwt.decode(result["id_token"], options={"verify_signature": False})
+        assert payload["email"] == "admin@example.org"
+        # custom user attribute resolved like any standard claim
+        assert payload["department"] == "IT"
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_names_are_skipped(self, app):
+        import jwt as pyjwt
+
+        result = await self._generate(
+            {"username": "admin", "scope": "openid", "id_token_claims": ["no_such_claim"]}
+        )
+        payload = pyjwt.decode(result["id_token"], options={"verify_signature": False})
+        assert "no_such_claim" not in payload
+
+    @pytest.mark.asyncio
+    async def test_id_token_claims_inert_without_openid_scope(self, app):
+        result = await self._generate(
+            {"username": "admin", "id_token_claims": ["email"]}
+        )
+        assert "id_token" not in result
+
+    @pytest.mark.asyncio
+    async def test_userinfo_claims_stamped_and_honoured(self, app, client):
+        import jwt as pyjwt
+
+        result = await self._generate(
+            {"username": "admin", "scope": "openid", "userinfo_claims": ["department"]}
+        )
+        access_payload = pyjwt.decode(
+            result["access_token"], options={"verify_signature": False}
+        )
+        assert access_payload["req_userinfo_claims"] == ["department"]
+
+        # /userinfo returns the requested claim at top level - under the dev
+        # profile `department` only appears nested in `attributes`, so this is
+        # observable even without scope gating.
+        resp = client.get(
+            "/userinfo", headers={"Authorization": "Bearer " + result["access_token"]}
+        )
+        assert resp.status_code == 200, resp.data
+        data = json.loads(resp.data)
+        assert data["department"] == "IT"
+
+    @pytest.mark.asyncio
+    async def test_claims_persist_across_refresh(self, app, client, auth_header):
+        import jwt as pyjwt
+
+        result = await self._generate(
+            {
+                "username": "admin",
+                "scope": "openid",
+                "id_token_claims": ["email"],
+                "userinfo_claims": ["department"],
+            }
+        )
+        rt_payload = pyjwt.decode(
+            result["refresh_token"], options={"verify_signature": False}
+        )
+        assert rt_payload["req_id_token_claims"] == ["email"]
+        assert rt_payload["req_userinfo_claims"] == ["department"]
+
+        # Refresh over HTTP: the refreshed tokens keep honouring the request (#112).
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": result["refresh_token"]},
+            headers=auth_header,
+        )
+        assert resp.status_code == 200, resp.data
+        refreshed = json.loads(resp.data)
+        id_payload = pyjwt.decode(refreshed["id_token"], options={"verify_signature": False})
+        assert id_payload["email"] == "admin@example.org"
+        access_payload = pyjwt.decode(
+            refreshed["access_token"], options={"verify_signature": False}
+        )
+        assert access_payload["req_userinfo_claims"] == ["department"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -569,6 +569,27 @@ class TestGenerateTokenClaims:
         assert data["department"] == "IT"
 
     @pytest.mark.asyncio
+    async def test_non_list_claims_arguments_rejected(self, app):
+        """The SDK does not enforce inputSchema server-side: a non-list value
+        must be rejected with a clean ValueError (turned into an error payload
+        by call_tool), not minted into a token that misbehaves at /userinfo."""
+        from nanoidp.config import get_config
+        from nanoidp.mcp_server import _execute_tool
+
+        for field, bad in (
+            ("userinfo_claims", "email"),
+            ("userinfo_claims", 5),
+            ("id_token_claims", "email"),
+            ("id_token_claims", [1, 2]),
+        ):
+            with pytest.raises(ValueError, match=field):
+                await _execute_tool(
+                    "generate_token",
+                    {"username": "admin", "scope": "openid", field: bad},
+                    get_config(),
+                )
+
+    @pytest.mark.asyncio
     async def test_claims_persist_across_refresh(self, app, client, auth_header):
         import jwt as pyjwt
 


### PR DESCRIPTION
Closes #112, closes #113 — the two remaining follow-ups from the post-release review of #104.

## #112 — requested claims persist across token refresh

The claim names requested via the OIDC `claims` parameter are now persisted in the refresh token as `req_id_token_claims` / `req_userinfo_claims`, alongside the already-persisted `scope`, `auth_time`, `client_id` and `rt_family`, and recovered by `_grant_refresh_token`:

- a refreshed **ID Token keeps** the claims the client requested via `claims={"id_token":{...}}` (same answer before and after refresh, OIDC Core §12.2);
- a refreshed **access token keeps `req_userinfo_claims`**, so `/userinfo` keeps honouring the `userinfo` member under `stricter-dev`/`oauth21`;
- persistence survives **rotation** (the rotated refresh token re-carries the names);
- **legacy refresh tokens** (minted before this change) carry neither claim and refresh exactly as before;
- both names are **reserved**: `resolve_user_claim` refuses them (extending the #110 choke point) and `create_token` strips them from caller-supplied `extra`, so they cannot be spoofed onto an access token.

`nonce` remains the deliberate, documented exception (binds the original authentication request only).

## #113 — coverage + cleanup

- **Cleanup:** `/userinfo`'s default claim assembly (scope-gated standard claims + nanoidp-specific claims) now goes through `resolve_user_claim`, the same resolver backing the `claims` parameter, so the two mappings cannot diverge. Behavior-invariant (locked by an invariance test).
- **MCP parity:** `generate_token` gains `userinfo_claims`, mirroring the HTTP `userinfo` member.
- **New tests** (22 added across the PR, suite at 799):
  - MCP `generate_token(id_token_claims)`: claims land in the ID Token, unresolvable names are skipped, inert without an `openid` scope;
  - MCP `userinfo_claims`: stamped on the access token and honoured by `/userinfo`;
  - custom user attribute driven through `/authorize` into the ID Token;
  - `essential`/`value` refinements accepted but ignored end-to-end (a `value` constraint never overrides the real value);
  - `/userinfo` no-overwrite branch (call-numbered sentinel resolver proves the scope-gated value is never re-resolved);
  - claims persistence across refresh: full authorize→token→refresh→refresh flow, stricter-dev `/userinfo` honouring after refresh, legacy tokens without the claims.
- **E2E agent:** new `Claims across refresh` test (refreshes the auth-code grant's token, asserts the requested `email` is still in the refreshed ID Token and an unrequested attribute is not).

## Verification

- Full suite: **799 passed**; ruff and mypy clean; coverage 79% (gate 75).
- Live run: `python -m nanoidp` + `examples/test_agent.py` → **42/42**; manual positive (claims survive refresh via the real authorize flow, `/userinfo` returns the requested attribute on the refreshed access token) and negative (legacy refresh token stays clean) checks against the live server.

Docs: `book/src/reference/tokens.md` documents the refresh persistence (and the `nonce` exception), `mcp.md` documents the new tool argument, CHANGELOG updated under Unreleased.


## Review hardening (second round)

A full self-review of this PR (8 finder angles + adversarial verification, findings posted in the comment below) led to two follow-up commits:

- `sanitize_claim_names` at the `create_token` choke point and in the `/userinfo` loop: malformed requested-claims values from hand-crafted tokens can no longer fail issuance after the refresh token was consumed, nor 500 `/userinfo`.
- MCP `generate_token` validates `id_token_claims`/`userinfo_claims` with `_normalize_str_list` (clean error on non-list input).
- `_AUTHORITATIVE_CLAIMS` shared constant ties the `extra` strip list to `_RESERVED_CLAIMS`.
- The scope-narrowing semantics are now explicit (code comment + docs) and pinned by a dedicated test: a claims request survives a narrowed refresh, including through rotation.
- Docs: refresh guide links the persistence semantics; stale "authorization code grant only" sentence amended.
