### PR TITLE
fix: lower cryptography floor to >=45.0.0 (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effect after a restart.
 
 ### Changed
+- **Lowered the `cryptography` floor from `>=46.0.3` to `>=45.0.0`** (#140). The
+  previous floor came from a generic dependency bump, not a real requirement:
+  our own API usage needs nothing newer than ~3.1. The effective minimum is set
+  by `signxml`, which imports `x509.verification.ExtensionPolicy` (added in
+  cryptography 45.0.0) at load time. This unblocks installs on environments
+  pinned to a `cryptography` between 45 and 46.
 - **Consolidated the OAuth client YAML merge logic** into a single
   `serialization.merge_client_entry()` helper, shared by the settings save
   path (`merge_oauth_clients()`) and `YamlWriter.save_client()`'s web UI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ dependencies = [
     "Flask-Cors>=6.0.2",
     "Flask-Limiter>=4.1.1",
     "PyJWT>=2.8.0",
-    "cryptography>=46.0.3",
+    # Floor is set by signxml: signxml 4.2.2 imports x509.verification.ExtensionPolicy
+    # (added in cryptography 45.0.0) at module load, though it only declares >=43.
+    # Our own API usage would be happy far lower - do not raise without a real reason.
+    "cryptography>=45.0.0",
     "lxml>=6.0.2",
     "signxml>=4.2.0",
     "PyYAML>=6.0",


### PR DESCRIPTION
Closes #140.

The `cryptography>=46.0.3` floor came from a generic "update deps" commit (2b5141f), not a real requirement.

**Findings**
- Our own `cryptography` API usage (in `services/crypto.py` and `services/saml_verification.py`) is all old, stable API - nothing introduced after ~3.1.
- The effective minimum is set transitively by `signxml`: signxml 4.2.2 imports `x509.verification.ExtensionPolicy` (added in cryptography **45.0.0**) at module load, even though its own metadata only declares `cryptography>=43`. So the declared transitive floor is misleadingly low.

**Verified empirically** (fresh venv, pinned cryptography):
- `43.0.1` -> signxml import fails (`ExtensionPolicy` missing)
- `44.0.1` -> signxml import fails
- `45.0.0` -> imports fine, full test suite 905 passed

Floor set to `>=45.0.0` with a comment recording why, so a future dep bump doesn't silently raise it again.