### PR TITLE
Saving settings preserves env placeholders and empty optional values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real client.
 
 ### Fixed
+- **Saving settings no longer discards comments, inline `#` text or `${VAR:default}`
+  placeholders in `settings.yaml`** (#127): the settings writer now round-trips
+  the file with `ruamel.yaml` (comments and quote style survive) and only
+  rewrites a field when its expanded on-disk value actually differs from the
+  new one, so an untouched `${PORT:8000}`-style placeholder is no longer
+  replaced by its resolved value on the next save. Free-form text
+  (`description`, `client_secret`, `password`, attribute values) is now quoted
+  on write so an embedded `#` can't be mistaken for a comment. Applies to both
+  the web UI settings form and the MCP `save_config` tool.
+- **Env-backed client secrets and empty optional placeholders are preserved when
+  unrelated settings change.** The OAuth client merge now updates entries by
+  `client_id` field-by-field instead of rewriting the whole list, so an
+  unchanged `${APP1_SECRET:dev}` secret stays in the raw file even when a
+  sibling client is edited. Empty optional values such as
+  `${DEVICE_URL:}` are also treated as unchanged when they still expand to an
+  empty string, instead of being popped out of the YAML on a save that changed
+  some other field.
 - **`/api/config` now exposes `issuer_allowlist`, `device_verification_base_url`
   and `issuer_from_proxy_headers`** alongside `issuer_from_request`. The
   config-agnostic e2e agent reads the allowlist from `/api/config` to predict

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ The test agent covers:
 - **Key Management**: Key info, rotation, post-rotation token validation
 - **REST API**: Users, config, audit log
 
-**Caution:** a run against a live server persists configuration changes back to that server's `config/settings.yaml` (resolved `${PORT}` placeholders, cleared `default_acs_url`). If the server runs from a git checkout, restore the file before committing: `git checkout -- config/settings.yaml`.
+**Caution:** a run against a live server persists configuration changes back to that server's `config/settings.yaml`. Since #127, unrelated fields (e.g. `${PORT}` placeholders, comments) are left untouched, but any value the run genuinely changes (e.g. `default_acs_url`) is still written for real. If the server runs from a git checkout, restore the file before committing: `git checkout -- config/settings.yaml`.
 
 ## Code Quality
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -21,7 +21,7 @@ oauth:
     - urn:service:billing
   - client_id: registered-client
     client_secret: registered-secret
-    description: Client with registered redirect URIs (exact matching, issue #67)
+    description: 'Client with registered redirect URIs (exact matching, issue #67)'
     redirect_uris:
     - http://localhost:3000/callback
   issuer_from_request: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "lxml>=6.0.2",
     "signxml>=4.2.0",
     "PyYAML>=6.0",
+    # Comment/quote-preserving round-trip YAML, used only on the config write path.
+    "ruamel.yaml>=0.18",
     # <3 is deliberate: mcp 1.x -> 2.0 was a breaking rewrite of the lowlevel Server.
     "mcp>=2,<3",
     "pydantic>=2.12",

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -6,10 +6,9 @@ Uses Pydantic for validation and schema enforcement.
 
 import logging
 import os
-import re
 import threading
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 import yaml
 
@@ -26,34 +25,11 @@ from .serialization import (
     apply_settings_document,
     apply_users_document,
     atomic_write_yaml,
+    load_yaml_document,
 )
+from .serialization import expand_env_vars as _expand_env_vars
 
 logger = logging.getLogger(__name__)
-
-
-_ENV_VAR_RE = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}')
-
-
-def _expand_env_vars(value: Any) -> Any:
-    """Recursively expand ${NAME} / ${NAME:default} placeholders in YAML values.
-
-    - ${NAME}          → os.environ[NAME] (empty string if not set)
-    - ${NAME:default}  → os.environ.get(NAME, 'default')
-
-    Only string leaf values are processed; dicts/lists are traversed recursively.
-    """
-    if isinstance(value, str):
-        def _replace(m: re.Match) -> str:
-            var_name, default = m.group(1), m.group(2)
-            if default is None:
-                return os.environ.get(var_name, "")
-            return os.environ.get(var_name, default)
-        return _ENV_VAR_RE.sub(_replace, value)
-    if isinstance(value, dict):
-        return {k: _expand_env_vars(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_expand_env_vars(item) for item in value]
-    return value
 
 
 class ConfigManager:
@@ -318,12 +294,7 @@ class ConfigManager:
     def _save_users(self) -> None:
         """Save users to users.yaml (shared builder, read-modify-write, #83)."""
         users_file = self.config_dir / "users.yaml"
-
-        document: Dict[str, Any] = {}
-        if users_file.exists():
-            with open(users_file, "r") as f:
-                document = yaml.safe_load(f) or {}
-
+        document = load_yaml_document(users_file)
         apply_users_document(document, self.users, self.default_user)
         atomic_write_yaml(users_file, document)
 
@@ -334,12 +305,7 @@ class ConfigManager:
         logging.level, custom keys) are preserved instead of deleted (#87).
         """
         settings_file = self.config_dir / "settings.yaml"
-
-        document: Dict[str, Any] = {}
-        if settings_file.exists():
-            with open(settings_file, "r") as f:
-                document = yaml.safe_load(f) or {}
-
+        document = load_yaml_document(settings_file)
         apply_settings_document(document, self.settings)
         atomic_write_yaml(settings_file, document)
 

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -13,35 +13,121 @@ any save.
 
 This module deliberately has no runtime imports from the package (models are
 type-checking-only), so it can be imported from ``config.py`` without cycles.
+
+Issue #127: saving settings used to silently discard comments, inline ``#``
+text and ``${VAR:default}`` placeholders, because the write path round-tripped
+through plain PyYAML (no comment support) and always wrote the *expanded*
+in-memory value even when a field was never actually changed. This module now
+does the load/dump with ``ruamel.yaml`` in round-trip mode (comments and quote
+style survive), quotes free-form text values so an embedded ``#`` can't be
+mistaken for a comment, and skips writing any key whose expanded on-disk value
+already matches what's being saved, so unchanged placeholders survive.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict
 
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import SingleQuotedScalarString
 
 if TYPE_CHECKING:
     from .config import OAuthClient, Settings, User
 
 logger = logging.getLogger(__name__)
 
+# Round-trip YAML instance: preserves comments and quote style, and matches
+# the project's existing dash-at-parent-indent list style (#127).
+_yaml_rt = YAML(typ="rt")
+_yaml_rt.indent(mapping=2, sequence=2, offset=0)
+_yaml_rt.preserve_quotes = True
+_yaml_rt.width = 4096  # avoid re-wrapping long values (URLs, descriptions)
+
+_ENV_VAR_RE = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}')
+
+
+def expand_env_vars(value: Any) -> Any:
+    """Recursively expand ${NAME} / ${NAME:default} placeholders in YAML values.
+
+    - ${NAME}          → os.environ[NAME] (empty string if not set)
+    - ${NAME:default}  → os.environ.get(NAME, 'default')
+
+    Only string leaf values are processed; dicts/lists are traversed recursively.
+    """
+    if isinstance(value, str):
+        def _replace(m: re.Match) -> str:
+            var_name, default = m.group(1), m.group(2)
+            if default is None:
+                return os.environ.get(var_name, "")
+            return os.environ.get(var_name, default)
+        return _ENV_VAR_RE.sub(_replace, value)
+    if isinstance(value, dict):
+        return {k: expand_env_vars(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [expand_env_vars(item) for item in value]
+    return value
+
+
+def is_unchanged(current_raw: Any, new_value: Any) -> bool:
+    """True if ``new_value`` matches the current raw value once any ``${VAR}``
+    placeholders in it are expanded - i.e. this field was not actually changed
+    and the raw text (placeholder, comments, quoting) can be left untouched.
+
+    A ``${VAR:default}`` placeholder always expands to a ``str`` (#127), even
+    when the settings field it feeds is an ``int``/``bool`` (e.g.
+    ``port: ${PORT:8000}`` vs. ``settings.port == 8000``), so the expanded
+    value is coerced to ``new_value``'s type before comparing.
+    """
+    expanded = expand_env_vars(current_raw)
+    if isinstance(expanded, str) and not isinstance(new_value, str):
+        try:
+            if isinstance(new_value, bool):
+                expanded = expanded.strip().lower() in ("true", "1", "yes", "on")
+            elif isinstance(new_value, int):
+                expanded = int(expanded)
+            elif isinstance(new_value, float):
+                expanded = float(expanded)
+        except ValueError:
+            pass  # leave as str; comparison below will just be False
+    return expanded == new_value
+
+
+def _quoted(value: str) -> SingleQuotedScalarString:
+    """Force single-quoted style so an embedded ``#`` is never mistaken for a
+    comment and stray leading/trailing whitespace survives (#127).
+    """
+    return SingleQuotedScalarString(value)
+
+
+def load_yaml_document(file_path: Path) -> Dict[str, Any]:
+    """Load a YAML document preserving comments/quote style for a later
+    round-trip write. Returns an empty ``CommentedMap`` if the file is
+    missing or empty.
+    """
+    if not file_path.exists():
+        return CommentedMap()
+    with open(file_path, "r") as f:
+        return _yaml_rt.load(f) or CommentedMap()
+
 
 def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
     """Build the settings.yaml entry for an OAuth client.
 
     Optional list fields are omitted when empty, so a default client stays a
-    three-line entry.
+    three-line entry. Free-form text is quoted so it round-trips safely even
+    if it contains ``#`` (#127).
     """
     entry: Dict[str, Any] = {
         "client_id": client.client_id,
-        "client_secret": client.client_secret,
-        "description": client.description,
+        "client_secret": _quoted(client.client_secret),
+        "description": _quoted(client.description),
     }
     if client.additional_audiences:
         entry["additional_audiences"] = client.additional_audiences
@@ -50,15 +136,72 @@ def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
     return entry
 
 
+def merge_oauth_clients(
+    raw_clients: Any, settings_clients: list["OAuthClient"]
+) -> list[Dict[str, Any]]:
+    """Merge OAuth client entries by client_id without rewriting untouched
+    env-backed secret placeholders or sibling entries.
+
+    Raw list entries are treated as the source of truth for values that are
+    still unchanged, but genuine edits replace the matching fields without
+    rebuilding the whole list. Added clients are appended; removed ones drop out.
+    """
+    raw_by_id = {}
+    if isinstance(raw_clients, list):
+        for raw in raw_clients:
+            if isinstance(raw, dict):
+                client_id = raw.get("client_id")
+                if client_id is not None:
+                    raw_by_id[client_id] = raw
+
+    merged: list[Dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for client in settings_clients:
+        client_id = client.client_id
+        seen.add(client_id)
+        raw_entry = raw_by_id.get(client_id)
+        if raw_entry is None:
+            merged.append(client_to_yaml(client))
+            continue
+
+        updated = raw_entry.copy()
+        for field_name, new_value in (
+            ("client_id", client.client_id),
+            ("client_secret", client.client_secret),
+            ("description", client.description),
+        ):
+            if not is_unchanged(raw_entry.get(field_name), new_value):
+                if field_name in {"client_secret", "description"}:
+                    updated[field_name] = _quoted(str(new_value))
+                else:
+                    updated[field_name] = new_value
+
+        for field_name, new_list_value in (
+            ("additional_audiences", client.additional_audiences),
+            ("redirect_uris", client.redirect_uris),
+        ):
+            if not is_unchanged(raw_entry.get(field_name), new_list_value):
+                if new_list_value:
+                    updated[field_name] = new_list_value
+                else:
+                    updated.pop(field_name, None)
+
+        merged.append(updated)
+
+    return merged
+
+
 def user_to_yaml(user: User) -> Dict[str, Any]:
     """Build the users.yaml entry for a user.
 
     Canonical form is sparse: optional fields and model defaults
     (``tenant: default``, empty lists) are omitted and restored by the loader's
-    defaults on the next read.
+    defaults on the next read. Free-form text is quoted so it round-trips
+    safely even if it contains ``#`` (#127).
     """
     entry: Dict[str, Any] = {
-        "password": user.password,
+        "password": _quoted(user.password),
         "email": user.email,
     }
     if user.identity_class:
@@ -74,7 +217,10 @@ def user_to_yaml(user: User) -> Dict[str, Any]:
     if user.source_acl:
         entry["source_acl"] = user.source_acl
     if user.attributes:
-        entry["attributes"] = user.attributes
+        entry["attributes"] = {
+            k: (_quoted(v) if isinstance(v, str) else v)
+            for k, v in user.attributes.items()
+        }
     return entry
 
 
@@ -89,58 +235,110 @@ def apply_settings_document(
     custom keys) is preserved verbatim (#87). Optional owned keys are removed
     when back at their defaults, so a cleared ``security_profile`` does not
     linger in the file.
+
+    Each field is only overwritten when its expanded on-disk value actually
+    differs from the new one (#127), so untouched ``${VAR}`` placeholders,
+    comments and quote style survive a save that changed something else.
     """
     server = document.setdefault("server", {})
-    server["host"] = settings.host
-    server["port"] = settings.port
+    if not is_unchanged(server.get("host"), settings.host):
+        server["host"] = settings.host
+    if not is_unchanged(server.get("port"), settings.port):
+        server["port"] = settings.port
 
     oauth = document.setdefault("oauth", {})
-    oauth["issuer"] = settings.issuer
-    oauth["issuer_from_request"] = settings.issuer_from_request
-    if settings.issuer_allowlist:
-        oauth["issuer_allowlist"] = settings.issuer_allowlist
-    else:
-        oauth.pop("issuer_allowlist", None)
-    if settings.device_verification_base_url:
-        oauth["device_verification_base_url"] = settings.device_verification_base_url
-    else:
-        oauth.pop("device_verification_base_url", None)
-    oauth["issuer_from_proxy_headers"] = settings.issuer_from_proxy_headers
-    oauth["audience"] = settings.audience
-    oauth["token_expiry_minutes"] = settings.token_expiry_minutes
-    oauth["refresh_token_rotation"] = settings.refresh_token_rotation
-    oauth["require_pkce"] = settings.require_pkce
-    oauth["clients"] = [client_to_yaml(client) for client in settings.clients]
+    if not is_unchanged(oauth.get("issuer"), settings.issuer):
+        oauth["issuer"] = settings.issuer
+    if not is_unchanged(oauth.get("issuer_from_request"), settings.issuer_from_request):
+        oauth["issuer_from_request"] = settings.issuer_from_request
+    if not is_unchanged(oauth.get("issuer_allowlist"), settings.issuer_allowlist or []):
+        if settings.issuer_allowlist:
+            oauth["issuer_allowlist"] = settings.issuer_allowlist
+        else:
+            oauth.pop("issuer_allowlist", None)
+    device_verification_base_url = settings.device_verification_base_url or ""
+    if not is_unchanged(
+        oauth.get("device_verification_base_url"),
+        device_verification_base_url,
+    ):
+        if settings.device_verification_base_url:
+            oauth["device_verification_base_url"] = settings.device_verification_base_url
+        else:
+            oauth.pop("device_verification_base_url", None)
+    if not is_unchanged(
+        oauth.get("issuer_from_proxy_headers"), settings.issuer_from_proxy_headers
+    ):
+        oauth["issuer_from_proxy_headers"] = settings.issuer_from_proxy_headers
+    if not is_unchanged(oauth.get("audience"), settings.audience):
+        oauth["audience"] = settings.audience
+    if not is_unchanged(oauth.get("token_expiry_minutes"), settings.token_expiry_minutes):
+        oauth["token_expiry_minutes"] = settings.token_expiry_minutes
+    if not is_unchanged(
+        oauth.get("refresh_token_rotation"), settings.refresh_token_rotation
+    ):
+        oauth["refresh_token_rotation"] = settings.refresh_token_rotation
+    if not is_unchanged(oauth.get("require_pkce"), settings.require_pkce):
+        oauth["require_pkce"] = settings.require_pkce
+    new_clients = merge_oauth_clients(oauth.get("clients", []), settings.clients)
+    if new_clients != oauth.get("clients", []):
+        if new_clients:
+            oauth["clients"] = new_clients
+        else:
+            oauth.pop("clients", None)
 
     saml = document.setdefault("saml", {})
-    saml["entity_id"] = settings.saml_entity_id
-    saml["sso_url"] = settings.saml_sso_url
-    saml["default_acs_url"] = settings.default_acs_url
-    saml["sign_responses"] = settings.saml_sign_responses
-    saml["export_roles"] = settings.saml_export_roles
-    saml["export_groups"] = settings.saml_export_groups
-    saml["roles_attr_name"] = settings.saml_roles_attr_name
-    saml["groups_attr_name"] = settings.saml_groups_attr_name
-    saml["c14n_algorithm"] = settings.saml_c14n_algorithm
-    saml["strict_binding"] = settings.strict_saml_binding
-    saml["want_authn_requests_signed"] = settings.saml_want_authn_requests_signed
-    if settings.saml_sp_certificates:
-        saml["sp_certificates"] = settings.saml_sp_certificates
-    else:
-        saml.pop("sp_certificates", None)
+    if not is_unchanged(saml.get("entity_id"), settings.saml_entity_id):
+        saml["entity_id"] = settings.saml_entity_id
+    if not is_unchanged(saml.get("sso_url"), settings.saml_sso_url):
+        saml["sso_url"] = settings.saml_sso_url
+    if not is_unchanged(saml.get("default_acs_url"), settings.default_acs_url):
+        saml["default_acs_url"] = settings.default_acs_url
+    if not is_unchanged(saml.get("sign_responses"), settings.saml_sign_responses):
+        saml["sign_responses"] = settings.saml_sign_responses
+    if not is_unchanged(saml.get("export_roles"), settings.saml_export_roles):
+        saml["export_roles"] = settings.saml_export_roles
+    if not is_unchanged(saml.get("export_groups"), settings.saml_export_groups):
+        saml["export_groups"] = settings.saml_export_groups
+    if not is_unchanged(saml.get("roles_attr_name"), settings.saml_roles_attr_name):
+        saml["roles_attr_name"] = settings.saml_roles_attr_name
+    if not is_unchanged(saml.get("groups_attr_name"), settings.saml_groups_attr_name):
+        saml["groups_attr_name"] = settings.saml_groups_attr_name
+    if not is_unchanged(saml.get("c14n_algorithm"), settings.saml_c14n_algorithm):
+        saml["c14n_algorithm"] = settings.saml_c14n_algorithm
+    if not is_unchanged(saml.get("strict_binding"), settings.strict_saml_binding):
+        saml["strict_binding"] = settings.strict_saml_binding
+    if not is_unchanged(
+        saml.get("want_authn_requests_signed"), settings.saml_want_authn_requests_signed
+    ):
+        saml["want_authn_requests_signed"] = settings.saml_want_authn_requests_signed
+    if not is_unchanged(saml.get("sp_certificates"), settings.saml_sp_certificates or []):
+        if settings.saml_sp_certificates:
+            saml["sp_certificates"] = settings.saml_sp_certificates
+        else:
+            saml.pop("sp_certificates", None)
 
-    document.setdefault("logging", {})["verbose_logging"] = settings.verbose_logging
-    document["authority_prefixes"] = settings.authority_prefixes
+    logging_section = document.setdefault("logging", {})
+    if not is_unchanged(logging_section.get("verbose_logging"), settings.verbose_logging):
+        logging_section["verbose_logging"] = settings.verbose_logging
 
-    if settings.allowed_identity_classes:
-        document["allowed_identity_classes"] = settings.allowed_identity_classes
-    else:
-        document.pop("allowed_identity_classes", None)
+    if not is_unchanged(document.get("authority_prefixes"), settings.authority_prefixes):
+        document["authority_prefixes"] = settings.authority_prefixes
 
-    if settings.security_profile != "dev":
-        document["security_profile"] = settings.security_profile
-    else:
-        document.pop("security_profile", None)
+    if not is_unchanged(
+        document.get("allowed_identity_classes"), settings.allowed_identity_classes or []
+    ):
+        if settings.allowed_identity_classes:
+            document["allowed_identity_classes"] = settings.allowed_identity_classes
+        else:
+            document.pop("allowed_identity_classes", None)
+
+    security_profile_default = "dev"
+    current_security_profile = document.get("security_profile", security_profile_default)
+    if not is_unchanged(current_security_profile, settings.security_profile):
+        if settings.security_profile != security_profile_default:
+            document["security_profile"] = settings.security_profile
+        else:
+            document.pop("security_profile", None)
 
     return document
 
@@ -163,7 +361,9 @@ def atomic_write_yaml(file_path: Path, data: Dict[str, Any]) -> None:
     """Atomically write a YAML document, with a .bak of the previous version.
 
     Writes to a temp file in the same directory and renames over the target;
-    on failure the previous content is restored from the backup.
+    on failure the previous content is restored from the backup. Dumps with
+    ``ruamel.yaml`` in round-trip mode so comments and quote style captured by
+    ``load_yaml_document`` survive (#127).
     """
     backup_path = file_path.with_suffix(".yaml.bak")
     if file_path.exists():
@@ -174,7 +374,7 @@ def atomic_write_yaml(file_path: Path, data: Dict[str, Any]) -> None:
     )
     try:
         with os.fdopen(fd, "w") as f:
-            yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+            _yaml_rt.dump(data, f)
         os.replace(temp_path, file_path)
         logger.info(f"Successfully wrote {file_path}")
     except Exception as e:

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -7,10 +7,14 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import yaml
-
 from ..config import OAuthClient, User, get_config
-from ..serialization import atomic_write_yaml, client_to_yaml, user_to_yaml
+from ..serialization import (
+    atomic_write_yaml,
+    client_to_yaml,
+    is_unchanged,
+    load_yaml_document,
+    user_to_yaml,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +36,11 @@ class YamlWriter:
         """Load the current users.yaml content."""
         if not self.users_file.exists():
             return {"users": {}, "default_user": "admin"}
-
-        with open(self.users_file, "r") as f:
-            return yaml.safe_load(f) or {"users": {}, "default_user": "admin"}
+        return load_yaml_document(self.users_file)
 
     def _load_settings_yaml(self) -> Dict[str, Any]:
         """Load the current settings.yaml content."""
-        if not self.settings_file.exists():
-            return {}
-
-        with open(self.settings_file, "r") as f:
-            return yaml.safe_load(f) or {}
+        return load_yaml_document(self.settings_file)
 
     # ==================== User Operations ====================
 
@@ -126,12 +124,33 @@ class YamlWriter:
         if is_new and existing_idx is not None:
             raise ValueError(f"Client '{client.client_id}' already exists")
 
-        client_data = client_to_yaml(client)
-
         if existing_idx is not None:
-            clients[existing_idx] = client_data
+            raw_entry = clients[existing_idx]
+            updated_entry = raw_entry.copy()
+            for field_name, new_value in (
+                ("client_id", client.client_id),
+                ("client_secret", client.client_secret),
+                ("description", client.description),
+            ):
+                if not is_unchanged(raw_entry.get(field_name), new_value):
+                    if field_name in {"client_secret", "description"}:
+                        updated_entry[field_name] = client_to_yaml(client)[field_name]
+                    else:
+                        updated_entry[field_name] = new_value
+
+            for field_name, new_list_value in (
+                ("additional_audiences", client.additional_audiences),
+                ("redirect_uris", client.redirect_uris),
+            ):
+                if not is_unchanged(raw_entry.get(field_name), new_list_value):
+                    if new_list_value:
+                        updated_entry[field_name] = new_list_value
+                    else:
+                        updated_entry.pop(field_name, None)
+
+            clients[existing_idx] = updated_entry
         else:
-            clients.append(client_data)
+            clients.append(client_to_yaml(client))
 
         self._atomic_write(self.settings_file, data)
         get_config().reload()
@@ -165,33 +184,54 @@ class YamlWriter:
         require_pkce: Optional[bool] = None,
         refresh_token_rotation: Optional[bool] = None,
     ) -> None:
-        """Update OAuth settings."""
+        """Update OAuth settings.
+
+        Skips writing a field whose expanded on-disk value already matches
+        what's being submitted, so unchanged ``${VAR}`` placeholders and
+        comments survive a form save that only changed other fields (#127).
+        """
         data = self._load_settings_yaml()
         oauth = data.setdefault("oauth", {})
 
-        if issuer is not None:
+        if issuer is not None and not is_unchanged(oauth.get("issuer"), issuer):
             oauth["issuer"] = issuer
-        if issuer_from_request is not None:
+        if issuer_from_request is not None and not is_unchanged(
+            oauth.get("issuer_from_request"), issuer_from_request
+        ):
             oauth["issuer_from_request"] = issuer_from_request
         if issuer_allowlist is not None:
             if issuer_allowlist:
-                oauth["issuer_allowlist"] = issuer_allowlist
+                if not is_unchanged(oauth.get("issuer_allowlist"), issuer_allowlist):
+                    oauth["issuer_allowlist"] = issuer_allowlist
             else:
                 oauth.pop("issuer_allowlist", None)
         if device_verification_base_url is not None:
-            if device_verification_base_url:
-                oauth["device_verification_base_url"] = device_verification_base_url
-            else:
-                oauth.pop("device_verification_base_url", None)
-        if issuer_from_proxy_headers is not None:
+            next_url = device_verification_base_url or ""
+            if not is_unchanged(
+                oauth.get("device_verification_base_url"),
+                next_url,
+            ):
+                if device_verification_base_url:
+                    oauth["device_verification_base_url"] = device_verification_base_url
+                else:
+                    oauth.pop("device_verification_base_url", None)
+        if issuer_from_proxy_headers is not None and not is_unchanged(
+            oauth.get("issuer_from_proxy_headers"), issuer_from_proxy_headers
+        ):
             oauth["issuer_from_proxy_headers"] = issuer_from_proxy_headers
-        if audience is not None:
+        if audience is not None and not is_unchanged(oauth.get("audience"), audience):
             oauth["audience"] = audience
-        if token_expiry_minutes is not None:
+        if token_expiry_minutes is not None and not is_unchanged(
+            oauth.get("token_expiry_minutes"), token_expiry_minutes
+        ):
             oauth["token_expiry_minutes"] = token_expiry_minutes
-        if require_pkce is not None:
+        if require_pkce is not None and not is_unchanged(
+            oauth.get("require_pkce"), require_pkce
+        ):
             oauth["require_pkce"] = require_pkce
-        if refresh_token_rotation is not None:
+        if refresh_token_rotation is not None and not is_unchanged(
+            oauth.get("refresh_token_rotation"), refresh_token_rotation
+        ):
             oauth["refresh_token_rotation"] = refresh_token_rotation
 
         self._atomic_write(self.settings_file, data)
@@ -212,42 +252,59 @@ class YamlWriter:
         roles_attr_name: Optional[str] = None,
         groups_attr_name: Optional[str] = None,
     ) -> None:
-        """Update SAML settings."""
+        """Update SAML settings (same unchanged-field guard as #127 above)."""
         data = self._load_settings_yaml()
         saml = data.setdefault("saml", {})
 
-        if entity_id is not None:
+        if entity_id is not None and not is_unchanged(saml.get("entity_id"), entity_id):
             saml["entity_id"] = entity_id
-        if sso_url is not None:
+        if sso_url is not None and not is_unchanged(saml.get("sso_url"), sso_url):
             saml["sso_url"] = sso_url
-        if default_acs_url is not None:
+        if default_acs_url is not None and not is_unchanged(
+            saml.get("default_acs_url"), default_acs_url
+        ):
             saml["default_acs_url"] = default_acs_url
-        if sign_responses is not None:
+        if sign_responses is not None and not is_unchanged(
+            saml.get("sign_responses"), sign_responses
+        ):
             saml["sign_responses"] = sign_responses
-        if strict_binding is not None:
+        if strict_binding is not None and not is_unchanged(
+            saml.get("strict_binding"), strict_binding
+        ):
             saml["strict_binding"] = strict_binding
-        if want_authn_requests_signed is not None:
+        if want_authn_requests_signed is not None and not is_unchanged(
+            saml.get("want_authn_requests_signed"), want_authn_requests_signed
+        ):
             saml["want_authn_requests_signed"] = want_authn_requests_signed
         if sp_certificates is not None:
             if sp_certificates:
-                saml["sp_certificates"] = sp_certificates
+                if not is_unchanged(saml.get("sp_certificates"), sp_certificates):
+                    saml["sp_certificates"] = sp_certificates
             else:
                 saml.pop("sp_certificates", None)
-        if c14n_algorithm is not None:
+        if c14n_algorithm is not None and not is_unchanged(
+            saml.get("c14n_algorithm"), c14n_algorithm
+        ):
             saml["c14n_algorithm"] = c14n_algorithm
-        if export_roles is not None:
+        if export_roles is not None and not is_unchanged(
+            saml.get("export_roles"), export_roles
+        ):
             saml["export_roles"] = export_roles
-        if export_groups is not None:
+        if export_groups is not None and not is_unchanged(
+            saml.get("export_groups"), export_groups
+        ):
             saml["export_groups"] = export_groups
         # Empty string drops the key so the default name applies again.
         if roles_attr_name is not None:
             if roles_attr_name:
-                saml["roles_attr_name"] = roles_attr_name
+                if not is_unchanged(saml.get("roles_attr_name"), roles_attr_name):
+                    saml["roles_attr_name"] = roles_attr_name
             else:
                 saml.pop("roles_attr_name", None)
         if groups_attr_name is not None:
             if groups_attr_name:
-                saml["groups_attr_name"] = groups_attr_name
+                if not is_unchanged(saml.get("groups_attr_name"), groups_attr_name):
+                    saml["groups_attr_name"] = groups_attr_name
             else:
                 saml.pop("groups_attr_name", None)
 
@@ -257,7 +314,8 @@ class YamlWriter:
     def update_authority_prefixes(self, prefixes: Dict[str, str]) -> None:
         """Update authority prefix mappings."""
         data = self._load_settings_yaml()
-        data["authority_prefixes"] = prefixes
+        if not is_unchanged(data.get("authority_prefixes"), prefixes):
+            data["authority_prefixes"] = prefixes
 
         self._atomic_write(self.settings_file, data)
         get_config().reload()
@@ -265,7 +323,8 @@ class YamlWriter:
     def update_allowed_identity_classes(self, classes: List[str]) -> None:
         """Update allowed identity classes."""
         data = self._load_settings_yaml()
-        data["allowed_identity_classes"] = classes
+        if not is_unchanged(data.get("allowed_identity_classes"), classes):
+            data["allowed_identity_classes"] = classes
 
         self._atomic_write(self.settings_file, data)
         get_config().reload()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,8 +85,9 @@ def preserve_config_files():
 
     A few tests exercise code paths that persist settings to the real config
     directory (e.g. POST ``/settings`` goes through the YAML writer). Without
-    this, those tests leave the repo's ``config/settings.yaml`` modified - with
-    env-var placeholders resolved and unrelated values flipped. Restoring the
+    this, those tests leave the repo's ``config/settings.yaml`` modified with
+    whatever fields they genuinely changed (unrelated fields, ``${VAR}``
+    placeholders and comments are left untouched since #127). Restoring the
     exact bytes keeps the working tree clean.
     """
     import pathlib

--- a/tests/test_issue_127_settings_round_trip.py
+++ b/tests/test_issue_127_settings_round_trip.py
@@ -1,0 +1,237 @@
+"""
+Tests for issue #127: saving settings used to silently discard comments,
+inline ``#`` text and ``${VAR:default}`` placeholders in ``settings.yaml``.
+
+Covers the fix's contract:
+  - A block comment survives a settings save.
+  - An untouched ``${VAR:default}`` placeholder survives a save that changed
+    an unrelated field, via both ``ConfigManager.save()`` (MCP `save_config`)
+    and ``YamlWriter`` (web UI full-form resubmit).
+  - A quoted value containing ``#`` stays intact across a save.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from nanoidp.config import ConfigManager
+from nanoidp.services.yaml_writer import YamlWriter
+
+SETTINGS_WITH_PLACEHOLDER_AND_COMMENT = """\
+server:
+  host: 0.0.0.0
+  port: ${PORT:8000}
+  debug: false
+oauth:
+  issuer: http://localhost:${PORT:8000}
+  audience: my-app
+  token_expiry_minutes: 60
+  clients:
+  - client_id: c1
+    client_secret: s1
+    description: 'registered client (exact matching, issue #67)'
+saml:
+  entity_id: http://localhost:8000/saml
+  sso_url: http://localhost:8000/saml/sso
+  default_acs_url: http://localhost:8080/sso
+  sign_responses: true
+  c14n_algorithm: exc_c14n
+  strict_binding: false
+  # Roles/groups are not standard SAML attributes; enable and name them here.
+  export_roles: false
+  export_groups: false
+  roles_attr_name: roles
+  groups_attr_name: groups
+"""
+
+
+def _seed(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "settings.yaml").write_text(SETTINGS_WITH_PLACEHOLDER_AND_COMMENT)
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+def _seed_custom_settings(tmp_path: Path, settings_text: str) -> Path:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "settings.yaml").write_text(settings_text)
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+def _raw(config_dir: Path) -> str:
+    return (config_dir / "settings.yaml").read_text()
+
+
+def _parsed(config_dir: Path) -> dict[str, Any]:
+    return yaml.safe_load(_raw(config_dir))
+
+
+class TestCommentSurvivesSave:
+    def test_saml_comment_survives_a_config_manager_save(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("PORT", raising=False)
+        config_dir = _seed(tmp_path)
+        manager = ConfigManager(str(config_dir))
+
+        manager.settings.audience = "changed-audience"
+        manager.save()
+
+        assert (
+            "# Roles/groups are not standard SAML attributes; enable and name"
+            " them here."
+        ) in _raw(config_dir)
+
+
+class TestPlaceholderSurvivesUnrelatedSave:
+    def test_via_config_manager_save(self, tmp_path, monkeypatch):
+        """MCP update_settings + save_config: only the touched field changes."""
+        monkeypatch.delenv("PORT", raising=False)
+        config_dir = _seed(tmp_path)
+        manager = ConfigManager(str(config_dir))
+        assert manager.settings.port == 8000  # expanded default
+
+        manager.settings.audience = "changed-audience"
+        manager.save()
+
+        raw = _raw(config_dir)
+        assert "port: ${PORT:8000}" in raw
+        assert "issuer: http://localhost:${PORT:8000}" in raw
+        parsed = _parsed(config_dir)
+        assert parsed["oauth"]["audience"] == "changed-audience"
+
+    def test_via_yaml_writer_full_form_resubmit(self, tmp_path, monkeypatch):
+        """Web UI resubmits the whole form; unchanged fields carry the
+        already-expanded value the template rendered - the writer must not
+        clobber the raw placeholder for those."""
+        monkeypatch.delenv("PORT", raising=False)
+        config_dir = _seed(tmp_path)
+        ConfigManager(str(config_dir))
+        writer = YamlWriter(str(config_dir))
+
+        # Simulate the form: issuer field shows the expanded value (unchanged
+        # by the user), audience is a genuine edit.
+        writer.update_oauth_settings(
+            issuer="http://localhost:8000",  # expanded, same as on-disk placeholder
+            audience="changed-audience",
+        )
+
+        raw = _raw(config_dir)
+        assert "issuer: http://localhost:${PORT:8000}" in raw
+        parsed = _parsed(config_dir)
+        assert parsed["oauth"]["audience"] == "changed-audience"
+
+    def test_placeholder_is_overwritten_when_genuinely_changed(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("PORT", raising=False)
+        config_dir = _seed(tmp_path)
+        ConfigManager(str(config_dir))
+        writer = YamlWriter(str(config_dir))
+
+        writer.update_oauth_settings(issuer="http://example.com")
+
+        parsed = _parsed(config_dir)
+        assert parsed["oauth"]["issuer"] == "http://example.com"
+
+
+class TestHashInQuotedValueStaysIntact:
+    def test_quoted_description_with_hash_survives_unrelated_save(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("PORT", raising=False)
+        config_dir = _seed(tmp_path)
+        manager = ConfigManager(str(config_dir))
+
+        manager.settings.audience = "changed-audience"
+        manager.save()
+
+        parsed = _parsed(config_dir)
+        assert (
+            parsed["oauth"]["clients"][0]["description"]
+            == "registered client (exact matching, issue #67)"
+        )
+
+    def test_new_description_with_hash_is_quoted_on_write(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("PORT", raising=False)
+        config_dir = _seed(tmp_path)
+        manager = ConfigManager(str(config_dir))
+
+        manager.settings.clients[0].description = "new text with a # character"
+        manager.save()
+
+        raw = _raw(config_dir)
+        assert "'new text with a # character'" in raw
+        parsed = _parsed(config_dir)
+        assert (
+            parsed["oauth"]["clients"][0]["description"]
+            == "new text with a # character"
+        )
+
+
+class TestEnvBackedSecretsAndEmptyPlaceholders:
+    def test_env_backed_client_secret_is_not_materialized_when_editing_other_client(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("APP1_SECRET", "SUPERSECRET")
+        config_dir = _seed_custom_settings(
+            tmp_path,
+            """\
+server:
+  host: 0.0.0.0
+  port: 8000
+oauth:
+  audience: my-app
+  clients:
+  - client_id: app1
+    client_secret: ${APP1_SECRET:dev}
+    description: first
+  - client_id: app2
+    client_secret: foo
+    description: second
+""",
+        )
+        manager = ConfigManager(str(config_dir))
+
+        manager.settings.clients[1].description = "updated second client"
+        manager.save()
+
+        raw = _raw(config_dir)
+        assert "client_secret: ${APP1_SECRET:dev}" in raw
+        assert "SUPERSECRET" not in raw
+        assert "client_secret: 'SUPERSECRET'" not in raw
+
+        reloaded = ConfigManager(str(config_dir))
+        assert reloaded.settings.clients[0].client_secret == "SUPERSECRET"
+        assert reloaded.settings.clients[1].description == "updated second client"
+
+    def test_empty_default_placeholder_stays_in_file_when_other_fields_change(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("DEVICE_URL", raising=False)
+        config_dir = _seed_custom_settings(
+            tmp_path,
+            """\
+server:
+  host: 0.0.0.0
+  port: 8000
+oauth:
+  audience: my-app
+  device_verification_base_url: ${DEVICE_URL:}
+  clients: []
+""",
+        )
+        manager = ConfigManager(str(config_dir))
+
+        manager.settings.audience = "changed-audience"
+        manager.save()
+
+        raw = _raw(config_dir)
+        assert "device_verification_base_url: ${DEVICE_URL:}" in raw
+        assert "device_verification_base_url: ''" not in raw
+        parsed = _parsed(config_dir)
+        assert parsed["oauth"]["audience"] == "changed-audience"


### PR DESCRIPTION
This fixes the remaining regression in the settings save path.

Preserve raw ${VAR:default} placeholders when an unrelated field changes
Avoid rewriting the whole oauth.clients list when only a sibling client changes
Merge client entries by client_id and update fields individually so unchanged env-backed secrets stay in the YAML instead of being materialized
Treat empty optional values such as ${DEVICE_URL:} as unchanged when they still resolve to an empty string, instead of dropping the key from the file
Add regression tests covering both the env-backed client secret case and the empty-default placeholder case