### PR TITLE
fix: match clients by expanded client_id so env placeholders survive (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ProxyFix` is wired at app startup, a value changed at runtime only takes
   effect after a restart.
 
+### Fixed
+- **Env-backed `client_id` placeholders are preserved on save** (#127). When a
+  client's `client_id` was itself a placeholder (`client_id: ${CLIENT_ID:app1}`),
+  the settings save matched the raw entry against the expanded id, missed it,
+  and rewrote the client from expanded values - losing the placeholders and
+  materializing the client secret; the web UI path appended a duplicate entry,
+  and `delete_client` could not find the client at all. Client matching now
+  expands the placeholder before comparing (`client_id_matches()`), used by the
+  settings save, `save_client()` and `delete_client()`.
+
 ### Changed
 - **Lowered the `cryptography` floor from `>=46.0.3` to `>=45.0.0`** (#140). The
   previous floor came from a generic dependency bump, not a real requirement:

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -106,6 +106,23 @@ def _quoted(value: str) -> SingleQuotedScalarString:
     return SingleQuotedScalarString(value)
 
 
+def client_id_matches(raw_entry: Any, client_id: str) -> bool:
+    """True if a raw settings.yaml client entry identifies the in-memory client
+    with ``client_id``.
+
+    ``client_id`` itself can be an env placeholder (``client_id: ${CLIENT_ID:app1}``),
+    which is expanded to its resolved value in the loaded ``Settings`` (#127).
+    Comparing the raw ``${CLIENT_ID:app1}`` against the expanded ``app1`` with
+    ``==`` would miss the entry, so the merge would treat it as a brand-new
+    client and rewrite it from expanded values - materializing any env-backed
+    secret in the process. Match through ``is_unchanged`` so the placeholder
+    expands before the comparison.
+    """
+    if not isinstance(raw_entry, dict):
+        return False
+    return is_unchanged(raw_entry.get("client_id"), client_id)
+
+
 def load_yaml_document(file_path: Path) -> Dict[str, Any]:
     """Load a YAML document preserving comments/quote style for a later
     round-trip write. Returns an empty ``CommentedMap`` if the file is
@@ -180,18 +197,18 @@ def merge_oauth_clients(
     still unchanged, but genuine edits replace the matching fields without
     rebuilding the whole list. Added clients are appended; removed ones drop out.
     """
-    raw_by_id = {}
-    if isinstance(raw_clients, list):
-        for raw in raw_clients:
-            if isinstance(raw, dict):
-                client_id = raw.get("client_id")
-                if client_id is not None:
-                    raw_by_id[client_id] = raw
+    raw_entries = [r for r in raw_clients if isinstance(r, dict)] if isinstance(
+        raw_clients, list
+    ) else []
 
     merged: list[Dict[str, Any]] = []
 
     for client in settings_clients:
-        raw_entry = raw_by_id.get(client.client_id)
+        # Match by expanded client_id so a raw ``${CLIENT_ID:app1}`` entry is
+        # recognised as the same client and its placeholders are preserved (#127).
+        raw_entry = next(
+            (r for r in raw_entries if client_id_matches(r, client.client_id)), None
+        )
         if raw_entry is None:
             merged.append(client_to_yaml(client))
         else:

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 from ..config import OAuthClient, User, get_config
 from ..serialization import (
     atomic_write_yaml,
+    client_id_matches,
     client_to_yaml,
     is_unchanged,
     load_yaml_document,
@@ -115,10 +116,12 @@ class YamlWriter:
 
         clients = data.setdefault("oauth", {}).setdefault("clients", [])
 
-        # Check if client exists
+        # Check if client exists. Match through client_id_matches so a raw
+        # ${CLIENT_ID:...} placeholder entry is recognised as the same client
+        # instead of being appended as a duplicate (#127).
         existing_idx = None
         for idx, c in enumerate(clients):
-            if c.get("client_id") == client.client_id:
+            if client_id_matches(c, client.client_id):
                 existing_idx = idx
                 break
 
@@ -138,7 +141,9 @@ class YamlWriter:
         data = self._load_settings_yaml()
 
         clients = data.get("oauth", {}).get("clients", [])
-        new_clients = [c for c in clients if c.get("client_id") != client_id]
+        # Match through client_id_matches so a client whose id is an env
+        # placeholder can still be deleted (#127).
+        new_clients = [c for c in clients if not client_id_matches(c, client_id)]
 
         if len(new_clients) == len(clients):
             raise ValueError(f"Client '{client_id}' not found")

--- a/tests/test_issue_127_settings_round_trip.py
+++ b/tests/test_issue_127_settings_round_trip.py
@@ -235,3 +235,78 @@ oauth:
         assert "device_verification_base_url: ''" not in raw
         parsed = _parsed(config_dir)
         assert parsed["oauth"]["audience"] == "changed-audience"
+
+
+class TestEnvBackedClientId:
+    """A client_id can itself be an env placeholder; the merge must still match
+    the raw entry by its expanded id, or it rewrites the client from expanded
+    values and materializes the secret (#127)."""
+
+    _SETTINGS = """\
+server:
+  host: 0.0.0.0
+  port: 8000
+oauth:
+  audience: my-app
+  clients:
+  - client_id: ${CLIENT_ID:app1}
+    client_secret: ${APP1_SECRET:dev}
+    description: first
+"""
+
+    def test_env_backed_client_id_survives_config_manager_save(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CLIENT_ID", "app1")
+        monkeypatch.setenv("APP1_SECRET", "SUPERSECRET")
+        config_dir = _seed_custom_settings(tmp_path, self._SETTINGS)
+        manager = ConfigManager(str(config_dir))
+        assert manager.settings.clients[0].client_id == "app1"  # expanded
+
+        manager.settings.clients[0].description = "first EDITED"
+        manager.save()
+
+        raw = _raw(config_dir)
+        assert "client_id: ${CLIENT_ID:app1}" in raw
+        assert "client_secret: ${APP1_SECRET:dev}" in raw
+        assert "SUPERSECRET" not in raw
+        assert raw.count("client_id") == 1  # not duplicated as a "new" client
+
+    def test_env_backed_client_id_survives_ui_save_client(
+        self, tmp_path, monkeypatch
+    ):
+        from nanoidp.config import OAuthClient
+
+        monkeypatch.setenv("CLIENT_ID", "app1")
+        monkeypatch.setenv("APP1_SECRET", "SUPERSECRET")
+        config_dir = _seed_custom_settings(tmp_path, self._SETTINGS)
+        ConfigManager(str(config_dir))
+        writer = YamlWriter(str(config_dir))
+
+        existing = writer._load_settings_yaml()["oauth"]["clients"][0]
+        # UI edit leaving the secret blank keeps the already-expanded value.
+        writer.save_client(
+            OAuthClient(
+                client_id="app1",
+                client_secret="SUPERSECRET",
+                description="edited via UI",
+            )
+        )
+
+        raw = _raw(config_dir)
+        assert "client_secret: ${APP1_SECRET:dev}" in raw
+        assert "SUPERSECRET" not in raw
+        assert raw.count("client_id") == 1  # updated in place, not appended
+        assert existing["client_id"] == "${CLIENT_ID:app1}"
+
+    def test_env_backed_client_id_can_be_deleted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLIENT_ID", "app1")
+        monkeypatch.setenv("APP1_SECRET", "SUPERSECRET")
+        config_dir = _seed_custom_settings(tmp_path, self._SETTINGS)
+        ConfigManager(str(config_dir))
+        writer = YamlWriter(str(config_dir))
+
+        writer.delete_client("app1")  # expanded id, raw is ${CLIENT_ID:app1}
+
+        parsed = _parsed(config_dir)
+        assert parsed["oauth"]["clients"] == []


### PR DESCRIPTION
Closes the last #127 gap (found in post-merge review of #138/#144).

**The bug**: a client whose `client_id` is itself an env placeholder is expanded on load, so in memory it is e.g. `app1` while the raw file still holds `${CLIENT_ID:app1}`. Every client-matching path compared the raw id against the expanded id with `==`, missed the entry, and treated it as a new/unknown client:

- **settings save** (`merge_oauth_clients`, also the MCP `save_config` path): rewrote the client from expanded values, losing both `${CLIENT_ID:...}` and `${...SECRET...}` placeholders and **materializing the secret in cleartext**;
- **web UI** (`save_client`): appended a **duplicate** client entry;
- **`delete_client`**: raised `Client '<id>' not found` - the client could not be deleted at all.

Reproduced empirically on all three paths before the fix.

**The fix**: `serialization.client_id_matches(raw_entry, client_id)` expands the raw id through `is_unchanged()` before comparing, used by `merge_oauth_clients()`, `save_client()` and `delete_client()`. Small and centralized.

**Verified**: all three paths corrected (placeholders kept, no secret materialized, no duplicate, delete works); the existing #127/#138 round-trip repros for non-placeholder clients still pass; ruff + mypy clean; full suite 908 passed (3 new regression tests with `CLIENT_ID` and `APP1_SECRET` both set).