### PR TITLE
chore(mcp): consolidate isError contract, precompile validators, real-protocol tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same check itself and returns an `is_error: true` result (`code:
   "MCP_INVALID_ARGUMENTS"`) instead of letting a missing required field reach
   the tool implementation as a bare `KeyError`.
+- **Consolidated the MCP `isError` contract** (#120): the rule is now written
+  once as a table in the `mcp_server` module docstring (a negative query answer
+  is not a failure) and the code follows it. `verify_token` on an invalid token
+  returns `{"valid": false, "reason": ...}` (was `error`) so a rejected token,
+  the tool's designed answer, is no longer flagged `is_error`. A domain-failure
+  audit entry now records the failure reason instead of only the tool name; the
+  uncaught-exception path now carries a `code` (`MCP_INTERNAL_ERROR`) and `tool`
+  like the guard rejections; and `_execute_tool`'s unreachable unknown-tool
+  fallback now raises rather than returning a divergent shape. The MCP audit
+  `details` codes are namespaced (`MCP_READONLY_MODE`,
+  `MCP_ADMIN_SECRET_REQUIRED`, `MCP_UNKNOWN_TOOL`, `MCP_INVALID_ARGUMENTS`),
+  observable via `get_audit_log` and `/api/audit`.
+- **Precompiled MCP tool-argument validators** (#121): each tool's JSON Schema
+  is compiled once at import (`Draft202012Validator`) instead of being
+  recompiled on every `tools/call`, which also surfaces a malformed schema at
+  import time. The direct `jsonschema` floor is raised to `>=4.20.0` to match
+  what mcp 2.0 already resolves.
+- **MCP tests drive the real protocol** (#122): the test harness now calls
+  tools through the mcp 2.0 in-memory client (real SDK dispatch and result
+  serialization) instead of invoking the lowlevel handlers with a fake request
+  context, so wire-level regressions fail the suite instead of only breaking a
+  real client.
 
 ## [2.5.0] - 2026-07-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "bcrypt>=5.0.0",
     # Used directly by mcp_server.call_tool() to validate arguments against a
     # tool's input_schema; mcp 2.0's on_call_tool no longer does this itself.
-    "jsonschema>=4.0.0",
+    "jsonschema>=4.20.0",
 ]
 
 [project.optional-dependencies]

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -763,8 +763,13 @@ _TOOLS: list[Tool] = [
 ]
 
 _TOOL_SCHEMAS: dict[str, dict[str, Any]] = {tool.name: tool.input_schema for tool in _TOOLS}
-# Compile each tool's schema once at import (surfacing a malformed schema here
-# rather than on the first tools/call) instead of recompiling on every call.
+# Compile each tool's schema once at import instead of recompiling on every
+# call. check_schema() comes first because the constructor assumes its schema
+# is already valid (per the jsonschema docs); only the explicit check makes a
+# malformed tool schema fail here, at import, rather than behave undefined on
+# the first tools/call.
+for _schema in _TOOL_SCHEMAS.values():
+    Draft202012Validator.check_schema(_schema)
 _TOOL_VALIDATORS: dict[str, Draft202012Validator] = {
     name: Draft202012Validator(schema) for name, schema in _TOOL_SCHEMAS.items()
 }

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -11,6 +11,27 @@ Security Note:
       the admin_secret parameter to match.
     - When --readonly flag or NANOIDP_MCP_READONLY=true, mutating tools
       are completely disabled.
+
+isError contract:
+    A tool result is flagged ``is_error=True`` only when the call failed. A
+    query that answers negatively is NOT a failure. call_tool applies this
+    once, via ``failed = result.get("success") is False or "error" in result``.
+
+    | Outcome                                    | key           | is_error |
+    |--------------------------------------------|---------------|----------|
+    | success                                    | success/data  | False    |
+    | negative query (get_user/get_client miss)  | found: False  | False    |
+    | negative query (verify_token invalid)      | valid: False  | False    |
+    |                                            | (+ ``reason``)|          |
+    | mutation failure (not found / exists / IO) | success: False| True     |
+    |                                            | (+ ``error``) |          |
+    | guard rejection (readonly/secret/unknown/  | error + code  | True     |
+    |   bad args), via _reject                   | + tool        |          |
+    | uncaught exception                         | error + code  | True     |
+    |                                            | + tool        |          |
+
+    Negative queries must therefore avoid the top-level ``error`` key (use
+    ``reason`` / ``found``) so the heuristic does not misclassify them.
 """
 
 import argparse
@@ -20,8 +41,9 @@ import logging
 import os
 from typing import Any, Optional, Tuple
 
-import jsonschema
 import jwt as pyjwt
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import best_match
 from mcp.server import Server, ServerRequestContext
 from mcp.server.stdio import stdio_server
 from mcp.types import (
@@ -741,6 +763,11 @@ _TOOLS: list[Tool] = [
 ]
 
 _TOOL_SCHEMAS: dict[str, dict[str, Any]] = {tool.name: tool.input_schema for tool in _TOOLS}
+# Compile each tool's schema once at import (surfacing a malformed schema here
+# rather than on the first tools/call) instead of recompiling on every call.
+_TOOL_VALIDATORS: dict[str, Draft202012Validator] = {
+    name: Draft202012Validator(schema) for name, schema in _TOOL_SCHEMAS.items()
+}
 
 
 async def list_tools(
@@ -807,14 +834,13 @@ async def call_tool(
         # before dispatch; the 2.0 on_call_tool path does not, so it is done
         # here to keep required-field/type errors from reaching _execute_tool
         # as bare KeyErrors.
-        schema = _TOOL_SCHEMAS.get(name)
-        if schema is None:
+        validator = _TOOL_VALIDATORS.get(name)
+        if validator is None:
             return _reject(name, "MCP_UNKNOWN_TOOL", f"Unknown tool: {name}")
-        try:
-            jsonschema.validate(instance=arguments, schema=schema)
-        except jsonschema.ValidationError as e:
-            field = ".".join(str(p) for p in e.absolute_path)
-            message = f"{field}: {e.message}" if field else e.message
+        error = best_match(validator.iter_errors(arguments))
+        if error is not None:
+            field = ".".join(str(p) for p in error.absolute_path)
+            message = f"{field}: {error.message}" if field else error.message
             return _reject(name, "MCP_INVALID_ARGUMENTS", f"Input validation error: {message}")
 
         result = await _execute_tool(name, arguments, config)
@@ -822,14 +848,20 @@ async def call_tool(
         # e.g. "user not found") are results, not exceptions, so they don't
         # go through the except branch below - but they still failed and must
         # be flagged the same way (CHANGELOG: "failed MCP tool calls now set
-        # is_error: true").
+        # is_error: true"). See the isError contract in the module docstring.
         failed = result.get("success") is False or "error" in result
-        _log_mcp_tool(name, success=not failed, details={"tool": name})
+        details = {"tool": name}
+        if failed:
+            details["error"] = result.get("error") or "tool reported failure"
+        _log_mcp_tool(name, success=not failed, details=details)
         return _text_result(result, is_error=failed)
     except Exception as e:
         logger.exception(f"Error executing tool {name}")
-        _log_mcp_tool(name, success=False, details={"error": str(e)})
-        return _text_result({"error": str(e), "tool": name}, is_error=True)
+        _log_mcp_tool(name, success=False, details={"error": str(e), "tool": name})
+        return _text_result(
+            {"error": str(e), "code": "MCP_INTERNAL_ERROR", "tool": name},
+            is_error=True,
+        )
 
 
 server = Server(
@@ -962,7 +994,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             payload = crypto.verify_jwt(token, config.settings.audience)
             return {"valid": True, "claims": payload}
         except Exception as e:
-            return {"valid": False, "error": str(e)}
+            # A rejected token is verify_token's designed answer, not a tool
+            # failure: use "reason" (not "error") so call_tool does not flag
+            # the result is_error (see the isError contract in the docstring).
+            return {"valid": False, "reason": str(e)}
 
     # Client Management
     elif name == "list_clients":
@@ -1233,8 +1268,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         )
         return {"success": True, **result}
 
-    else:
-        return {"error": f"Unknown tool: {name}"}
+    # Unreachable on the protocol path: call_tool rejects an unknown name with
+    # MCP_UNKNOWN_TOOL before dispatching here. Raising (rather than returning a
+    # divergent {"error": ...} shape) makes a direct mis-call a clear bug.
+    raise ValueError(f"Unknown tool: {name}")
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ Pytest configuration and shared fixtures for NanoIDP tests.
 """
 
 import base64
-from typing import Any, Optional, cast
+from typing import Optional
 
 import pytest
 
@@ -16,24 +16,31 @@ from nanoidp.config import OAuthClient, User
 
 
 async def call_mcp_tool(name: str, arguments: Optional[dict] = None):
-    """Drive the lowlevel MCP tool handler, which takes (ctx, params).
+    """Drive tools/call through the mcp 2.0 in-memory client.
 
-    ``ctx`` is None because nanoidp's handler never reads it.
+    The client speaks the real protocol to nanoidp's ``server`` over an
+    in-memory transport - SDK dispatch, argument delivery and result
+    serialization included - instead of invoking the lowlevel handler with a
+    fake ``ctx``. Wire-level regressions (isError aliasing, result-schema
+    validation) therefore fail the suite instead of only breaking a real
+    client (#122).
     """
-    from mcp.types import CallToolRequestParams
+    from mcp import Client
 
-    from nanoidp.mcp_server import call_tool
+    from nanoidp.mcp_server import server
 
-    return await call_tool(
-        cast(Any, None), CallToolRequestParams(name=name, arguments=arguments)
-    )
+    async with Client(server) as client:
+        return await client.call_tool(name, arguments)
 
 
 async def list_mcp_tools():
-    """Drive the lowlevel MCP tools/list handler and return its Tool list."""
-    from nanoidp.mcp_server import list_tools
+    """Drive tools/list through the mcp 2.0 in-memory client (see call_mcp_tool)."""
+    from mcp import Client
 
-    return (await list_tools(cast(Any, None), None)).tools
+    from nanoidp.mcp_server import server
+
+    async with Client(server) as client:
+        return (await client.list_tools()).tools
 
 
 @pytest.fixture

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -287,6 +287,24 @@ class TestMCPHandlerRegistration:
         payload = json.loads(result.content[0].text)
         assert payload["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_verify_token_invalid_is_not_an_error(self, monkeypatch, mcp_call_tool):
+        """An invalid/expired token is verify_token's designed answer, not a
+        failed call: the result reports valid=False with a `reason` (not an
+        `error` key) and is not flagged is_error (isError contract)."""
+        import nanoidp.mcp_server as mcp
+
+        monkeypatch.setattr(mcp, "_readonly_mode", False)
+        monkeypatch.delenv("NANOIDP_MCP_ADMIN_SECRET", raising=False)
+
+        result = await mcp_call_tool("verify_token", {"token": "not-a-real-jwt"})
+
+        assert result.is_error is False
+        payload = json.loads(result.content[0].text)
+        assert payload["valid"] is False
+        assert "reason" in payload
+        assert "error" not in payload
+
 
 class TestMCPReadonlyMode:
     """Tests for MCP readonly mode behavior."""
@@ -600,8 +618,12 @@ class TestMCPClientAdditionalAudiences:
 
     @pytest.mark.asyncio
     async def test_call_tool_returns_clean_error_for_bad_audiences(self, tmp_path, monkeypatch, mcp_call_tool):
-        """The public call_tool handler turns the ValueError into a readable error
-        response (not a crash) - closing the raise/handle loop end to end."""
+        """A non-string entry in additional_audiences is caught by the schema
+        pre-check before dispatch, so call_tool returns a clean
+        MCP_INVALID_ARGUMENTS error naming the field (not a crash). The
+        _normalize_str_list ValueError path this used to exercise is now
+        unreachable via call_tool; it still guards direct _execute_tool callers
+        (see TestGenerateTokenClaims), so its isinstance branch stays."""
         import nanoidp.mcp_server as mcp
 
         monkeypatch.setattr(mcp, "_config", self._config(tmp_path))
@@ -617,6 +639,7 @@ class TestMCPClientAdditionalAudiences:
         assert result.is_error is True
         payload = json.loads(result.content[0].text)
         assert payload["tool"] == "create_client"
+        assert payload["code"] == "MCP_INVALID_ARGUMENTS"
         assert "additional_audiences" in payload["error"]
 
 


### PR DESCRIPTION
Follow-ups from the #118 review, bundled since they all touch the MCP 2.0 server and its tests.

Closes #120, closes #121, closes #122.

## #120 - consolidate the isError contract
- The contract is now written once, as a table in the `mcp_server` module docstring: a negative query answer is not a failure. `call_tool` applies it in one place.
- `verify_token` on an invalid token returns `{"valid": false, "reason": ...}` (was `error`), so a rejected token - the tool's designed answer - is no longer flagged `is_error`.
- Domain-failure audit entries now record the failure reason, not just the tool name.
- The uncaught-exception path now carries a `code` (`MCP_INTERNAL_ERROR`) and `tool`, matching the four `_reject` branches.
- `_execute_tool`'s unreachable unknown-tool fallback now raises instead of returning a divergent `{"error": ...}` shape (`call_tool` already rejects unknown names with `MCP_UNKNOWN_TOOL` before dispatch).
- The `get_user`/`get_client` (miss = `found: False`, not an error) vs mutation (miss = error) boundary is now documented rather than changed.
- The namespaced audit `details` codes (`MCP_READONLY_MODE`, ...) are documented in the CHANGELOG.

## #121 - polish
- Each tool's JSON Schema is compiled once at import (`Draft202012Validator`) instead of being recompiled on every `tools/call`; `best_match(iter_errors(...))` keeps the current message format. A malformed schema now surfaces at import.
- The direct `jsonschema` floor is raised to `>=4.20.0` to match what mcp 2.0 already resolves.
- The stale docstring on `test_call_tool_returns_clean_error_for_bad_audiences` is corrected (the schema pre-check now intercepts the bad element; the `_normalize_str_list` path it described is unreachable via `call_tool` but still guards direct `_execute_tool` callers, so its isinstance branch stays), plus an assertion on the error `code`.

## #122 - drive tests through the real protocol
- The conftest MCP helpers now call tools through the mcp 2.0 in-memory client (real SDK dispatch and result serialization) instead of invoking the lowlevel handlers with a fake request context, so wire-level regressions fail the suite instead of only breaking a real client.

## Verification
- Full suite green, mypy and ruff clean.
- The MCP suite (including the negative-query and isError-contract tests, and a new `verify_token`-invalid test) passes through the in-memory client path.
