### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.0] - 2026-07-19
 
 ### Added
 - **`claims` parameter requests persist across token refresh** (#112, OIDC
@@ -475,6 +475,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Key rotation with JWKS support for multiple keys
 - External key import support
 
+[2.5.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.1.0...v2.2.0

--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -24,7 +24,7 @@ docker run --rm -p 8000:8000 \
   ghcr.io/cdelmonte-zg/nanoidp:latest
 ```
 
-Container tags are derived from release tags (for example `v2.4.0`);
+Container tags are derived from release tags (for example `v2.5.0`);
 `latest` points at the newest non-prerelease.
 
 ## From source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.4.0"
+version = "2.5.0"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 2.5.0.

- Version bump 2.4.0 -> 2.5.0 in pyproject.toml
- CHANGELOG: the Unreleased section becomes 2.5.0 (2026-07-19) with its compare link
- Container tag example in the install guide refreshed to v2.5.0

Content (see CHANGELOG for details):
- #112: OIDC `claims` parameter requests persist across token refresh (OIDC Core §12.2), with sanitization of requested-claims values at the token service (hand-crafted tokens with malformed values cannot fail issuance post-consumption nor 500 /userinfo); a claims request deliberately survives scope narrowing
- #113: /userinfo claim assembly centralized on `resolve_user_claim`; MCP `generate_token` gains `userinfo_claims` with strict argument validation; test coverage for the whole #104 surface
- #110: reserved claim names refused in `resolve_user_claim` (registered/protocol claim hijack via colliding user attributes)

Minor rather than patch because the release contains backward-compatible new functionality (SemVer).

Pre-flight done: 799 tests green with the 75% coverage gate (79.39%), ruff/mypy clean, live e2e agent 42/42 against a running server.