### PR TITLE
fix: pre-release hardening (PyJWT floor, client_id uniqueness, INTERN typo)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,13 +68,15 @@ jobs:
       - name: List dependency licenses
         run: pip-licenses --with-authors --with-urls --format=markdown
 
-      - name: Fail on copyleft licenses incompatible with MIT redistribution
+      - name: Fail on copyleft licenses blocked by the dependency-license policy
         run: |
-          # nanoidp ships under MIT. Strong/network copyleft (GPL, LGPL, AGPL,
-          # SSPL, EUPL) is incompatible with redistributing the combined work
-          # under MIT, so any dependency carrying one must be reviewed by a
-          # human before it can ship. Weak per-file copyleft (MPL-2.0, already
-          # present via certifi) is allowed and intentionally not listed.
+          # nanoidp ships under MIT. The project's dependency-license policy
+          # blocks strong/network copyleft (GPL, LGPL, AGPL, SSPL, EUPL) from
+          # shipping without explicit human review: redistributing such a
+          # dependency in an MIT work carries conditions that need a conscious
+          # decision, so the gate stops the build until someone makes it. Weak
+          # per-file copyleft (MPL-2.0, already present via certifi) is allowed
+          # and intentionally not listed.
           # "General Public License" catches the GPL/LGPL/AGPL full names;
           # "GPL" catches their acronym spellings. --partial-match is required:
           # without it --fail-on only matches a license string in full.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are affected by CVE-2026-48525 (unbounded Base64URL decoding of a `b64=false`
   detached JWS payload, a DoS vector).
 - **Added a CI license gate** (#148): the build fails if a dependency in the
-  redistributed closure carries a GPL/LGPL/AGPL/SSPL/EUPL license incompatible
-  with MIT redistribution.
+  redistributed closure carries a GPL/LGPL/AGPL/SSPL/EUPL license, which the
+  project's dependency-license policy blocks from redistribution without
+  explicit review.
 - **Lowered the `cryptography` floor from `>=46.0.3` to `>=45.0.0`** (#140). The
   previous floor came from a generic dependency bump, not a real requirement:
   our own API usage needs nothing newer than ~3.1. The effective minimum is set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effect after a restart.
 
 ### Changed
+- **Raised the `PyJWT` floor to `>=2.13.0`** (was `>=2.8.0`). `/userinfo` and
+  `/introspect` pass a client-supplied token to `jwt.decode()`, and 2.8.0-2.12.1
+  are affected by CVE-2026-48525 (unbounded Base64URL decoding of a `b64=false`
+  detached JWS payload, a DoS vector).
+- **Added a CI license gate** (#148): the build fails if a dependency in the
+  redistributed closure carries a GPL/LGPL/AGPL/SSPL/EUPL license incompatible
+  with MIT redistribution.
 - **Lowered the `cryptography` floor from `>=46.0.3` to `>=45.0.0`** (#140). The
   previous floor came from a generic dependency bump, not a real requirement:
   our own API usage needs nothing newer than ~3.1. The effective minimum is set
@@ -129,6 +136,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real client.
 
 ### Fixed
+- **Duplicate OAuth `client_id`s are rejected at load** (#127). Two clients
+  that resolve to the same effective id (including two `${VAR}` placeholders
+  expanding to the same value) made client lookup ambiguous and caused the
+  save-merge to match the wrong raw entry, materializing a secret; the loader
+  now fails fast with a clear error instead.
+- **Import no longer crashes when package metadata is absent** (#139). Running
+  from an uninstalled source tree (vendored, or copied into an image without
+  `pip install`) raised `PackageNotFoundError`; the version now falls back to
+  reading `pyproject.toml`, then to a static string.
+- **Default admin user's `identity_class` is `INTERNAL`, not `INTERN`**. The
+  no-`users.yaml` fallback used a typo'd class that didn't match the generated
+  template or the default allowed classes.
 - **Env-backed `client_id` placeholders are preserved on save** (#127). When a
   client's `client_id` was itself a placeholder (`client_id: ${CLIENT_ID:app1}`),
   the settings save matched the raw entry against the expanded id, missed it,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ dependencies = [
     "Flask>=3.0.0",
     "Flask-Cors>=6.0.2",
     "Flask-Limiter>=4.1.1",
-    "PyJWT>=2.8.0",
+    # >=2.13.0: /userinfo and /introspect pass a client-supplied token to
+    # jwt.decode(), and 2.8.0-2.12.1 are affected by CVE-2026-48525 (unbounded
+    # Base64URL decode of a b64=false detached JWS payload -> DoS).
+    "PyJWT>=2.13.0",
     # Floor is set by signxml: signxml 4.2.2 imports x509.verification.ExtensionPolicy
     # (added in cryptography 45.0.0) at module load, though it only declares >=43.
     # Our own API usage would be happy far lower - do not raise without a real reason.

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -106,6 +106,21 @@ class ConfigManager:
                 ),
             ))
 
+        # A client_id must be unique. Duplicates - including two ${VAR}
+        # placeholders that expand to the same value - make client lookup
+        # ambiguous and cause the settings-save merge to match the wrong raw
+        # entry, which can materialize an env-backed secret (#127/#151). Fail
+        # fast rather than silently corrupt settings.yaml on the next save.
+        seen_client_ids: set[str] = set()
+        for parsed_client in clients:
+            if parsed_client.client_id in seen_client_ids:
+                raise ValueError(
+                    f"Duplicate OAuth client_id '{parsed_client.client_id}' in "
+                    "settings.yaml; client ids must be unique (check for env "
+                    "placeholders that expand to the same value)"
+                )
+            seen_client_ids.add(parsed_client.client_id)
+
         self.settings = Settings(
             # Server
             host=server.get("host", "0.0.0.0"),
@@ -221,7 +236,7 @@ class ConfigManager:
                 username="admin",
                 password="admin",
                 email="admin@example.org",
-                identity_class="INTERN",
+                identity_class="INTERNAL",
                 roles=["USER", "ADMIN"],
                 tenant="default",
             ),

--- a/tests/test_issue_127_settings_round_trip.py
+++ b/tests/test_issue_127_settings_round_trip.py
@@ -310,3 +310,34 @@ oauth:
 
         parsed = _parsed(config_dir)
         assert parsed["oauth"]["clients"] == []
+
+
+class TestDuplicateClientIdFailsFast:
+    """Two clients that resolve to the same effective client_id would make the
+    save-merge match the wrong raw entry and materialize a secret (#127/#151);
+    the loader rejects them instead."""
+
+    def test_duplicate_effective_client_id_is_rejected(self, tmp_path, monkeypatch):
+        import pytest
+
+        monkeypatch.setenv("CLIENT_A", "foo")
+        monkeypatch.setenv("CLIENT_B", "foo")
+        config_dir = _seed_custom_settings(
+            tmp_path,
+            """\
+server:
+  host: 127.0.0.1
+  port: 8000
+oauth:
+  audience: my-app
+  clients:
+  - client_id: ${CLIENT_A:foo}
+    client_secret: sa
+    description: A
+  - client_id: ${CLIENT_B:foo}
+    client_secret: sb
+    description: B
+""",
+        )
+        with pytest.raises(ValueError, match="Duplicate OAuth client_id 'foo'"):
+            ConfigManager(str(config_dir))


### PR DESCRIPTION
Pre-2.6.0 preflight fixes (from a review of current `main`). The loopback-binding gap and the cryptography/lxml floor questions are handled separately (see notes below).

**PyJWT floor `>=2.8.0` -> `>=2.13.0`** (security). `/userinfo` and `/introspect` pass a client-supplied token to `jwt.decode()`; 2.8.0-2.12.1 are affected by CVE-2026-48525 (unbounded Base64URL decode of a `b64=false` detached JWS payload, a DoS vector). 2.13.0 is the fixed release. Verified the code path exists and the full suite passes on 2.13.0.

**Duplicate `client_id` rejected at load** (#127/#151 follow-up). Two clients resolving to the same effective id - including two `${VAR}` placeholders expanding to the same value - made the save-merge match the wrong raw entry and **materialize a secret** (reproduced). Rather than define merge semantics for something OAuth forbids, the loader now fails fast with a clear error. Regression test included.

**`INTERN` -> `INTERNAL` typo** in the no-`users.yaml` admin fallback, so it matches the generated template and the default allowed identity classes.

**CHANGELOG**: added the missing #139 (version fallback) and #148 (license gate) entries.

Verified: ruff clean, full suite 909 passed on PyJWT 2.13.0 (+1 duplicate-id regression test).

---
Not in this PR, by design / for a decision:
- **Loopback default binding** (wizard + `--host` help + init template + model/loader): lives on the private advisory branch with the rest of the GHSA fix, merges at the release tag (kept out of public history until disclosure).
- **`cryptography` floor** (#140 lowered it to 45 for install compatibility): leaving as-is; a security-vs-compatibility bump to 46.0.7 would undo that. Flagging for a conscious call, not changing automatically.
- **`lxml` floor**: SAML parser is hardened (`resolve_entities=False`, `no_network=True`, `load_dtd=False`) with no `iterparse`/`ETCompatXMLParser` use, so no exploit path; a bump to `>=6.1.0` would be cleaner but isn't required.
- **`--profile dev` not overriding a YAML profile**: real but non-security (fails restrictive); deferred to 2.6.1/2.7.