### PR TITLE
fix: /api/config issuer companions + config-agnostic e2e agent fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on; the rate-limit effect applies regardless. Only enable this when
   NanoIDP is deployed directly behind exactly one trusted proxy - these
   headers are otherwise spoofable by any client. Readable/settable via the
-  MCP `get_settings`/`update_settings` tools; since `ProxyFix` is wired at
-  app startup, a value changed at runtime only takes effect after a restart.
+  Settings page and the MCP `get_settings`/`update_settings` tools; since
+  `ProxyFix` is wired at app startup, a value changed at runtime only takes
+  effect after a restart.
 
 ### Changed
 - **Migrated the MCP server to the mcp 2.0 SDK** and pinned `mcp>=2,<3`. mcp 2.0
@@ -85,6 +86,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same check itself and returns an `is_error: true` result (`code:
   "MCP_INVALID_ARGUMENTS"`) instead of letting a missing required field reach
   the tool implementation as a bare `KeyError`.
+
+### Fixed
+- **`/api/config` now exposes `issuer_allowlist`, `device_verification_base_url`
+  and `issuer_from_proxy_headers`** alongside `issuer_from_request`. The
+  config-agnostic e2e agent reads the allowlist from `/api/config` to predict
+  the effective issuer; without the exposure it assumed an empty allowlist and
+  failed on any server with one configured. The agent also takes its
+  fixed-issuer baseline from `/api/config`'s `oauth.issuer` now: a plain
+  discovery response reflects the request's own Host when the flag is on, so
+  it is only a valid baseline when the flag is off.
+- **`examples/test_agent.py` SAML export check honours the configured attribute
+  names**: it now reads `saml.roles_attr_name` / `saml.groups_attr_name` from
+  `/api/config` instead of assuming the default `roles` / `groups` names, so it
+  no longer fails on servers exporting under custom names.
 
 ## [2.5.0] - 2026-07-19
 

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -390,9 +390,14 @@ class NanoIDPTestAgent:
             ).json()
             observed_issuer = discovery.get("issuer")
 
-            allowlisted = not issuer_allowlist or f"http://{custom_host}" in issuer_allowlist
+            # The server reflects the request's real scheme (request.host_url),
+            # so derive it from base_url instead of hardcoding http - against
+            # an https deployment the reflected issuer is https://... too.
+            scheme = urlparse(self.base_url).scheme or "http"
+            candidate_issuer = f"{scheme}://{custom_host}"
+            allowlisted = not issuer_allowlist or candidate_issuer in issuer_allowlist
             expected_issuer = (
-                f"http://{custom_host}" if issuer_from_request and allowlisted else fixed_issuer
+                candidate_issuer if issuer_from_request and allowlisted else fixed_issuer
             )
             discovery_ok = observed_issuer == expected_issuer
 

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -367,14 +367,20 @@ class NanoIDPTestAgent:
             config_response = self.session.get(f"{self.base_url}/api/config", timeout=5)
             issuer_from_request = False
             issuer_allowlist: List[str] = []
+            fixed_issuer = None
             if config_response.status_code == 200:
                 oauth_config = config_response.json().get("oauth", {})
                 issuer_from_request = oauth_config.get("issuer_from_request", False)
                 issuer_allowlist = oauth_config.get("issuer_allowlist", []) or []
-
-            fixed_issuer = self.session.get(
-                f"{self.base_url}/.well-known/openid-configuration", timeout=5
-            ).json().get("issuer")
+                # The configured issuer is the fallback baseline. A plain
+                # discovery response is NOT: with the flag on it reflects this
+                # request's own Host, so it only equals the fixed issuer when
+                # the flag is off (or the test's host happens to match).
+                fixed_issuer = oauth_config.get("issuer")
+            if not fixed_issuer:
+                fixed_issuer = self.session.get(
+                    f"{self.base_url}/.well-known/openid-configuration", timeout=5
+                ).json().get("issuer")
 
             custom_host = "test-agent-issuer-check:9999"
             discovery = self.session.get(
@@ -2199,10 +2205,17 @@ class NanoIDPTestAgent:
 
             export_roles = False
             export_groups = False
+            roles_attr_name = "roles"
+            groups_attr_name = "groups"
             if config_response.status_code == 200:
                 saml_config = config_response.json().get("saml", {})
                 export_roles = saml_config.get("export_roles", False)
                 export_groups = saml_config.get("export_groups", False)
+                # The exported attribute names are configurable; honour them
+                # instead of assuming the defaults, or the check fails on any
+                # server with custom saml.roles_attr_name/groups_attr_name.
+                roles_attr_name = saml_config.get("roles_attr_name") or "roles"
+                groups_attr_name = saml_config.get("groups_attr_name") or "groups"
 
             attr_query = f"""
             <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
@@ -2228,8 +2241,8 @@ class NanoIDPTestAgent:
 
             if response.status_code == 200:
                 saml_response = response.text
-                has_roles = 'Name="roles"' in saml_response
-                has_groups = 'Name="groups"' in saml_response
+                has_roles = f'Name="{roles_attr_name}"' in saml_response
+                has_groups = f'Name="{groups_attr_name}"' in saml_response
 
                 roles_respected = has_roles == export_roles
                 groups_respected = has_groups == export_groups

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -127,6 +127,12 @@ def get_configuration() -> ResponseReturnValue:
         "oauth": {
             "issuer": settings.issuer,
             "issuer_from_request": settings.issuer_from_request,
+            # Companions of issuer_from_request: exposed so a config-agnostic
+            # client (examples/test_agent.py) can predict the effective issuer
+            # instead of assuming an empty allowlist.
+            "issuer_allowlist": settings.issuer_allowlist,
+            "device_verification_base_url": settings.device_verification_base_url,
+            "issuer_from_proxy_headers": settings.issuer_from_proxy_headers,
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
             "clients_count": len(settings.clients),


### PR DESCRIPTION
Findings from a toggles-ON release-readiness pass: a live run with every new opt-in setting enabled (`issuer_from_request` + allowlist + proxy headers + SAML export with custom attribute names + device verification URL override), which CI never exercises since it runs the e2e against the default config (all toggles off).

## Fixes

- **`/api/config` now exposes `issuer_allowlist`, `device_verification_base_url` and `issuer_from_proxy_headers`** alongside `issuer_from_request`. The config-agnostic e2e agent reads the allowlist from `/api/config` to predict the effective issuer; without the exposure it assumed an empty allowlist and failed on any server with one configured.
- **e2e SAML export check honours configured attribute names**: it now reads `saml.roles_attr_name` / `saml.groups_attr_name` from `/api/config` instead of assuming the default `roles` / `groups`, so it no longer fails on servers exporting under custom names.
- **e2e issuer test takes its fixed-issuer baseline from `/api/config`'s `oauth.issuer`**: a plain discovery response reflects the request's own Host whenever the flag is on, so it is only a valid baseline when the flag is off.
- CHANGELOG: the `issuer_from_proxy_headers` entry now mentions the Settings page control added in #128.

## Verification

- Live toggles-ON run: e2e agent **45/45** (was 43/45 before these fixes).
- Unit suite: 888 passed.
- Default-config behavior unchanged (the new reads fall back to the old values when absent), so the CI e2e path is unaffected.

A fourth, deeper finding from the same pass (the `/settings` POST resets every field absent from the form; the e2e C14N test triggers it and silently wipes operator config) is filed separately.