### PR TITLE
Consolidated the OAuth client YAML merge logic into a single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effect after a restart.
 
 ### Changed
+- **Consolidated the OAuth client YAML merge logic** into a single
+  `serialization.merge_client_entry()` helper, shared by the settings save
+  path (`merge_oauth_clients()`) and `YamlWriter.save_client()`'s web UI
+  edit path, which previously duplicated the same field-by-field merge
+  rules. Internal cleanup, no behavior change.
 - **Migrated the MCP server to the mcp 2.0 SDK** and pinned `mcp>=2,<3`. mcp 2.0
   replaced the lowlevel `Server` decorators (`@server.list_tools()` /
   `@server.call_tool()`) with `on_*` constructor parameters, so a fresh install

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -136,6 +136,40 @@ def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
     return entry
 
 
+def merge_client_entry(raw_entry: Dict[str, Any], client: OAuthClient) -> Dict[str, Any]:
+    """Update a single raw settings.yaml client entry from ``client``, field by
+    field, guarded by ``is_unchanged()`` (#127/#138).
+
+    Shared by ``merge_oauth_clients()`` (full-list merge) and
+    ``YamlWriter.save_client()`` (single-entry update) so the merge rules -
+    which fields are quoted, when an emptied optional list field is dropped -
+    only exist once. Returns a new dict; ``raw_entry`` is not mutated.
+    """
+    updated = raw_entry.copy()
+    for field_name, new_value in (
+        ("client_id", client.client_id),
+        ("client_secret", client.client_secret),
+        ("description", client.description),
+    ):
+        if not is_unchanged(raw_entry.get(field_name), new_value):
+            if field_name in {"client_secret", "description"}:
+                updated[field_name] = _quoted(str(new_value))
+            else:
+                updated[field_name] = new_value
+
+    for field_name, new_list_value in (
+        ("additional_audiences", client.additional_audiences),
+        ("redirect_uris", client.redirect_uris),
+    ):
+        if not is_unchanged(raw_entry.get(field_name), new_list_value):
+            if new_list_value:
+                updated[field_name] = new_list_value
+            else:
+                updated.pop(field_name, None)
+
+    return updated
+
+
 def merge_oauth_clients(
     raw_clients: Any, settings_clients: list["OAuthClient"]
 ) -> list[Dict[str, Any]]:
@@ -155,39 +189,13 @@ def merge_oauth_clients(
                     raw_by_id[client_id] = raw
 
     merged: list[Dict[str, Any]] = []
-    seen: set[str] = set()
 
     for client in settings_clients:
-        client_id = client.client_id
-        seen.add(client_id)
-        raw_entry = raw_by_id.get(client_id)
+        raw_entry = raw_by_id.get(client.client_id)
         if raw_entry is None:
             merged.append(client_to_yaml(client))
-            continue
-
-        updated = raw_entry.copy()
-        for field_name, new_value in (
-            ("client_id", client.client_id),
-            ("client_secret", client.client_secret),
-            ("description", client.description),
-        ):
-            if not is_unchanged(raw_entry.get(field_name), new_value):
-                if field_name in {"client_secret", "description"}:
-                    updated[field_name] = _quoted(str(new_value))
-                else:
-                    updated[field_name] = new_value
-
-        for field_name, new_list_value in (
-            ("additional_audiences", client.additional_audiences),
-            ("redirect_uris", client.redirect_uris),
-        ):
-            if not is_unchanged(raw_entry.get(field_name), new_list_value):
-                if new_list_value:
-                    updated[field_name] = new_list_value
-                else:
-                    updated.pop(field_name, None)
-
-        merged.append(updated)
+        else:
+            merged.append(merge_client_entry(raw_entry, client))
 
     return merged
 

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -13,6 +13,7 @@ from ..serialization import (
     client_to_yaml,
     is_unchanged,
     load_yaml_document,
+    merge_client_entry,
     user_to_yaml,
 )
 
@@ -125,30 +126,7 @@ class YamlWriter:
             raise ValueError(f"Client '{client.client_id}' already exists")
 
         if existing_idx is not None:
-            raw_entry = clients[existing_idx]
-            updated_entry = raw_entry.copy()
-            for field_name, new_value in (
-                ("client_id", client.client_id),
-                ("client_secret", client.client_secret),
-                ("description", client.description),
-            ):
-                if not is_unchanged(raw_entry.get(field_name), new_value):
-                    if field_name in {"client_secret", "description"}:
-                        updated_entry[field_name] = client_to_yaml(client)[field_name]
-                    else:
-                        updated_entry[field_name] = new_value
-
-            for field_name, new_list_value in (
-                ("additional_audiences", client.additional_audiences),
-                ("redirect_uris", client.redirect_uris),
-            ):
-                if not is_unchanged(raw_entry.get(field_name), new_list_value):
-                    if new_list_value:
-                        updated_entry[field_name] = new_list_value
-                    else:
-                        updated_entry.pop(field_name, None)
-
-            clients[existing_idx] = updated_entry
+            clients[existing_idx] = merge_client_entry(clients[existing_idx], client)
         else:
             clients.append(client_to_yaml(client))
 


### PR DESCRIPTION
  `serialization.merge_client_entry()` helper, shared by the settings save
  path (`merge_oauth_clients()`) and `YamlWriter.save_client()`'s web UI
  edit path, which previously duplicated the same field-by-field merge
  rules. Internal cleanup, no behavior change.
#143 