### PR TITLE
fix: merge colliding SAML export attribute names; pass lists to AttributeQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names**: it now reads `saml.roles_attr_name` / `saml.groups_attr_name` from
   `/api/config` instead of assuming the default `roles` / `groups` names, so it
   no longer fails on servers exporting under custom names.
+- **SAML export: colliding attribute names merge instead of overwriting, and
+  values are passed as lists** (#134). With both exports enabled and
+  `saml_roles_attr_name` equal to `saml_groups_attr_name` (e.g. both
+  `memberOf`), the groups list silently replaced the roles list; the two are
+  now merged into the single shared attribute, roles first, deduplicated. The
+  AttributeQuery path also passes roles/groups (and entitlements) to the
+  response builder as lists instead of comma-joined strings, so a legitimate
+  comma-bearing value like `"Finance, EMEA"` stays one `AttributeValue`, as it
+  already did in the SSO assertion.
 - **`/api/users/<username>/token` now honours `issuer_from_request`** (#133):
   the endpoint mints real JWTs but kept using the fixed `settings.issuer`,
   so with the flag on its tokens carried an `iss` that failed validation

--- a/book/src/reference/saml.md
+++ b/book/src/reference/saml.md
@@ -78,6 +78,12 @@ saml:
 Attribute"** / **"Export Groups Attribute"** and set the matching attribute
 name → Save Settings. Clearing a name field restores its default.
 
+Each entry becomes its own `AttributeValue`, in both the SSO assertion and
+the AttributeQuery response, so a value containing a comma stays a single
+value. Configuring the same name for both exports (e.g. `memberOf` for roles
+and groups alike) is supported: the two lists are merged into that one
+attribute, roles first, deduplicated.
+
 Any name works, including the URIs SPs commonly expect:
 
 | SP | Typical roles attribute name |

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -154,6 +154,21 @@ def _parse_saml_request(
         return None
 
 
+def _add_export_attr(attrs: dict, name: str, values: list) -> None:
+    """Add an exported roles/groups attribute, merging on a name collision.
+
+    ``saml_roles_attr_name`` and ``saml_groups_attr_name`` are configured
+    independently, so both exports can target the same attribute (e.g.
+    ``memberOf``). Plain assignment would let the second list silently replace
+    the first (#134); merging keeps both, roles first, deduplicated.
+    """
+    existing = attrs.get(name)
+    if isinstance(existing, (list, tuple)):
+        attrs[name] = list(existing) + [v for v in values if v not in existing]
+    else:
+        attrs[name] = list(values)
+
+
 def _build_saml_response(
     acs_url: str,
     issuer: str,
@@ -512,9 +527,11 @@ def sso() -> ResponseReturnValue:
     # Roles/groups are opt-in: they have no standard SAML attribute name, so the
     # SP-specific name is configured alongside the switch.
     if config.settings.saml_export_roles and user.roles:
-        saml_attrs[config.settings.saml_roles_attr_name] = user.roles
+        _add_export_attr(saml_attrs, config.settings.saml_roles_attr_name, user.roles)
     if config.settings.saml_export_groups and user.groups:
-        saml_attrs[config.settings.saml_groups_attr_name] = user.groups
+        _add_export_attr(
+            saml_attrs, config.settings.saml_groups_attr_name, user.groups
+        )
     # Add custom attributes
     if user.attributes:
         saml_attrs.update(user.attributes)
@@ -747,20 +764,24 @@ def attribute_query() -> ResponseReturnValue:
             if user.identity_class:
                 attributes["identity_class"] = user.identity_class
             if user.entitlements:
-                # Convert list to comma-separated for SAML
-                if isinstance(user.entitlements, list):
-                    attributes["entitlements"] = ",".join(user.entitlements)
-                else:
-                    attributes["entitlements"] = user.entitlements
+                # Passed as a list: the response builder emits one
+                # AttributeValue per entry, and a comma-bearing entitlement
+                # stays a single value instead of being split (#134).
+                attributes["entitlements"] = user.entitlements
             # Add source_acl for data source authorization
             if user.source_acl:
                 attributes["source_acl"] = user.source_acl  # List for multiple values
 
-            # Roles/groups only when explicitly enabled (see /saml/sso)
+            # Roles/groups only when explicitly enabled (see /saml/sso).
+            # Lists, not ",".join: same reason as entitlements above (#134).
             if config.settings.saml_export_roles and user.roles:
-                attributes[config.settings.saml_roles_attr_name] = ",".join(user.roles)
+                _add_export_attr(
+                    attributes, config.settings.saml_roles_attr_name, user.roles
+                )
             if config.settings.saml_export_groups and user.groups:
-                attributes[config.settings.saml_groups_attr_name] = ",".join(user.groups)
+                _add_export_attr(
+                    attributes, config.settings.saml_groups_attr_name, user.groups
+                )
 
             # Add custom attributes
             if user.attributes:

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -1647,10 +1647,72 @@ class TestSAMLRolesGroupsExport:
         assert response.status_code == 200
 
         root = etree.fromstring(response.data)
-        # The route comma-joins, then the response builder splits back out into
-        # one AttributeValue per entry (same handling as entitlements).
+        # Lists go straight to the response builder, which emits one
+        # AttributeValue per entry (#134: no more comma-join round-trip).
         assert self._attribute_values(root, "roles") == ["USER", "ADMIN"]
         assert self._attribute_values(root, "groups") == ["ADMINISTRATORS", "EVERYONE"]
+
+    _ATTRIBUTE_QUERY = """<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <saml2p:AttributeQuery
+            xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+            xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+            ID="_req134"
+            Version="2.0"
+            IssueInstant="2025-01-01T00:00:00Z">
+            <saml2:Issuer>http://sp.example.com</saml2:Issuer>
+            <saml2:Subject>
+                <saml2:NameID>admin</saml2:NameID>
+            </saml2:Subject>
+        </saml2p:AttributeQuery>
+    </soap:Body>
+</soap:Envelope>"""
+
+    def _attribute_query_root(self, client):
+        response = client.post(
+            '/saml/attribute-query', data=self._ATTRIBUTE_QUERY,
+            content_type='text/xml'
+        )
+        assert response.status_code == 200
+        return etree.fromstring(response.data)
+
+    def test_colliding_attr_names_merge_in_sso(self, client, saml_settings):
+        """#134: both exports targeting the same attribute name merge into one
+        attribute (roles first, deduplicated) instead of the groups list
+        silently replacing the roles list."""
+        saml_settings.saml_export_roles = True
+        saml_settings.saml_export_groups = True
+        saml_settings.saml_roles_attr_name = "memberOf"
+        saml_settings.saml_groups_attr_name = "memberOf"
+
+        root = self._sso_assertion(client)
+        assert self._attribute_values(root, "memberOf") == [
+            "USER", "ADMIN", "ADMINISTRATORS", "EVERYONE",
+        ]
+
+    def test_colliding_attr_names_merge_in_attribute_query(self, client, saml_settings):
+        saml_settings.saml_export_roles = True
+        saml_settings.saml_export_groups = True
+        saml_settings.saml_roles_attr_name = "memberOf"
+        saml_settings.saml_groups_attr_name = "memberOf"
+
+        root = self._attribute_query_root(client)
+        assert self._attribute_values(root, "memberOf") == [
+            "USER", "ADMIN", "ADMINISTRATORS", "EVERYONE",
+        ]
+
+    def test_comma_bearing_group_stays_one_attribute_value(self, client, saml_settings):
+        """#134: a legitimate value containing a comma is one AttributeValue in
+        the AttributeQuery response, as it already was in the SSO assertion
+        (previously the ",".join / re-split round-trip split it in two)."""
+        from nanoidp.config import get_config
+
+        saml_settings.saml_export_groups = True
+        get_config().get_user("admin").groups = ["Finance, EMEA"]
+
+        root = self._attribute_query_root(client)
+        assert self._attribute_values(root, "groups") == ["Finance, EMEA"]
 
 
 class TestSAMLAttributeNameSettingsUI:


### PR DESCRIPTION
Closes #134.

Post-merge review findings on #125, both P3 correctness:

1. **Attribute-name collision no longer drops roles.** With both exports enabled and `saml_roles_attr_name` == `saml_groups_attr_name` (e.g. both `memberOf`), the groups list silently replaced the roles list. A shared `_add_export_attr` helper now merges into the single shared attribute: roles first, deduplicated. Used by both the SSO assertion and the AttributeQuery path, and documented in the SAML reference (`memberOf` carrying both is a common real-world shape).

2. **AttributeQuery passes lists instead of comma-joining.** The response builder already emits one `AttributeValue` per list entry, so the `",".join(...)` / re-split round-trip only served to split a legitimate comma-bearing value like `"Finance, EMEA"` into two values while the SSO assertion kept it as one. Roles, groups and (for consistency, same class of defect) entitlements are now passed as lists; output is byte-identical for values without commas.

## Tests

- Collision merge asserted in both the SSO assertion and the AttributeQuery response.
- A comma-bearing group value stays a single AttributeValue in the AttributeQuery response.
- Full suite: 897 passed; ruff and mypy clean.