### PR TITLE
fix: POST /settings follows an absent-equals-unchanged contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names**: it now reads `saml.roles_attr_name` / `saml.groups_attr_name` from
   `/api/config` instead of assuming the default `roles` / `groups` names, so it
   no longer fails on servers exporting under custom names.
+- **`POST /settings` no longer resets settings that were not on the submitted
+  form** (#131). Previously every checkbox absent from the form was stored as
+  `false` and every absent text field was cleared, so any partial form (a
+  stale tab, a script, the e2e agent's c14n round-trip) silently wiped
+  unrelated configuration - observed live as `issuer_from_request`,
+  `issuer_from_proxy_headers` and the SAML export toggles flipping off and the
+  allowlist, device verification URL and attribute names being deleted
+  mid-test-run. The handler now follows an "absent = unchanged" contract: text
+  fields and textareas are only applied when present (present-but-blank still
+  clears), and each checkbox is paired with a hidden `__on_form` marker so
+  "rendered but unchecked" (persist `false`) is distinguishable from "not on
+  this form" (leave unchanged).
 
 ## [2.5.0] - 2026-07-19
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -484,6 +484,35 @@ def client_regenerate_secret(client_id: str) -> ResponseReturnValue:
 
 # ==================== Settings ====================
 
+def _form_bool(name: str) -> bool | None:
+    """Checkbox value under the "absent = unchanged" contract (#131).
+
+    An unchecked checkbox never appears in a submitted form, so on its own it
+    is indistinguishable from a field that was not on the form at all. The
+    settings template therefore carries a hidden ``<name>__on_form`` marker for
+    every checkbox it renders. Name present -> its submitted state; marker
+    alone -> the box was rendered and left unchecked (False); neither -> the
+    field was not part of this form, leave the setting unchanged (None).
+    """
+    if name in request.form:
+        return request.form.get(name) == "true"
+    if f"{name}__on_form" in request.form:
+        return False
+    return None
+
+
+def _form_text(name: str) -> str | None:
+    """Text field: absent from the form means unchanged, blank means clear."""
+    value = request.form.get(name)
+    return value.strip() if value is not None else None
+
+
+def _form_textarea_list(name: str) -> list[str] | None:
+    """Textarea list: absent from the form means unchanged, blank means clear."""
+    raw = request.form.get(name)
+    return _parse_textarea_list(raw) if raw is not None else None
+
+
 @ui_bp.route("/settings", methods=["GET", "POST"])
 def settings() -> ResponseReturnValue:
     """IdP settings configuration page."""
@@ -500,43 +529,40 @@ def settings() -> ResponseReturnValue:
     try:
         yaml_writer = get_yaml_writer()
 
+        # Every value follows the "absent = unchanged" contract (#131): a field
+        # missing from the submitted form is passed as None and the YAML writer
+        # leaves it alone, so a partial form (a stale tab, a script, the e2e
+        # agent's c14n round-trip) can no longer silently reset settings it
+        # never carried. Present-but-blank still means "clear".
+        expiry_raw = request.form.get("token_expiry_minutes")
+
         # OAuth settings
         yaml_writer.update_oauth_settings(
-            issuer=request.form.get("issuer"),
-            issuer_from_request=request.form.get("issuer_from_request") == "true",
-            issuer_allowlist=_parse_textarea_list(
-                request.form.get("issuer_allowlist", "")
-            ),
-            device_verification_base_url=request.form.get(
-                "device_verification_base_url", ""
-            ).strip(),
-            issuer_from_proxy_headers=request.form.get("issuer_from_proxy_headers") == "true",
-            audience=request.form.get("audience"),
-            token_expiry_minutes=int(request.form.get("token_expiry_minutes", 60)),
-            require_pkce=request.form.get("require_pkce") == "true",
-            refresh_token_rotation=(
-                request.form.get("refresh_token_rotation") == "true"
-            ),
+            issuer=_form_text("issuer"),
+            issuer_from_request=_form_bool("issuer_from_request"),
+            issuer_allowlist=_form_textarea_list("issuer_allowlist"),
+            device_verification_base_url=_form_text("device_verification_base_url"),
+            issuer_from_proxy_headers=_form_bool("issuer_from_proxy_headers"),
+            audience=_form_text("audience"),
+            token_expiry_minutes=int(expiry_raw) if expiry_raw else None,
+            require_pkce=_form_bool("require_pkce"),
+            refresh_token_rotation=_form_bool("refresh_token_rotation"),
         )
 
         # SAML settings
         yaml_writer.update_saml_settings(
-            entity_id=request.form.get("saml_entity_id"),
-            sso_url=request.form.get("saml_sso_url"),
-            default_acs_url=request.form.get("default_acs_url"),
-            sign_responses=request.form.get("saml_sign_responses") == "true",
-            strict_binding=request.form.get("strict_saml_binding") == "true",
-            want_authn_requests_signed=(
-                request.form.get("saml_want_authn_requests_signed") == "true"
-            ),
-            sp_certificates=_parse_textarea_list(
-                request.form.get("saml_sp_certificates", "")
-            ),
-            c14n_algorithm=request.form.get("saml_c14n_algorithm"),
-            export_roles=request.form.get("saml_export_roles") == "true",
-            export_groups=request.form.get("saml_export_groups") == "true",
-            roles_attr_name=request.form.get("saml_roles_attr_name", "").strip(),
-            groups_attr_name=request.form.get("saml_groups_attr_name", "").strip(),
+            entity_id=_form_text("saml_entity_id"),
+            sso_url=_form_text("saml_sso_url"),
+            default_acs_url=_form_text("default_acs_url"),
+            sign_responses=_form_bool("saml_sign_responses"),
+            strict_binding=_form_bool("strict_saml_binding"),
+            want_authn_requests_signed=_form_bool("saml_want_authn_requests_signed"),
+            sp_certificates=_form_textarea_list("saml_sp_certificates"),
+            c14n_algorithm=_form_text("saml_c14n_algorithm"),
+            export_roles=_form_bool("saml_export_roles"),
+            export_groups=_form_bool("saml_export_groups"),
+            roles_attr_name=_form_text("saml_roles_attr_name"),
+            groups_attr_name=_form_text("saml_groups_attr_name"),
         )
 
         # Identity classes

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -8,6 +8,19 @@
 </div>
 
 <form method="post">
+    {# An unchecked checkbox never submits, so on its own it looks identical to
+       a checkbox that was never on the form. These markers let the server
+       apply "absent = unchanged" (#131): a checkbox is only interpreted when
+       its marker is present. One marker per checkbox rendered below. #}
+    <input type="hidden" name="issuer_from_request__on_form" value="1">
+    <input type="hidden" name="issuer_from_proxy_headers__on_form" value="1">
+    <input type="hidden" name="require_pkce__on_form" value="1">
+    <input type="hidden" name="refresh_token_rotation__on_form" value="1">
+    <input type="hidden" name="saml_sign_responses__on_form" value="1">
+    <input type="hidden" name="strict_saml_binding__on_form" value="1">
+    <input type="hidden" name="saml_want_authn_requests_signed__on_form" value="1">
+    <input type="hidden" name="saml_export_roles__on_form" value="1">
+    <input type="hidden" name="saml_export_groups__on_form" value="1">
     <div class="row g-4">
         <!-- OAuth Settings -->
         <div class="col-md-6">

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -838,7 +838,9 @@ class TestSAMLSigningUI:
         original_value = config.settings.saml_sign_responses
 
         try:
-            # POST without sign_responses (unchecked checkbox)
+            # POST without sign_responses (unchecked checkbox). The __on_form
+            # marker is what marks it as rendered-but-unchecked; without the
+            # marker an absent checkbox means "unchanged" (#131).
             response = client.post('/settings', data={
                 'issuer': config.settings.issuer,
                 'audience': config.settings.audience,
@@ -846,7 +848,7 @@ class TestSAMLSigningUI:
                 'saml_entity_id': config.settings.saml_entity_id,
                 'saml_sso_url': config.settings.saml_sso_url,
                 'default_acs_url': config.settings.default_acs_url,
-                # saml_sign_responses NOT included = unchecked
+                'saml_sign_responses__on_form': '1',
                 'allowed_identity_classes': 'INTERNAL\nEXTERNAL',
             }, follow_redirects=True)
 
@@ -1655,6 +1657,9 @@ class TestSAMLAttributeNameSettingsUI:
     """The export toggles and attribute names are editable from the settings page."""
 
     def _base_form(self, settings) -> dict:
+        # Mimics the full settings form, marker per checkbox included, so a
+        # checkbox absent from this dict reads as "rendered but unchecked"
+        # rather than "not on this form = unchanged" (#131).
         return {
             "issuer": settings.issuer,
             "audience": settings.audience,
@@ -1664,6 +1669,10 @@ class TestSAMLAttributeNameSettingsUI:
             "default_acs_url": settings.default_acs_url,
             "saml_sign_responses": "true",
             "allowed_identity_classes": "INTERNAL\nEXTERNAL",
+            "saml_sign_responses__on_form": "1",
+            "strict_saml_binding__on_form": "1",
+            "saml_export_roles__on_form": "1",
+            "saml_export_groups__on_form": "1",
         }
 
     def test_settings_page_renders_the_fields(self, client):

--- a/tests/test_ui_oauth_settings.py
+++ b/tests/test_ui_oauth_settings.py
@@ -8,15 +8,31 @@ from nanoidp.config import get_config
 
 
 def _base_form(settings) -> dict:
+    """Mimic the full settings page form (#131): the real form always carries a
+    hidden ``__on_form`` marker per checkbox (so "unchecked" is distinguishable
+    from "not on this form") and renders every text field, blank when unset.
+    A checkbox absent from this dict therefore means "rendered but unchecked",
+    while a truly partial form (no markers) must leave settings unchanged."""
     return {
         "issuer": settings.issuer,
         "audience": settings.audience,
         "token_expiry_minutes": settings.token_expiry_minutes,
+        "issuer_allowlist": "\n".join(settings.issuer_allowlist),
+        "device_verification_base_url": settings.device_verification_base_url or "",
         "saml_entity_id": settings.saml_entity_id,
         "saml_sso_url": settings.saml_sso_url,
         "default_acs_url": settings.default_acs_url,
         "saml_sign_responses": "true",
         "allowed_identity_classes": "INTERNAL\nEXTERNAL",
+        "issuer_from_request__on_form": "1",
+        "issuer_from_proxy_headers__on_form": "1",
+        "require_pkce__on_form": "1",
+        "refresh_token_rotation__on_form": "1",
+        "saml_sign_responses__on_form": "1",
+        "strict_saml_binding__on_form": "1",
+        "saml_want_authn_requests_signed__on_form": "1",
+        "saml_export_roles__on_form": "1",
+        "saml_export_groups__on_form": "1",
     }
 
 
@@ -89,7 +105,8 @@ class TestIssuerAllowlistRoundTrip:
 
         response = client.post(
             "/settings",
-            data=_base_form(config.settings),  # issuer_allowlist absent
+            # Present but blank means clear; absent would mean unchanged (#131).
+            data={**_base_form(config.settings), "issuer_allowlist": ""},
             follow_redirects=True,
         )
         assert response.status_code == 200
@@ -131,7 +148,8 @@ class TestDeviceVerificationBaseUrlRoundTrip:
 
         response = client.post(
             "/settings",
-            data=_base_form(config.settings),  # device_verification_base_url absent
+            # Present but blank means clear; absent would mean unchanged (#131).
+            data={**_base_form(config.settings), "device_verification_base_url": ""},
             follow_redirects=True,
         )
         assert response.status_code == 200
@@ -175,3 +193,69 @@ class TestIssuerFromProxyHeadersRoundTrip:
         r = client.get("/settings")
         assert r.status_code == 200
         assert b'name="issuer_from_proxy_headers"' in r.data
+
+
+class TestPartialFormLeavesSettingsUnchanged:
+    """#131: a form that does not carry a field must not reset it.
+
+    Reproduces the wipe observed live: the e2e agent's "SAML Exclusive C14N"
+    test posts only the fields it knows about, and before the fix that
+    round-trip flipped every absent checkbox to false and cleared every absent
+    text field (allowlist, device URL, attribute names, expiry)."""
+
+    def test_c14n_style_partial_form_does_not_wipe_other_settings(
+        self, client, preserve_config_files
+    ):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+        config = get_config()
+
+        # Arrange: enable a representative spread of settings via the full form
+        response = client.post(
+            "/settings",
+            data={
+                **_base_form(config.settings),
+                "issuer_from_request": "true",
+                "issuer_allowlist": "http://localhost:8000\nhttp://nanoidp:9900",
+                "device_verification_base_url": "https://idp.example.com",
+                "saml_export_roles": "true",
+                "saml_roles_attr_name": "memberRoles",
+                "token_expiry_minutes": "120",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        # Act: the e2e agent's C14N form shape - no markers, none of the
+        # fields enabled above
+        response = client.post(
+            "/settings",
+            data={
+                "issuer": config.settings.issuer,
+                "audience": config.settings.audience,
+                "saml_entity_id": config.settings.saml_entity_id,
+                "saml_sso_url": config.settings.saml_sso_url,
+                "default_acs_url": config.settings.default_acs_url,
+                "saml_sign_responses": "true",
+                "strict_saml_binding": "",
+                "saml_c14n_algorithm": "exc_c14n",
+                "allowed_identity_classes": "INTERNAL\nEXTERNAL",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        # Assert: everything the partial form did not carry is unchanged...
+        config.reload()
+        assert config.settings.issuer_from_request is True
+        assert config.settings.issuer_allowlist == [
+            "http://localhost:8000",
+            "http://nanoidp:9900",
+        ]
+        assert config.settings.device_verification_base_url == "https://idp.example.com"
+        assert config.settings.saml_export_roles is True
+        assert config.settings.saml_roles_attr_name == "memberRoles"
+        assert config.settings.token_expiry_minutes == 120
+        # ...while the fields it did carry took effect
+        assert config.settings.saml_c14n_algorithm == "exc_c14n"
+        assert config.settings.saml_sign_responses is True


### PR DESCRIPTION
Closes #131.

## Problem

Every checkbox absent from the submitted `/settings` form was stored as `false` and every absent text field was cleared, so any partial form (a stale tab, a script, the e2e agent's "SAML Exclusive C14N" round-trip) silently reset settings it never carried. Observed live: the issuer/proxy/export toggles flipped off and the allowlist, device verification URL and attribute names were deleted mid-test-run.

## Fix

The handler now passes `None` (= leave unchanged; the `yaml_writer` update methods already skip `None` for every parameter) for any field not present in the form:

- Text fields and textareas apply only when present; present-but-blank still means clear.
- `token_expiry_minutes` absent no longer resets to 60.
- Checkboxes: an unchecked box never submits, so the settings page now renders a hidden `<name>__on_form` marker per checkbox. Name present = its state; marker alone = rendered-but-unchecked (persist `false`); neither = not on this form (unchanged).

## Tests

- New regression test replays the e2e c14n partial-form shape and asserts nothing else moved (toggles, allowlist, device URL, attribute names, expiry) while the carried fields took effect.
- The two `_base_form` helpers now mimic the full rendered form (markers included); the blank-clears tests post the blank explicitly.
- Full suite: 890 passed; ruff and mypy clean.

## Live verification

Toggles-ON server (issuer reflection + allowlist + proxy headers + SAML export with custom names + device URL) + full e2e agent run: settings.yaml values compared before/after are identical on all 10 tracked keys - the wipe reproduced on main no longer occurs. (The two e2e-agent failures on this branch are the known ones fixed by #130, unrelated.)