### PR TITLE
feat: add option to infer issuer from request for discovery/OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Settings page and the MCP `update_settings` tool, and apply to both the SSO
   assertion and the AttributeQuery endpoint, with one `AttributeValue` per
   entry.
+- **`oauth.issuer_from_request`** (off by default): when enabled, the
+  discovery document's `issuer`, every minted token's `iss`, and the device
+  flow's `verification_uri` are derived from the incoming request's own Host
+  header instead of the fixed `oauth.issuer`. Lets the same NanoIDP be
+  reachable under more than one hostname (e.g. a Docker Compose service name
+  from other containers and `localhost` from the host browser) without a
+  discovery/token issuer mismatch - each hostname advertises and issues
+  tokens against itself. The MCP `get_oidc_discovery`/`get_settings` tools
+  have no request of their own and always report the fixed `issuer`.
+- **`oauth.issuer_allowlist`**: restricts `issuer_from_request` to a list of
+  allowed origins (e.g. `["http://localhost:8000", "http://nanoidp:9900"]`).
+  Empty (default) allows any Host header, unchanged from before; when set, a
+  request whose Host doesn't match falls back to the fixed `oauth.issuer`
+  instead of trusting an arbitrary Host header. Settable from the Settings
+  page and the MCP `update_settings` tool.
+- **`oauth.device_verification_base_url`**: pins the device flow's
+  `verification_uri` to a fixed, human-reachable URL (e.g.
+  `https://idp.example.com`), overriding `issuer_from_request`'s derivation
+  for that field only - discovery's `issuer` and a token's `iss` are
+  unaffected. Fixes a backend/container caller of `/device_authorization`
+  (e.g. `Host: nanoidp:9900`) otherwise leaking its own Host into a URL the
+  end user's browser can't open. Unset by default. Settable from the
+  Settings page and the MCP `update_settings` tool.
+- **`oauth.issuer_from_proxy_headers`** (off by default): trusts
+  `X-Forwarded-Proto`/`X-Forwarded-Host`/`X-Forwarded-For` from a single
+  reverse-proxy hop (via werkzeug's `ProxyFix`), so `issuer_from_request` and
+  rate-limit client IPs see the original scheme/host/client instead of the
+  proxy's own connection when TLS is terminated upstream. Only changes the
+  derived issuer/`iss`/`verification_uri` when `issuer_from_request` is also
+  on; the rate-limit effect applies regardless. Only enable this when
+  NanoIDP is deployed directly behind exactly one trusted proxy - these
+  headers are otherwise spoofable by any client. Readable/settable via the
+  MCP `get_settings`/`update_settings` tools; since `ProxyFix` is wired at
+  app startup, a value changed at runtime only takes effect after a restart.
 
 ### Changed
 - **Migrated the MCP server to the mcp 2.0 SDK** and pinned `mcp>=2,<3`. mcp 2.0

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -51,6 +51,33 @@ server:
 
 oauth:
   issuer: "http://localhost:8000"
+  issuer_from_request: false    # true: derive issuer/iss/verification_uri from
+                                 # each request's own Host header instead of the
+                                 # fixed issuer above - lets the same NanoIDP be
+                                 # reachable under more than one hostname (e.g. a
+                                 # Docker Compose service name vs. localhost) without
+                                 # a discovery/token issuer mismatch. MCP tools have
+                                 # no request of their own and always report the
+                                 # fixed issuer.
+  issuer_allowlist: []          # origins allowed to be reflected by issuer_from_request,
+                                 # e.g. ["http://localhost:8000", "http://nanoidp:9900"].
+                                 # Empty (default) allows any Host header; a non-matching
+                                 # Host falls back to the fixed issuer above.
+  device_verification_base_url: null  # fixed, human-reachable URL (e.g.
+                                 # "https://idp.example.com") for the device flow's
+                                 # verification_uri, overriding issuer_from_request's
+                                 # derivation there - use this when a backend/container
+                                 # calls /device_authorization so the returned URL is
+                                 # still one a human's browser can open. Discovery's
+                                 # issuer and a token's iss are unaffected.
+  issuer_from_proxy_headers: false  # true: trust X-Forwarded-Proto/Host/For from a
+                                 # single reverse-proxy hop in front of NanoIDP
+                                 # (applies werkzeug's ProxyFix). Only affects the
+                                 # issuer_from_request derivation above - has no
+                                 # visible effect unless that's also on - but always
+                                 # affects rate-limit client IP attribution. Only
+                                 # enable behind exactly one trusted proxy - these
+                                 # headers are otherwise spoofable.
   audience: "my-app"            # access token "aud" (resource audience, RFC 9068)
   token_expiry_minutes: 60
   refresh_token_rotation: false # true: each refresh invalidates the used refresh token

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -24,6 +24,8 @@ oauth:
     description: Client with registered redirect URIs (exact matching, issue #67)
     redirect_uris:
     - http://localhost:3000/callback
+  issuer_from_request: false
+  issuer_from_proxy_headers: false
 saml:
   entity_id: http://localhost:${PORT:8000}/saml
   sso_url: http://localhost:${PORT:8000}/saml/sso

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -202,6 +202,37 @@ All MCP tool calls are logged to the audit log, including:
 
 ---
 
+## Multi-hostname Issuer (`issuer_from_request`)
+
+`oauth.issuer_from_request` (off by default) reflects each request's own
+Host header as the discovery `issuer`, token `iss`, and device flow
+`verification_uri`, so the same NanoIDP can be reached under more than one
+hostname (e.g. a Docker Compose service name vs. `localhost`) without a
+discovery/token issuer mismatch.
+
+**Trust caveats:**
+- The Host header is trusted as-is unless `oauth.issuer_allowlist` is set to
+  a non-empty list of allowed origins; a non-matching Host then falls back to
+  the fixed `issuer` instead. Only enable `issuer_from_request` without an
+  allowlist on trusted networks.
+- Behind a TLS-terminating reverse proxy, also enable
+  `oauth.issuer_from_proxy_headers` so `request.scheme`/`host_url` reflect
+  `X-Forwarded-Proto`/`X-Forwarded-Host` instead of the proxy's own HTTP
+  connection - this only changes the derived issuer when `issuer_from_request`
+  is also on (it always affects rate-limit client IP attribution regardless).
+  Only enable this when NanoIDP sits directly behind exactly one trusted proxy
+  - these headers are otherwise spoofable by any client.
+- By default, the device flow's `verification_uri` reflects whichever Host
+  called `/device_authorization`. If that caller is a backend/container
+  (e.g. `Host: nanoidp:9900`) rather than the end user's own browser, the
+  returned URL may not be reachable from the user's machine. Set
+  `oauth.device_verification_base_url` to a fixed, human-reachable URL (e.g.
+  `https://idp.example.com`) to pin `verification_uri` regardless of the
+  calling Host; discovery's `issuer` and a token's `iss` are unaffected and
+  keep following the request that fetched/requested them.
+
+---
+
 ## Environment Variables
 
 | Variable | Description | Default |

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -351,6 +351,75 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("Client Credentials", TestCategory.OAUTH, False, str(e))
 
+    def test_issuer_from_request(self) -> TestResult:
+        """Discovery/token issuer parity for oauth.issuer_from_request.
+
+        issuer_from_request defaults to off, so discovery must keep reporting
+        the fixed issuer regardless of the Host header used. If an operator's
+        config has it on (and the Host is allowlisted, or no allowlist is
+        set), discovery must reflect that Host instead - and a token minted
+        for the same Host must report the exact same value as `iss`, since
+        OIDC Discovery and ID Token validation both require an exact match.
+        Mirrors test_saml_signing_config's pattern of reading /api/config
+        first and asserting the toggle is honoured either way.
+        """
+        try:
+            config_response = self.session.get(f"{self.base_url}/api/config", timeout=5)
+            issuer_from_request = False
+            issuer_allowlist: List[str] = []
+            if config_response.status_code == 200:
+                oauth_config = config_response.json().get("oauth", {})
+                issuer_from_request = oauth_config.get("issuer_from_request", False)
+                issuer_allowlist = oauth_config.get("issuer_allowlist", []) or []
+
+            fixed_issuer = self.session.get(
+                f"{self.base_url}/.well-known/openid-configuration", timeout=5
+            ).json().get("issuer")
+
+            custom_host = "test-agent-issuer-check:9999"
+            discovery = self.session.get(
+                f"{self.base_url}/.well-known/openid-configuration",
+                headers={"Host": custom_host},
+                timeout=5,
+            ).json()
+            observed_issuer = discovery.get("issuer")
+
+            allowlisted = not issuer_allowlist or f"http://{custom_host}" in issuer_allowlist
+            expected_issuer = (
+                f"http://{custom_host}" if issuer_from_request and allowlisted else fixed_issuer
+            )
+            discovery_ok = observed_issuer == expected_issuer
+
+            token_response = self.session.post(
+                f"{self.base_url}/token",
+                data={"grant_type": "client_credentials"},
+                headers={"Host": custom_host},
+                timeout=5,
+            )
+            token_iss = None
+            if token_response.status_code == 200 and jwt:
+                access_token = token_response.json().get("access_token")
+                token_iss = jwt.decode(access_token, options={"verify_signature": False}).get("iss")
+
+            iss_matches_discovery = token_iss == observed_issuer
+
+            return self._add_result(
+                "Issuer From Request",
+                TestCategory.OAUTH,
+                discovery_ok and iss_matches_discovery,
+                f"issuer_from_request={issuer_from_request}, discovery_issuer={observed_issuer}, "
+                f"token_iss={token_iss}",
+                {
+                    "issuer_from_request": issuer_from_request,
+                    "issuer_allowlist": issuer_allowlist,
+                    "expected_issuer": expected_issuer,
+                    "discovery_issuer": observed_issuer,
+                    "token_iss": token_iss,
+                },
+            )
+        except Exception as e:
+            return self._add_result("Issuer From Request", TestCategory.OAUTH, False, str(e))
+
     def test_authorization_code_pkce(self) -> TestResult:
         """Authorization Code Flow with PKCE (simulated)."""
         try:
@@ -3033,6 +3102,7 @@ class NanoIDPTestAgent:
                 self.test_jwks,
                 self.test_password_grant,
                 self.test_client_credentials,
+                self.test_issuer_from_request,
                 self.test_authorization_code_pkce,
                 self.test_redirect_uri_exact_matching,
                 self.test_id_token_audience,

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -10,6 +10,7 @@ from flask import Flask, Response, jsonify
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from . import __version__
 from .config import get_config, init_config
@@ -66,6 +67,14 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
         static_folder=os.path.join(os.path.dirname(__file__), "static"),
     )
     app.secret_key = settings.secret_key
+
+    # Trust X-Forwarded-Proto/Host/For from a single reverse-proxy hop, so
+    # request.scheme/host_url (and therefore issuer_from_request, rate-limit
+    # client IPs) reflect the original client instead of the proxy.
+    if settings.issuer_from_proxy_headers:
+        app.wsgi_app = ProxyFix(  # type: ignore[method-assign]
+            app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1
+        )
 
     # Configure CORS based on security profile
     if settings.security_profile == "stricter-dev":

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -137,6 +137,10 @@ class ConfigManager:
             debug=server.get("debug", False),
             # OAuth
             issuer=oauth.get("issuer", "http://localhost:8000"),
+            issuer_from_request=oauth.get("issuer_from_request", False),
+            issuer_allowlist=oauth.get("issuer_allowlist", []) or [],
+            device_verification_base_url=oauth.get("device_verification_base_url"),
+            issuer_from_proxy_headers=oauth.get("issuer_from_proxy_headers", False),
             audience=oauth.get("audience", "default"),
             token_expiry_minutes=oauth.get("token_expiry_minutes", 60),
             refresh_token_rotation=oauth.get("refresh_token_rotation", False),

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -548,6 +548,43 @@ _TOOLS: list[Tool] = [
                     "type": "string",
                     "description": "OAuth2/OIDC issuer URL",
                 },
+                "issuer_from_request": {
+                    "type": "boolean",
+                    "description": "Derive the issuer from each request's own Host "
+                    "header instead of the fixed 'issuer' (dev convenience for "
+                    "setups reachable under more than one hostname). MCP tools "
+                    "have no request of their own, so this only affects HTTP "
+                    "discovery/token/device-flow responses, never MCP ones.",
+                },
+                "issuer_allowlist": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Origins (e.g. 'http://localhost:8000') allowed "
+                    "to be reflected back by 'issuer_from_request'. Empty (default) "
+                    "allows any Host header. A non-matching Host falls back to the "
+                    "fixed 'issuer'.",
+                },
+                "device_verification_base_url": {
+                    "type": "string",
+                    "description": "Fixed base URL for the device flow's "
+                    "verification_uri (e.g. 'https://idp.example.com'), used "
+                    "instead of the request-derived issuer so a backend/container "
+                    "caller's Host doesn't leak into a URL a human's browser can't "
+                    "reach. Only consulted when 'issuer_from_request' is on; empty "
+                    "string clears it back to following the request Host.",
+                },
+                "issuer_from_proxy_headers": {
+                    "type": "boolean",
+                    "description": "Trust 'X-Forwarded-Proto'/'X-Forwarded-Host'/"
+                    "'X-Forwarded-For' from a single reverse-proxy hop in front of "
+                    "NanoIDP (applies werkzeug's ProxyFix). Only affects the "
+                    "'issuer_from_request' derivation - and only when that toggle "
+                    "is also on; it always affects rate-limit client IP "
+                    "attribution regardless. Only enable this when NanoIDP is "
+                    "deployed directly behind exactly one trusted proxy - these "
+                    "headers are otherwise spoofable by any client. Takes effect "
+                    "on the next app restart, not the running process.",
+                },
                 "audience": {
                     "type": "string",
                     "description": "Default token audience",
@@ -1002,6 +1039,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         settings = config.settings
         return {
             "issuer": settings.issuer,
+            "issuer_from_request": settings.issuer_from_request,
+            "issuer_allowlist": settings.issuer_allowlist,
+            "device_verification_base_url": settings.device_verification_base_url,
+            "issuer_from_proxy_headers": settings.issuer_from_proxy_headers,
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
             "security_profile": settings.security_profile,
@@ -1040,6 +1081,22 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         if "issuer" in arguments:
             settings.issuer = arguments["issuer"]
             updated.append("issuer")
+        if "issuer_from_request" in arguments:
+            settings.issuer_from_request = arguments["issuer_from_request"]
+            updated.append("issuer_from_request")
+        if "issuer_allowlist" in arguments:
+            settings.issuer_allowlist = _normalize_str_list(
+                arguments["issuer_allowlist"], "issuer_allowlist"
+            )
+            updated.append("issuer_allowlist")
+        if "device_verification_base_url" in arguments:
+            settings.device_verification_base_url = (
+                arguments["device_verification_base_url"] or None
+            )
+            updated.append("device_verification_base_url")
+        if "issuer_from_proxy_headers" in arguments:
+            settings.issuer_from_proxy_headers = arguments["issuer_from_proxy_headers"]
+            updated.append("issuer_from_proxy_headers")
         if "audience" in arguments:
             settings.audience = arguments["audience"]
             updated.append("audience")
@@ -1096,6 +1153,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             "updated_fields": updated,
             "current_settings": {
                 "issuer": settings.issuer,
+                "issuer_from_request": settings.issuer_from_request,
+                "issuer_allowlist": settings.issuer_allowlist,
+                "device_verification_base_url": settings.device_verification_base_url,
+                "issuer_from_proxy_headers": settings.issuer_from_proxy_headers,
                 "audience": settings.audience,
                 "token_expiry_minutes": settings.token_expiry_minutes,
                 "refresh_token_rotation": settings.refresh_token_rotation,

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -128,6 +128,54 @@ class Settings(BaseModel):
 
     # OAuth
     issuer: str = Field(default="http://localhost:8000", description="OAuth issuer URL")
+    issuer_from_request: bool = Field(
+        default=False,
+        description="Derive the issuer (discovery 'issuer', token 'iss', device "
+        "verification_uri) from each request's own Host header instead of the "
+        "fixed 'issuer' above. Lets the same NanoIDP be reachable under more "
+        "than one hostname (e.g. Docker Compose service name vs. localhost) "
+        "without a discovery/token issuer mismatch. Off by default; the MCP "
+        "tools have no request to derive from and always report the fixed "
+        "'issuer'. The Host header is trusted as-is unless 'issuer_allowlist' "
+        "below is non-empty - only enable this on trusted networks. The device "
+        "flow's verification_uri follows the same derivation unless "
+        "'device_verification_base_url' below overrides it - see that field "
+        "when a backend/container Host would otherwise leak into a URL the "
+        "human's own browser can't reach.",
+    )
+    issuer_allowlist: List[str] = Field(
+        default_factory=list,
+        description="Origins (scheme+host[:port], e.g. 'http://localhost:8000') "
+        "allowed to be reflected back by 'issuer_from_request'. Empty (default) "
+        "allows any Host header, matching prior behavior. When non-empty, a "
+        "request whose Host doesn't match falls back to the fixed 'issuer' "
+        "instead of trusting an arbitrary Host header.",
+    )
+    device_verification_base_url: Optional[str] = Field(
+        default=None,
+        description="Fixed base URL for the device flow's verification_uri "
+        "(e.g. 'https://idp.example.com'), used instead of the request-derived "
+        "issuer. Discovery's 'issuer' and a token's 'iss' must match the "
+        "request that fetched/requested them, but the device flow's "
+        "verification_uri is opened by a human, often on a different host "
+        "than whatever backend/container called /device_authorization - set "
+        "this to pin it to a hostname the human can actually reach. Only "
+        "consulted when 'issuer_from_request' is on; ignored otherwise.",
+    )
+    issuer_from_proxy_headers: bool = Field(
+        default=False,
+        description="Trust 'X-Forwarded-Proto'/'X-Forwarded-Host'/'X-Forwarded-For' "
+        "from a single reverse proxy hop in front of NanoIDP (applies werkzeug's "
+        "ProxyFix). Fixes 'request.scheme'/'host_url', which the "
+        "'issuer_from_request' derivation above depends on - has no visible "
+        "effect on the issuer/iss/verification_uri unless 'issuer_from_request' "
+        "is also on. Also affects rate-limit client IPs regardless. Off by "
+        "default; only enable this when NanoIDP is deployed directly behind "
+        "exactly one trusted proxy, since these headers are otherwise trivially "
+        "spoofable by any client. ProxyFix is wired at app startup, so a value "
+        "changed at runtime (e.g. via the MCP update_settings tool) only takes "
+        "effect after the process restarts.",
+    )
     audience: str = Field(default="default", min_length=1, description="OAuth audience")
     token_expiry_minutes: int = Field(default=60, gt=0, le=1440, description="Token expiry in minutes")
     refresh_token_rotation: bool = Field(

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -126,6 +126,7 @@ def get_configuration() -> ResponseReturnValue:
         },
         "oauth": {
             "issuer": settings.issuer,
+            "issuer_from_request": settings.issuer_from_request,
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
             "clients_count": len(settings.clients),

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -12,7 +12,7 @@ import jwt as pyjwt
 from flask import Blueprint, abort, jsonify, redirect, render_template, request, session
 from flask.typing import ResponseReturnValue
 
-from ..config import ConfigManager, User, get_config
+from ..config import ConfigManager, Settings, User, get_config
 from ..services import (
     DevicePollOutcome,
     DeviceVerifyOutcome,
@@ -66,11 +66,39 @@ def _parse_claims_parameter(raw: Optional[str]) -> Optional[Dict[str, list]]:
 
 
 
+def _effective_issuer(settings: Settings) -> str:
+    """The issuer for the current request: fixed, unless opted into reflecting
+    how this request actually reached NanoIDP.
+
+    Docker Compose / multi-hostname dev setups often make the same NanoIDP
+    reachable at more than one hostname (e.g. ``nanoidp:9900`` from other
+    containers, ``localhost:9900`` from the host browser), each of which must
+    see a matching issuer: OIDC Discovery requires the document's ``issuer``
+    to exactly equal the URL it was fetched from, and a token's ``iss`` must
+    match what discovery advertised. Off by default, so every existing
+    deployment keeps its fixed, configured issuer.
+
+    When ``issuer_allowlist`` is non-empty, a request whose Host doesn't match
+    any allowed origin falls back to the fixed ``issuer`` rather than
+    reflecting an arbitrary Host header.
+    """
+    if not settings.issuer_from_request:
+        return settings.issuer
+    candidate = request.host_url.rstrip("/")
+    if settings.issuer_allowlist and candidate not in settings.issuer_allowlist:
+        return settings.issuer
+    return candidate
+
+
 @oauth_bp.route("/.well-known/openid-configuration")
 def oidc_config() -> ResponseReturnValue:
     """OIDC Discovery endpoint."""
     config = get_config()
-    return jsonify(build_discovery_document(config.settings))
+    return jsonify(
+        build_discovery_document(
+            config.settings, issuer=_effective_issuer(config.settings)
+        )
+    )
 
 
 @oauth_bp.route("/.well-known/jwks.json")
@@ -950,6 +978,7 @@ def token() -> ResponseReturnValue:
         refresh_family=result.refresh_family,
         id_token_claims=result.id_token_claims,
         userinfo_claims=result.userinfo_claims,
+        issuer=_effective_issuer(config.settings),
     )
 
     # Audit log
@@ -1368,8 +1397,17 @@ def device_authorization() -> ResponseReturnValue:
 
     logger.info(f"Device authorization initiated, user_code: {user_code}")
 
-    # Build verification URI
-    verification_uri = f"{config.settings.issuer}/device"
+    # Build verification URI. device_verification_base_url overrides the
+    # request-derived issuer here so a backend/container caller's Host
+    # doesn't leak into a URL the human's own browser can't reach.
+    settings = config.settings
+    verification_base = settings.issuer
+    if settings.issuer_from_request:
+        verification_base = (
+            settings.device_verification_base_url
+            or _effective_issuer(settings)
+        )
+    verification_uri = f"{verification_base}/device"
     verification_uri_complete = f"{verification_uri}?user_code={user_code}"
 
     return jsonify({

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -503,6 +503,13 @@ def settings() -> ResponseReturnValue:
         # OAuth settings
         yaml_writer.update_oauth_settings(
             issuer=request.form.get("issuer"),
+            issuer_from_request=request.form.get("issuer_from_request") == "true",
+            issuer_allowlist=_parse_textarea_list(
+                request.form.get("issuer_allowlist", "")
+            ),
+            device_verification_base_url=request.form.get(
+                "device_verification_base_url", ""
+            ).strip(),
             audience=request.form.get("audience"),
             token_expiry_minutes=int(request.form.get("token_expiry_minutes", 60)),
             require_pkce=request.form.get("require_pkce") == "true",

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -96,6 +96,16 @@ def apply_settings_document(
 
     oauth = document.setdefault("oauth", {})
     oauth["issuer"] = settings.issuer
+    oauth["issuer_from_request"] = settings.issuer_from_request
+    if settings.issuer_allowlist:
+        oauth["issuer_allowlist"] = settings.issuer_allowlist
+    else:
+        oauth.pop("issuer_allowlist", None)
+    if settings.device_verification_base_url:
+        oauth["device_verification_base_url"] = settings.device_verification_base_url
+    else:
+        oauth.pop("device_verification_base_url", None)
+    oauth["issuer_from_proxy_headers"] = settings.issuer_from_proxy_headers
     oauth["audience"] = settings.audience
     oauth["token_expiry_minutes"] = settings.token_expiry_minutes
     oauth["refresh_token_rotation"] = settings.refresh_token_rotation

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -7,12 +7,14 @@ drift apart (issue #40 - the MCP tool used to return an abbreviated dict that
 omitted ``claims_supported``/``azp`` and the auth-method metadata).
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from ..config import Settings
 
 
-def build_discovery_document(settings: Settings) -> Dict[str, Any]:
+def build_discovery_document(
+    settings: Settings, issuer: Optional[str] = None
+) -> Dict[str, Any]:
     """Build the OIDC discovery metadata for the given settings.
 
     Every value advertised here must reflect what the endpoints actually
@@ -20,8 +22,14 @@ def build_discovery_document(settings: Settings) -> Dict[str, Any]:
     entry is worse than a missing feature (see issue #41: ``token`` was
     advertised in ``response_types_supported`` while ``/authorize`` only
     accepts ``code``).
+
+    ``issuer`` lets a caller with a live request override ``settings.issuer``
+    (``issuer_from_request``, so the same NanoIDP can advertise a different,
+    per-request-correct issuer at more than one hostname). Callers with no
+    request of their own - the MCP ``get_oidc_discovery`` tool - omit it and
+    always get the fixed, configured issuer back.
     """
-    issuer = settings.issuer
+    issuer = issuer or settings.issuer
     return {
         "issuer": issuer,
         "authorization_endpoint": f"{issuer}/authorize",

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -216,6 +216,7 @@ class TokenService:
         refresh_family: Optional[str] = None,
         id_token_claims: Optional[List[str]] = None,
         userinfo_claims: Optional[List[str]] = None,
+        issuer: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user.
 
@@ -231,8 +232,15 @@ class TokenService:
         are stamped on the access token so ``/userinfo`` can honour them. Both
         lists are also persisted in the refresh token (like ``scope`` and
         ``auth_time``), so refreshed tokens keep honouring the request (#112).
+
+        ``issuer`` overrides ``settings.issuer`` for the ``iss`` claim on every
+        token minted here (access, ID, refresh), so it must be whatever the
+        caller's own discovery document just advertised (``issuer_from_request``)
+        - a token whose ``iss`` doesn't match what discovery said is rejected by
+        any spec-compliant client.
         """
         settings = self.config.settings
+        effective_issuer = issuer or settings.issuer
 
         if exp_minutes is None:
             exp_minutes = settings.token_expiry_minutes
@@ -299,7 +307,7 @@ class TokenService:
         # Create access token JWT
         token = self.crypto.create_jwt(
             sub=user.username,
-            issuer=settings.issuer,
+            issuer=effective_issuer,
             audience=settings.audience,
             roles=user.roles,
             tenant=user.tenant,
@@ -341,7 +349,7 @@ class TokenService:
                     id_extra.setdefault(claim_name, value)
             id_token = self.crypto.create_jwt(
                 sub=user.username,
-                issuer=settings.issuer,
+                issuer=effective_issuer,
                 audience=id_aud,
                 exp_minutes=exp_minutes,
                 nonce=nonce,
@@ -376,7 +384,7 @@ class TokenService:
         refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
         refresh_token = self.crypto.create_jwt(
             sub=user.username,
-            issuer=settings.issuer,
+            issuer=effective_issuer,
             audience=settings.audience,
             roles=user.roles,
             tenant=user.tenant,

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -156,6 +156,9 @@ class YamlWriter:
     def update_oauth_settings(
         self,
         issuer: Optional[str] = None,
+        issuer_from_request: Optional[bool] = None,
+        issuer_allowlist: Optional[List[str]] = None,
+        device_verification_base_url: Optional[str] = None,
         audience: Optional[str] = None,
         token_expiry_minutes: Optional[int] = None,
         require_pkce: Optional[bool] = None,
@@ -167,6 +170,18 @@ class YamlWriter:
 
         if issuer is not None:
             oauth["issuer"] = issuer
+        if issuer_from_request is not None:
+            oauth["issuer_from_request"] = issuer_from_request
+        if issuer_allowlist is not None:
+            if issuer_allowlist:
+                oauth["issuer_allowlist"] = issuer_allowlist
+            else:
+                oauth.pop("issuer_allowlist", None)
+        if device_verification_base_url is not None:
+            if device_verification_base_url:
+                oauth["device_verification_base_url"] = device_verification_base_url
+            else:
+                oauth.pop("device_verification_base_url", None)
         if audience is not None:
             oauth["audience"] = audience
         if token_expiry_minutes is not None:

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -24,6 +24,30 @@
                     </div>
 
                     <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="issuer_from_request" name="issuer_from_request" value="true"
+                                   {% if settings.issuer_from_request %}checked{% endif %}>
+                            <label class="form-check-label" for="issuer_from_request">Derive Issuer from Request</label>
+                        </div>
+                        <div class="form-text">Use each request's own Host header instead of the Issuer URL above (discovery, tokens, device flow all agree per-hostname; dev convenience for setups reachable under more than one hostname).</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="issuer_allowlist" class="form-label">Issuer Allowlist</label>
+                        <textarea class="form-control" id="issuer_allowlist" name="issuer_allowlist"
+                                  rows="2" placeholder="One origin per line, e.g. http://localhost:8000">{{ settings.issuer_allowlist | join('\n') }}</textarea>
+                        <div class="form-text">Origins allowed to be reflected back by "Derive Issuer from Request". Empty = allow any Host header (dev convenience). A non-matching Host falls back to the Issuer URL above.</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="device_verification_base_url" class="form-label">Device Verification Base URL</label>
+                        <input type="url" class="form-control" id="device_verification_base_url" name="device_verification_base_url"
+                               value="{{ settings.device_verification_base_url or '' }}" placeholder="https://idp.example.com (optional)">
+                        <div class="form-text">Overrides the device flow's verification_uri when "Derive Issuer from Request" is on, so a backend/container caller's Host doesn't leak into a URL the human's browser can't reach. Leave blank to keep following the request Host.</div>
+                    </div>
+
+                    <div class="mb-3">
                         <label for="audience" class="form-label">Audience</label>
                         <input type="text" class="form-control" id="audience" name="audience"
                                value="{{ settings.audience }}">
@@ -252,6 +276,10 @@ function updatePreview() {
     const preview = {
         oauth: {
             issuer: document.getElementById('issuer').value,
+            issuer_from_request: document.getElementById('issuer_from_request').checked,
+            issuer_allowlist: document.getElementById('issuer_allowlist').value
+                .split('\n').map(s => s.trim()).filter(s => s),
+            device_verification_base_url: document.getElementById('device_verification_base_url').value.trim(),
             audience: document.getElementById('audience').value,
             token_expiry_minutes: parseInt(document.getElementById('token_expiry_minutes').value) || 60,
             require_pkce: document.getElementById('require_pkce').checked,

--- a/tests/test_issuer_from_proxy_headers.py
+++ b/tests/test_issuer_from_proxy_headers.py
@@ -1,0 +1,179 @@
+"""
+Tests for ``oauth.issuer_from_proxy_headers`` - trust a single reverse-proxy hop's
+``X-Forwarded-Proto``/``X-Forwarded-Host``/``X-Forwarded-For`` headers (via
+werkzeug's ProxyFix).
+
+Off by default, so ``request.scheme``/``host_url`` (and therefore
+``issuer_from_request``, which depends on them) reflect the connection
+NanoIDP itself sees, not the client-supplied forwarding headers - which are
+otherwise trivially spoofable. Opted in, they're combined with
+``issuer_from_request`` here since that's the only user-visible signal that
+observes ``request.host_url``.
+"""
+
+import json
+
+import pytest
+import yaml
+
+from nanoidp.app import create_app
+from nanoidp.config import get_config
+from nanoidp.mcp_server import _execute_tool
+
+
+def _write_settings(tmp_path, oauth_overrides=None):
+    data = {
+        "server": {"host": "0.0.0.0", "port": 8000},
+        "oauth": {
+            "issuer": "http://localhost:8000",
+            "audience": "my-app",
+            "token_expiry_minutes": 60,
+            "clients": [],
+            **(oauth_overrides or {}),
+        },
+    }
+    (tmp_path / "settings.yaml").write_text(yaml.safe_dump(data))
+
+
+class TestIssuerFromProxyHeadersOff:
+    def test_default_is_off(self, tmp_path):
+        _write_settings(tmp_path)
+        app = create_app(config_dir=str(tmp_path))
+        with app.app_context():
+            assert get_config().settings.issuer_from_proxy_headers is False
+
+    def test_discovery_ignores_forwarded_headers_by_default(self, tmp_path):
+        _write_settings(tmp_path, oauth_overrides={"issuer_from_request": True})
+        app = create_app(config_dir=str(tmp_path))
+        client = app.test_client()
+
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={
+                "Host": "internal:8000",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "idp.example.com",
+            },
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://internal:8000"
+
+
+class TestIssuerFromProxyHeadersOn:
+    def test_forwarded_headers_flip_discovery_issuer(self, tmp_path):
+        _write_settings(
+            tmp_path,
+            oauth_overrides={"issuer_from_proxy_headers": True, "issuer_from_request": True},
+        )
+        app = create_app(config_dir=str(tmp_path))
+        client = app.test_client()
+
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={
+                "Host": "internal:8000",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "idp.example.com",
+            },
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "https://idp.example.com"
+        assert doc["jwks_uri"] == "https://idp.example.com/.well-known/jwks.json"
+
+    def test_without_forwarded_headers_falls_back_to_actual_connection(self, tmp_path):
+        _write_settings(
+            tmp_path,
+            oauth_overrides={"issuer_from_proxy_headers": True, "issuer_from_request": True},
+        )
+        app = create_app(config_dir=str(tmp_path))
+        client = app.test_client()
+
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "internal:8000"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://internal:8000"
+
+    def test_health_endpoint_unaffected(self, tmp_path):
+        """Sanity check that enabling the middleware doesn't break plain requests."""
+        _write_settings(tmp_path, oauth_overrides={"issuer_from_proxy_headers": True})
+        app = create_app(config_dir=str(tmp_path))
+        client = app.test_client()
+
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
+class TestIssuerFromProxyHeadersWithIssuerAllowlist:
+    """issuer_allowlist is checked against the proxy-derived origin, not the
+    raw (untrusted) Host header the request actually arrived with."""
+
+    def test_allowlist_matches_the_forwarded_origin(self, tmp_path):
+        _write_settings(
+            tmp_path,
+            oauth_overrides={
+                "issuer_from_proxy_headers": True,
+                "issuer_from_request": True,
+                "issuer_allowlist": ["https://idp.example.com"],
+            },
+        )
+        app = create_app(config_dir=str(tmp_path))
+        client = app.test_client()
+
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={
+                "Host": "internal:8000",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "idp.example.com",
+            },
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "https://idp.example.com"
+
+    def test_allowlist_rejects_a_forwarded_origin_not_listed(self, tmp_path):
+        _write_settings(
+            tmp_path,
+            oauth_overrides={
+                "issuer_from_proxy_headers": True,
+                "issuer_from_request": True,
+                "issuer_allowlist": ["https://idp.example.com"],
+            },
+        )
+        app = create_app(config_dir=str(tmp_path))
+        client = app.test_client()
+
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={
+                "Host": "internal:8000",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "evil.example.com",
+            },
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://localhost:8000"
+
+
+class TestIssuerFromProxyHeadersMcp:
+    """MCP get_settings/update_settings mirror the toggle, like every other
+    oauth.* setting. Since ProxyFix is wired at Flask app construction, a
+    value flipped at runtime here only takes effect after the process
+    restarts - update_settings still records the change for save_config."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_settings_reports_it(self, app):
+        with app.app_context():
+            assert get_config().settings.issuer_from_proxy_headers is False
+        result = await _execute_tool("get_settings", {}, get_config())
+        assert result["issuer_from_proxy_headers"] is False
+
+    @pytest.mark.asyncio
+    async def test_mcp_update_settings_sets_it(self, app):
+        result = await _execute_tool(
+            "update_settings", {"issuer_from_proxy_headers": True}, get_config()
+        )
+        assert result["success"] is True
+        assert result["current_settings"]["issuer_from_proxy_headers"] is True
+        assert get_config().settings.issuer_from_proxy_headers is True

--- a/tests/test_issuer_from_request.py
+++ b/tests/test_issuer_from_request.py
@@ -1,0 +1,310 @@
+"""
+Tests for ``oauth.issuer_from_request`` - reflect the issuer with respect to
+how NanoIDP was actually reached, rather than always the fixed configured
+value.
+
+Off by default, so discovery, tokens, and the device flow all keep reporting
+the fixed ``settings.issuer`` unchanged. Opted in, all three follow the
+incoming request's own Host header instead, so the same NanoIDP can be
+reachable at more than one hostname (e.g. a Docker Compose service name from
+other containers, ``localhost`` from the host browser) without ending up
+with a discovery ``issuer`` that disagrees with a token's ``iss`` - both OIDC
+Discovery and ID Token validation require an exact match.
+
+The MCP tools have no HTTP request of their own to derive a host from, so
+they always report the fixed ``settings.issuer`` regardless of this setting
+- a deliberate, narrow exception to the discovery-parity guarantee asserted
+in ``test_discovery_parity.py`` (which only exercises the default, off,
+case).
+"""
+
+import json
+
+import jwt as pyjwt
+import pytest
+
+from nanoidp.config import get_config
+from nanoidp.mcp_server import _execute_tool
+
+
+class TestDefaultBehaviorUnchanged:
+    def test_default_is_off(self, app):
+        with app.app_context():
+            assert get_config().settings.issuer_from_request is False
+
+    def test_discovery_issuer_ignores_host_header_by_default(self, client):
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "nanoidp:9900"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == get_config().settings.issuer
+
+    def test_device_verification_uri_ignores_host_header_by_default(
+        self, client, auth_header
+    ):
+        resp = client.post(
+            "/device_authorization",
+            data={"scope": "openid"},
+            headers={**auth_header, "Host": "nanoidp:9900"},
+        )
+        data = json.loads(resp.data)
+        assert data["verification_uri"] == f"{get_config().settings.issuer}/device"
+
+
+class TestIssuerFromRequest:
+    @pytest.fixture(autouse=True)
+    def enable(self, app):
+        with app.app_context():
+            get_config().settings.issuer_from_request = True
+        yield
+
+    def test_discovery_issuer_reflects_host_header(self, client):
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "nanoidp:9900"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://nanoidp:9900"
+        assert doc["jwks_uri"] == "http://nanoidp:9900/.well-known/jwks.json"
+        assert doc["token_endpoint"] == "http://nanoidp:9900/token"
+
+    def test_discovery_issuer_reflects_a_different_host_header(self, client):
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "localhost:9900"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://localhost:9900"
+
+    def test_token_iss_matches_discovery_for_the_same_host(self, client, auth_header):
+        host = "nanoidp:9900"
+        discovery = json.loads(
+            client.get(
+                "/.well-known/openid-configuration", headers={"Host": host}
+            ).data
+        )
+
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={**auth_header, "Host": host},
+        )
+        tokens = json.loads(response.data)
+        payload = pyjwt.decode(
+            tokens["access_token"], options={"verify_signature": False}
+        )
+
+        assert payload["iss"] == discovery["issuer"] == f"http://{host}"
+
+    def test_device_verification_uri_reflects_host_header(self, client, auth_header):
+        host = "nanoidp:9900"
+        resp = client.post(
+            "/device_authorization",
+            data={"scope": "openid"},
+            headers={**auth_header, "Host": host},
+        )
+        data = json.loads(resp.data)
+        assert data["verification_uri"] == f"http://{host}/device"
+        assert data["verification_uri_complete"].startswith(data["verification_uri"])
+
+
+class TestMcpToolsUnaffected:
+    """MCP tools have no request to derive a host from - the fixed issuer is
+    the only value they can report, on or off."""
+
+    @pytest.fixture(autouse=True)
+    def enable(self, app):
+        with app.app_context():
+            get_config().settings.issuer_from_request = True
+        yield
+
+    @pytest.mark.asyncio
+    async def test_mcp_discovery_still_reports_fixed_issuer(self):
+        doc = await _execute_tool("get_oidc_discovery", {}, get_config())
+        assert doc["issuer"] == get_config().settings.issuer
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_settings_reports_the_toggle(self):
+        result = await _execute_tool("get_settings", {}, get_config())
+        assert result["issuer_from_request"] is True
+
+
+class TestIssuerAllowlist:
+    """``issuer_allowlist`` narrows ``issuer_from_request``: a Host that
+    doesn't match an allowed origin falls back to the fixed ``issuer``
+    instead of trusting an arbitrary Host header. Empty (the default) keeps
+    prior behavior - any Host is reflected.
+    """
+
+    @pytest.fixture(autouse=True)
+    def enable(self, app):
+        with app.app_context():
+            get_config().settings.issuer_from_request = True
+        yield
+
+    def test_empty_allowlist_allows_any_host(self, client):
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "anyhost:9900"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://anyhost:9900"
+
+    def test_matching_host_is_reflected(self, app, client):
+        with app.app_context():
+            get_config().settings.issuer_allowlist = ["http://nanoidp:9900"]
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "nanoidp:9900"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://nanoidp:9900"
+
+    def test_non_matching_host_falls_back_to_fixed_issuer(self, app, client):
+        with app.app_context():
+            get_config().settings.issuer_allowlist = ["http://nanoidp:9900"]
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "evil.example.com"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == get_config().settings.issuer
+
+    def test_token_iss_falls_back_when_host_not_allowlisted(
+        self, app, client, auth_header
+    ):
+        with app.app_context():
+            get_config().settings.issuer_allowlist = ["http://nanoidp:9900"]
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={**auth_header, "Host": "evil.example.com"},
+        )
+        tokens = json.loads(resp.data)
+        payload = pyjwt.decode(
+            tokens["access_token"], options={"verify_signature": False}
+        )
+        assert payload["iss"] == get_config().settings.issuer
+
+    def test_device_verification_uri_falls_back_when_host_not_allowlisted(
+        self, app, client, auth_header
+    ):
+        with app.app_context():
+            get_config().settings.issuer_allowlist = ["http://nanoidp:9900"]
+        resp = client.post(
+            "/device_authorization",
+            data={"scope": "openid"},
+            headers={**auth_header, "Host": "evil.example.com"},
+        )
+        data = json.loads(resp.data)
+        assert data["verification_uri"] == f"{get_config().settings.issuer}/device"
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_settings_reports_allowlist(self, app):
+        with app.app_context():
+            get_config().settings.issuer_allowlist = ["http://nanoidp:9900"]
+        result = await _execute_tool("get_settings", {}, get_config())
+        assert result["issuer_allowlist"] == ["http://nanoidp:9900"]
+
+    @pytest.mark.asyncio
+    async def test_mcp_update_settings_normalizes_allowlist(self, app):
+        result = await _execute_tool(
+            "update_settings",
+            {"issuer_allowlist": ["http://nanoidp:9900", ""]},
+            get_config(),
+        )
+        assert result["success"] is True
+        assert get_config().settings.issuer_allowlist == ["http://nanoidp:9900"]
+
+
+class TestDeviceVerificationBaseUrl:
+    """``device_verification_base_url`` pins the device flow's
+    verification_uri to a human-reachable host, decoupled from whichever
+    Host called ``/device_authorization`` (a backend/container caller's Host
+    would otherwise leak into a URL the human's own browser can't open).
+    """
+
+    def test_default_is_none(self, app):
+        with app.app_context():
+            assert get_config().settings.device_verification_base_url is None
+
+    def test_overrides_verification_uri_regardless_of_calling_host(
+        self, app, client, auth_header
+    ):
+        with app.app_context():
+            get_config().settings.issuer_from_request = True
+            get_config().settings.device_verification_base_url = (
+                "https://idp.example.com"
+            )
+        resp = client.post(
+            "/device_authorization",
+            data={"scope": "openid"},
+            headers={**auth_header, "Host": "nanoidp:9900"},
+        )
+        data = json.loads(resp.data)
+        assert data["verification_uri"] == "https://idp.example.com/device"
+
+    def test_does_not_affect_discovery_issuer_or_token_iss(
+        self, app, client, auth_header
+    ):
+        """Only the device flow's verification_uri is overridden - discovery
+        and tokens must still match the request that fetched/requested them."""
+        with app.app_context():
+            get_config().settings.issuer_from_request = True
+            get_config().settings.device_verification_base_url = (
+                "https://idp.example.com"
+            )
+        resp = client.get(
+            "/.well-known/openid-configuration",
+            headers={"Host": "nanoidp:9900"},
+        )
+        doc = json.loads(resp.data)
+        assert doc["issuer"] == "http://nanoidp:9900"
+
+    def test_ignored_when_issuer_from_request_is_off(
+        self, app, client, auth_header
+    ):
+        with app.app_context():
+            get_config().settings.device_verification_base_url = (
+                "https://idp.example.com"
+            )
+        resp = client.post(
+            "/device_authorization",
+            data={"scope": "openid"},
+            headers={**auth_header, "Host": "nanoidp:9900"},
+        )
+        data = json.loads(resp.data)
+        assert data["verification_uri"] == f"{get_config().settings.issuer}/device"
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_settings_reports_it(self, app):
+        with app.app_context():
+            get_config().settings.device_verification_base_url = (
+                "https://idp.example.com"
+            )
+        result = await _execute_tool("get_settings", {}, get_config())
+        assert result["device_verification_base_url"] == "https://idp.example.com"
+
+    @pytest.mark.asyncio
+    async def test_mcp_update_settings_sets_and_clears_it(self, app):
+        result = await _execute_tool(
+            "update_settings",
+            {"device_verification_base_url": "https://idp.example.com"},
+            get_config(),
+        )
+        assert result["success"] is True
+        assert (
+            get_config().settings.device_verification_base_url
+            == "https://idp.example.com"
+        )
+
+        result = await _execute_tool(
+            "update_settings",
+            {"device_verification_base_url": ""},
+            get_config(),
+        )
+        assert result["success"] is True
+        assert get_config().settings.device_verification_base_url is None
+
+

--- a/tests/test_ui_oauth_settings.py
+++ b/tests/test_ui_oauth_settings.py
@@ -59,6 +59,43 @@ class TestOAuthTogglesRoundTrip:
         assert config.settings.require_pkce is False
         assert config.settings.refresh_token_rotation is False
 
+
+class TestIssuerAllowlistRoundTrip:
+    def test_allowlist_persists_as_a_list(self, client, preserve_config_files):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+
+        response = client.post(
+            "/settings",
+            data={
+                **_base_form(config.settings),
+                "issuer_allowlist": "http://localhost:8000\nhttp://nanoidp:9900",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        config.reload()
+        assert config.settings.issuer_allowlist == [
+            "http://localhost:8000",
+            "http://nanoidp:9900",
+        ]
+
+    def test_blank_allowlist_clears_it(self, client, preserve_config_files):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+        config.settings.issuer_allowlist = ["http://nanoidp:9900"]
+
+        response = client.post(
+            "/settings",
+            data=_base_form(config.settings),  # issuer_allowlist absent
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        config.reload()
+        assert config.settings.issuer_allowlist == []
+
     def test_settings_page_renders_the_toggles(self, client):
         with client.session_transaction() as sess:
             sess["user"] = "admin"
@@ -66,3 +103,37 @@ class TestOAuthTogglesRoundTrip:
         assert r.status_code == 200
         assert b'name="require_pkce"' in r.data
         assert b'name="refresh_token_rotation"' in r.data
+
+
+class TestDeviceVerificationBaseUrlRoundTrip:
+    def test_value_persists(self, client, preserve_config_files):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+
+        response = client.post(
+            "/settings",
+            data={
+                **_base_form(config.settings),
+                "device_verification_base_url": "https://idp.example.com",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        config.reload()
+        assert config.settings.device_verification_base_url == "https://idp.example.com"
+
+    def test_blank_value_clears_it(self, client, preserve_config_files):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+        config.settings.device_verification_base_url = "https://idp.example.com"
+
+        response = client.post(
+            "/settings",
+            data=_base_form(config.settings),  # device_verification_base_url absent
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        config.reload()
+        assert config.settings.device_verification_base_url is None


### PR DESCRIPTION
- **`oauth.issuer_from_request`** (off by default): when enabled, the
  discovery document's `issuer`, every minted token's `iss`, and the device
  flow's `verification_uri` are derived from the incoming request's own Host
  header instead of the fixed `oauth.issuer`. Lets the same NanoIDP be
  reachable under more than one hostname (e.g. a Docker Compose service name
  from other containers and `localhost` from the host browser) without a
  discovery/token issuer mismatch - each hostname advertises and issues
  tokens against itself. The MCP `get_oidc_discovery`/`get_settings` tools
  have no request of their own and always report the fixed `issuer`.