### PR TITLE
feat: Per-client login page branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the security caveats inline.
 
 ### Added
+- **Per-client login page branding**: optional per-client colors (background,
+  header, footer, all as validated hex values), show/hide client_id and
+  description on the `/authorize` login page, and per-client logo images
+  stored locally in `static/logos/` keyed by client ID (no YAML config needed
+  for logos; place the image file and it's served automatically; the
+  directory is overridable via `oauth.logos_dir`). Colours and toggles are
+  editable from the OAuth client form in the UI and from the MCP
+  `create_client`/`update_client`/`get_client` tools, descriptions are
+  already supported, and logos are deployed by the operator to the server
+  filesystem. Designed for demos and prototyping; colours are structured
+  (not free-form CSS) to prevent stored-XSS on the auth UI, and logos are
+  local files only (no remote URLs) to avoid beacons.
 - **First-class group support**: users gain a `groups` list alongside `roles`,
   modelled exactly the same way. It is loaded from and persisted to
   `users.yaml` (omitted when empty), emitted as a `groups` claim on the access

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -96,6 +96,15 @@ oauth:
       description: "Client whose redirect_uri is pinned"
       redirect_uris:            # optional; when set, /authorize enforces
         - "http://localhost:3000/callback"  # exact string matching
+    - client_id: "branded-client"
+      client_secret: "secret"
+      description: "Demo client with custom login page branding"
+      background_color: "#2c3e50"  # optional; hex only, behind the login card
+      header_color: "#3498db"      # optional; hex only, the card's header band
+      footer_color: "#e8f4f8"      # optional; hex only, the card's footer band
+      show_client_id: true         # optional; default true
+      show_description: true       # optional; default false
+  # logos_dir: "./static/logos"    # optional; defaults to src/nanoidp/static/logos
 
 saml:
   entity_id: "http://localhost:8000/saml"
@@ -137,6 +146,29 @@ OAuth 2.1 §4.1.1): no prefix, host or path normalization, and a mismatch
 is answered with `400 invalid_request` directly, never by redirecting to
 the unvalidated URI (§3.1.2.4). Clients without the field keep accepting
 any syntactically valid URI, the permissive dev default.
+
+**Login page branding**: for demos and prototyping, a client can show its
+`client_id` and `description` on the `/authorize` login page and use custom
+colors, so testers can see which application they're signing in to. All
+fields are optional and safe by construction: colors must be a plain
+`#rrggbb` hex string (validated on save, rejected otherwise), never raw CSS
+or markup, and a logo is a local file, never a remote URL. To add a logo,
+drop an image at `<logos_dir>/<client_id>.{svg,png,jpg,jpeg,webp}` (default
+`logos_dir`: `src/nanoidp/static/logos`, overridable via `oauth.logos_dir`);
+it's picked up by filename, no config entry needed.
+
+To preview a client's branded login page, open `/authorize` with its
+`client_id` and a `redirect_uri` (any syntactically valid URL works unless
+the client has `redirect_uris` pinned - see above):
+
+```text
+http://localhost:8000/authorize?response_type=code&client_id=branded-client&redirect_uri=http://localhost:3000/callback
+```
+
+The page won't complete the flow (there's no app listening at
+`redirect_uri` to receive the code), but it renders the branding, which is
+all a visual check needs. This only affects `/authorize`; the dashboard's
+own `/login` and the SAML SSO login page are unbranded.
 
 The SAML options (`strict_binding`, `sign_responses`, `c14n_algorithm`)
 are covered in detail in [SAML options](saml.md). Security-related

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -24,8 +24,17 @@ oauth:
     description: 'Client with registered redirect URIs (exact matching, issue #67)'
     redirect_uris:
     - http://localhost:3000/callback
+  - client_id: branded-client
+    client_secret: branded-secret
+    description: Demo client with custom login page branding
+    background_color: '#2c3e50'
+    header_color: '#3498db'
+    footer_color: '#e8f4f8'
+    show_client_id: true
+    show_description: true
   issuer_from_request: false
   issuer_from_proxy_headers: false
+  # logos_dir: ./static/logos  # optional override; defaults to src/nanoidp/static/logos
 saml:
   entity_id: http://localhost:${PORT:8000}/saml
   sso_url: http://localhost:${PORT:8000}/saml/sso

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -813,6 +813,74 @@ class NanoIDPTestAgent:
                 "Redirect URI Exact Match", TestCategory.OAUTH, False, f"Error: {e}"
             )
 
+    def test_client_branding(self) -> TestResult:
+        """Per-client login page branding is created and rendered end-to-end (#150).
+
+        Creates a client with colors and the id/description toggles via the
+        clients UI form, then checks that /authorize's login page reflects
+        every one of them, and cleans the client up afterwards.
+        """
+        test_client_id = f"branding-test-{secrets.token_hex(4)}"
+        test_description = "Branding e2e test client"
+        try:
+            create = requests.post(
+                f"{self.base_url}/clients/create",
+                data={
+                    "client_id": test_client_id,
+                    "client_secret": "branding-test-secret",
+                    "description": test_description,
+                    "background_color": "#123456",
+                    "header_color": "#abcdef",
+                    "footer_color": "#654321",
+                    "show_client_id": "on",
+                    "show_description": "on",
+                },
+                allow_redirects=False,
+                timeout=5,
+            )
+            created = (
+                create.status_code in (302, 303)
+                and create.headers.get("Location", "").rstrip("/").endswith("/clients")
+            )
+            if not created:
+                return self._add_result(
+                    "Client Branding", TestCategory.OAUTH, False,
+                    f"Client creation failed: status={create.status_code}, "
+                    f"location={create.headers.get('Location')}",
+                )
+
+            authorize = requests.get(
+                f"{self.base_url}/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": test_client_id,
+                    "redirect_uri": "http://localhost:3000/callback",
+                },
+                timeout=5,
+            )
+            html = authorize.text
+            checks = {
+                "background_color": "#123456" in html,
+                "header_color": "#abcdef" in html,
+                "footer_color": "#654321" in html,
+                "client_id_shown": test_client_id in html,
+                "description_shown": test_description in html,
+            }
+            success = authorize.status_code == 200 and all(checks.values())
+            return self._add_result(
+                "Client Branding", TestCategory.OAUTH, success,
+                f"authorize_status={authorize.status_code}, checks={checks}",
+                checks,
+            )
+        except Exception as e:
+            return self._add_result(
+                "Client Branding", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+        finally:
+            requests.post(
+                f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
+            )
+
     def test_id_token_audience(self) -> TestResult:
         """ID Token `aud` is the client_id; access token `aud` is the resource (issue #32)."""
         try:
@@ -3251,6 +3319,7 @@ class NanoIDPTestAgent:
                 self.test_issuer_from_proxy_headers,
                 self.test_authorization_code_pkce,
                 self.test_redirect_uri_exact_matching,
+                self.test_client_branding,
                 self.test_id_token_audience,
                 self.test_id_token_time_claims,
                 self.test_id_token_audience_array,

--- a/src/nanoidp/branding.py
+++ b/src/nanoidp/branding.py
@@ -1,0 +1,41 @@
+"""Per-client login page branding utilities."""
+
+import os
+import re
+from typing import Optional
+
+_LOGO_EXTENSIONS = (".svg", ".png", ".jpg", ".jpeg", ".webp")
+_SAFE_CLIENT_ID = re.compile(r"[a-zA-Z0-9_-]+")
+
+
+def resolve_client_logo(logos_dir: str, client_id: str) -> Optional[str]:
+    """Return the filename of client_id's local logo, or None.
+
+    Ensures path-traversal safety by validating client_id against a charset
+    whitelist before building a filesystem path.
+
+    Args:
+        logos_dir: Absolute or relative path to the logos directory.
+        client_id: The OAuth client ID.
+
+    Returns:
+        A filename like "client-1.svg", or None if no logo found.
+    """
+    if not _SAFE_CLIENT_ID.fullmatch(client_id):
+        return None
+    logos_path = os.path.abspath(logos_dir)
+    for ext in _LOGO_EXTENSIONS:
+        filename = f"{client_id}{ext}"
+        path = os.path.join(logos_path, filename)
+        if os.path.isfile(path):
+            return filename
+    return None
+
+
+def effective_logos_dir(logos_dir: Optional[str], static_folder: Optional[str]) -> str:
+    """Resolve the configured logos directory, falling back to the app's static/logos.
+
+    Shared by the /authorize logo lookup, the logo-serving route, and the
+    clients form's help text, so all three always agree (#150 review).
+    """
+    return logos_dir or os.path.join(static_folder or "static", "logos")

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -98,6 +98,11 @@ class ConfigManager:
                 client_id=client_id,
                 client_secret=client_data.get("client_secret", ""),
                 description=client_data.get("description", ""),
+                background_color=client_data.get("background_color"),
+                header_color=client_data.get("header_color"),
+                footer_color=client_data.get("footer_color"),
+                show_client_id=client_data.get("show_client_id", True),
+                show_description=client_data.get("show_description", False),
                 additional_audiences=_coerce_additional_audiences(
                     client_data.get("additional_audiences", []), client_id
                 ),
@@ -137,6 +142,7 @@ class ConfigManager:
             refresh_token_rotation=oauth.get("refresh_token_rotation", False),
             require_pkce=oauth.get("require_pkce", False),
             clients=clients,
+            logos_dir=oauth.get("logos_dir"),
             # SAML
             saml_entity_id=saml.get("entity_id", "http://localhost:8000/saml"),
             saml_sso_url=saml.get("sso_url", "http://localhost:8000/saml/sso"),

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -39,6 +39,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from typing import Any, Optional, Tuple
 
 import jwt as pyjwt
@@ -57,7 +58,7 @@ from mcp.types import (
 
 from . import __version__
 from .config import ConfigManager, OAuthClient, User, init_config
-from .models import normalize_saml_attr_name
+from .models import HEX_COLOR_PATTERN, normalize_saml_attr_name
 from .services import (
     build_discovery_document,
     get_audit_log,
@@ -183,6 +184,11 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
     return {
         "client_id": client.client_id,
         "description": client.description,
+        "background_color": client.background_color,
+        "header_color": client.header_color,
+        "footer_color": client.footer_color,
+        "show_client_id": client.show_client_id,
+        "show_description": client.show_description,
         "additional_audiences": client.additional_audiences,
         "redirect_uris": client.redirect_uris,
     }
@@ -205,6 +211,21 @@ def _normalize_str_list(value: Any, field: str) -> list[str]:
 def _normalize_audiences(value: Any) -> list[str]:
     """Coerce a raw audiences argument (see ``_normalize_str_list``)."""
     return _normalize_str_list(value, "additional_audiences")
+
+
+_HEX_COLOR_RE = re.compile(HEX_COLOR_PATTERN)
+
+
+def _normalize_hex_color(value: Any, field: str) -> Optional[str]:
+    """Coerce a raw color argument: falsy (omitted/empty) clears it, otherwise
+    it must match OAuthClient's own hex pattern - checked here too so a bad
+    value is caught before any other field on the client is mutated (#37).
+    """
+    if not value:
+        return None
+    if not isinstance(value, str) or not _HEX_COLOR_RE.match(value):
+        raise ValueError(f"{field} must be a hex color like '#1a1a2e'")
+    return value
 
 
 # =============================================================================
@@ -480,6 +501,26 @@ _TOOLS: list[Tool] = [
                     "type": "string",
                     "description": "Human-readable description (optional)",
                 },
+                "background_color": {
+                    "type": "string",
+                    "description": "Hex color (e.g. '#1a1a2e') behind the /authorize login card (optional)",
+                },
+                "header_color": {
+                    "type": "string",
+                    "description": "Hex color (e.g. '#0d6efd') for the /authorize login card header band (optional)",
+                },
+                "footer_color": {
+                    "type": "string",
+                    "description": "Hex color (e.g. '#ffffff') for the /authorize login card footer band (optional)",
+                },
+                "show_client_id": {
+                    "type": "boolean",
+                    "description": "Show client_id on the /authorize login page (optional, default true)",
+                },
+                "show_description": {
+                    "type": "boolean",
+                    "description": "Show description on the /authorize login page (optional, default false)",
+                },
                 "additional_audiences": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -511,6 +552,26 @@ _TOOLS: list[Tool] = [
                 "description": {
                     "type": "string",
                     "description": "New description (optional)",
+                },
+                "background_color": {
+                    "type": "string",
+                    "description": "New hex color (e.g. '#1a1a2e') behind the /authorize login card; empty string clears it (optional)",
+                },
+                "header_color": {
+                    "type": "string",
+                    "description": "New hex color (e.g. '#0d6efd') for the /authorize login card header band; empty string clears it (optional)",
+                },
+                "footer_color": {
+                    "type": "string",
+                    "description": "New hex color (e.g. '#ffffff') for the /authorize login card footer band; empty string clears it (optional)",
+                },
+                "show_client_id": {
+                    "type": "boolean",
+                    "description": "Show client_id on the /authorize login page (optional)",
+                },
+                "show_description": {
+                    "type": "boolean",
+                    "description": "Show description on the /authorize login page (optional)",
                 },
                 "additional_audiences": {
                     "type": "array",
@@ -1026,6 +1087,13 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             client_id=client_id,
             client_secret=arguments["client_secret"],
             description=arguments.get("description", ""),
+            background_color=_normalize_hex_color(
+                arguments.get("background_color"), "background_color"
+            ),
+            header_color=_normalize_hex_color(arguments.get("header_color"), "header_color"),
+            footer_color=_normalize_hex_color(arguments.get("footer_color"), "footer_color"),
+            show_client_id=arguments.get("show_client_id", True),
+            show_description=arguments.get("show_description", False),
             additional_audiences=_normalize_audiences(arguments.get("additional_audiences")),
             redirect_uris=_normalize_str_list(
                 arguments.get("redirect_uris"), "redirect_uris"
@@ -1053,11 +1121,36 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             if "redirect_uris" in arguments
             else None
         )
+        new_background_color = (
+            _normalize_hex_color(arguments["background_color"], "background_color")
+            if "background_color" in arguments
+            else None
+        )
+        new_header_color = (
+            _normalize_hex_color(arguments["header_color"], "header_color")
+            if "header_color" in arguments
+            else None
+        )
+        new_footer_color = (
+            _normalize_hex_color(arguments["footer_color"], "footer_color")
+            if "footer_color" in arguments
+            else None
+        )
 
         if "client_secret" in arguments:
             client.client_secret = arguments["client_secret"]
         if "description" in arguments:
             client.description = arguments["description"]
+        if "background_color" in arguments:
+            client.background_color = new_background_color
+        if "header_color" in arguments:
+            client.header_color = new_header_color
+        if "footer_color" in arguments:
+            client.footer_color = new_footer_color
+        if "show_client_id" in arguments:
+            client.show_client_id = arguments["show_client_id"]
+        if "show_description" in arguments:
+            client.show_description = arguments["show_description"]
         if new_audiences is not None:
             client.additional_audiences = new_audiences
         if new_redirect_uris is not None:

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -96,6 +96,11 @@ class User(BaseModel):
         }
 
 
+# Shared with mcp_server's pre-mutation check, so the MCP tool and this model
+# can never diverge on what a valid color is (#150 review).
+HEX_COLOR_PATTERN = r"^#[0-9a-fA-F]{6}$"
+
+
 class OAuthClient(BaseModel):
     """Represents an OAuth client."""
     # Validate on direct attribute assignment too (e.g. MCP update_client), so the
@@ -105,6 +110,20 @@ class OAuthClient(BaseModel):
     client_id: str = Field(..., min_length=1, description="OAuth client ID")
     client_secret: str = Field(..., min_length=1, description="OAuth client secret")
     description: str = Field(default="", description="Client description")
+    background_color: Optional[str] = Field(
+        default=None, pattern=HEX_COLOR_PATTERN,
+        description="Optional hex background color for the /authorize page (behind the login card)",
+    )
+    header_color: Optional[str] = Field(
+        default=None, pattern=HEX_COLOR_PATTERN,
+        description="Optional hex color for the /authorize login card header band",
+    )
+    footer_color: Optional[str] = Field(
+        default=None, pattern=HEX_COLOR_PATTERN,
+        description="Optional hex color for the /authorize login card footer band",
+    )
+    show_client_id: bool = Field(default=True, description="Show client_id on the /authorize login page")
+    show_description: bool = Field(default=False, description="Show description on the /authorize login page")
     additional_audiences: List[str] = Field(
         default_factory=list,
         description="Extra audiences added to the ID Token 'aud' alongside the client_id",
@@ -185,6 +204,13 @@ class Settings(BaseModel):
         "refresh token, so its reuse fails (lets clients test rotation handling, #46)",
     )
     clients: List[OAuthClient] = Field(default_factory=list, description="OAuth clients")
+    logos_dir: Optional[str] = Field(
+        default=None,
+        description="Directory path where per-client logo files are stored for the "
+        "/authorize login page (relative to the process cwd, or absolute). "
+        "When unset (default), resolves to the Flask app's 'static/logos' "
+        "subdirectory (src/nanoidp/static/logos).",
+    )
 
     # SAML
     saml_entity_id: str = Field(default="http://localhost:8000/saml", description="SAML entity ID")

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -4,14 +4,27 @@ OAuth2/OIDC routes for token endpoint and discovery.
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Union
 from urllib.parse import urlencode, urlparse
 
 import jwt as pyjwt
-from flask import Blueprint, abort, jsonify, redirect, render_template, request, session
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    send_from_directory,
+    session,
+    url_for,
+)
 from flask.typing import ResponseReturnValue
 
+from ..branding import effective_logos_dir, resolve_client_logo
 from ..config import ConfigManager, User, get_config
 from ..services import (
     DevicePollOutcome,
@@ -358,12 +371,39 @@ def authorize() -> ResponseReturnValue:
             error_msg = "Username and password are required"
 
     # Show login page (GET or failed POST)
+    logo_url = None
+    if client:
+        logos_dir = effective_logos_dir(config.settings.logos_dir, current_app.static_folder)
+        if resolve_client_logo(logos_dir, client.client_id):
+            logo_url = url_for("oauth.client_logo", client_id=client.client_id)
+
     return render_template(
         "authorize.html",
         client_id=client_id,
+        client=client,
+        logo_url=logo_url,
         scope=scope,
         error=error_msg,
     )
+
+
+@oauth_bp.route("/client-logos/<client_id>")
+def client_logo(client_id: str) -> ResponseReturnValue:
+    """Serve a per-client logo file for the /authorize login page.
+
+    A dedicated route rather than Flask's built-in static handler, which only
+    ever serves the app's own static/ folder - so a configured 'logos_dir'
+    override actually takes effect instead of silently only working for the
+    default location (#150 review). resolve_client_logo() re-validates
+    client_id against the charset whitelist, so this is as path-traversal-safe
+    as the default case.
+    """
+    config = get_config()
+    logos_dir = effective_logos_dir(config.settings.logos_dir, current_app.static_folder)
+    filename = resolve_client_logo(logos_dir, client_id)
+    if not filename:
+        abort(404)
+    return send_from_directory(os.path.abspath(logos_dir), filename)
 
 
 # ============================================================================

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -11,6 +11,7 @@ from io import StringIO
 from flask import (
     Blueprint,
     Response,
+    current_app,
     flash,
     redirect,
     render_template,
@@ -20,6 +21,7 @@ from flask import (
 )
 from flask.typing import ResponseReturnValue
 
+from ..branding import effective_logos_dir
 from ..config import OAuthClient, User, get_config
 from ..services import get_audit_log, get_token_service, get_yaml_writer
 from ._audit import audit_event
@@ -327,10 +329,14 @@ def client_create() -> ResponseReturnValue:
     if request.method == "GET":
         # Generate a random client secret
         generated_secret = secrets.token_urlsafe(32)
+        logos_dir = effective_logos_dir(
+            get_config().settings.logos_dir, current_app.static_folder
+        )
         return render_template(
             "clients_form.html",
             client=None,
             generated_secret=generated_secret,
+            logos_dir=logos_dir,
             current_user=session.get("user"),
         )
 
@@ -350,6 +356,11 @@ def client_create() -> ResponseReturnValue:
             client_id=client_id,
             client_secret=client_secret,
             description=request.form.get("description", ""),
+            background_color=request.form.get("background_color") or None,
+            header_color=request.form.get("header_color") or None,
+            footer_color=request.form.get("footer_color") or None,
+            show_client_id=bool(request.form.get("show_client_id")),
+            show_description=bool(request.form.get("show_description")),
             additional_audiences=_parse_textarea_list(
                 request.form.get("additional_audiences", "")
             ),
@@ -388,10 +399,14 @@ def client_edit(client_id: str) -> ResponseReturnValue:
         return redirect(url_for("ui.clients"))
 
     if request.method == "GET":
+        logos_dir = effective_logos_dir(
+            config.settings.logos_dir, current_app.static_folder
+        )
         return render_template(
             "clients_form.html",
             client=client,
             generated_secret=None,
+            logos_dir=logos_dir,
             current_user=session.get("user"),
         )
 
@@ -406,6 +421,11 @@ def client_edit(client_id: str) -> ResponseReturnValue:
             client_id=client_id,
             client_secret=client_secret,
             description=request.form.get("description", ""),
+            background_color=request.form.get("background_color") or None,
+            header_color=request.form.get("header_color") or None,
+            footer_color=request.form.get("footer_color") or None,
+            show_client_id=bool(request.form.get("show_client_id")),
+            show_description=bool(request.form.get("show_description")),
             additional_audiences=_parse_textarea_list(
                 request.form.get("additional_audiences", "")
             ),
@@ -547,6 +567,7 @@ def settings() -> ResponseReturnValue:
             token_expiry_minutes=int(expiry_raw) if expiry_raw else None,
             require_pkce=_form_bool("require_pkce"),
             refresh_token_rotation=_form_bool("refresh_token_rotation"),
+            logos_dir=_form_text("logos_dir"),
         )
 
         # SAML settings

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -146,6 +146,16 @@ def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
         "client_secret": _quoted(client.client_secret),
         "description": _quoted(client.description),
     }
+    if client.background_color:
+        entry["background_color"] = client.background_color
+    if client.header_color:
+        entry["header_color"] = client.header_color
+    if client.footer_color:
+        entry["footer_color"] = client.footer_color
+    if not client.show_client_id:
+        entry["show_client_id"] = False
+    if client.show_description:
+        entry["show_description"] = True
     if client.additional_audiences:
         entry["additional_audiences"] = client.additional_audiences
     if client.redirect_uris:
@@ -167,12 +177,27 @@ def merge_client_entry(raw_entry: Dict[str, Any], client: OAuthClient) -> Dict[s
         ("client_id", client.client_id),
         ("client_secret", client.client_secret),
         ("description", client.description),
+        ("background_color", client.background_color),
+        ("header_color", client.header_color),
+        ("footer_color", client.footer_color),
     ):
         if not is_unchanged(raw_entry.get(field_name), new_value):
             if field_name in {"client_secret", "description"}:
                 updated[field_name] = _quoted(str(new_value))
             else:
-                updated[field_name] = new_value
+                updated[field_name] = new_value if new_value else None
+                if updated[field_name] is None:
+                    updated.pop(field_name, None)
+
+    for field_name, new_bool_value, default_value in (
+        ("show_client_id", client.show_client_id, True),
+        ("show_description", client.show_description, False),
+    ):
+        if not is_unchanged(raw_entry.get(field_name), new_bool_value):
+            if new_bool_value != default_value:
+                updated[field_name] = new_bool_value
+            else:
+                updated.pop(field_name, None)
 
     for field_name, new_list_value in (
         ("additional_audiences", client.additional_audiences),
@@ -304,6 +329,12 @@ def apply_settings_document(
         oauth["refresh_token_rotation"] = settings.refresh_token_rotation
     if not is_unchanged(oauth.get("require_pkce"), settings.require_pkce):
         oauth["require_pkce"] = settings.require_pkce
+    logos_dir = settings.logos_dir or ""
+    if not is_unchanged(oauth.get("logos_dir"), logos_dir):
+        if settings.logos_dir:
+            oauth["logos_dir"] = settings.logos_dir
+        else:
+            oauth.pop("logos_dir", None)
     new_clients = merge_oauth_clients(oauth.get("clients", []), settings.clients)
     if new_clients != oauth.get("clients", []):
         if new_clients:

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -166,6 +166,7 @@ class YamlWriter:
         token_expiry_minutes: Optional[int] = None,
         require_pkce: Optional[bool] = None,
         refresh_token_rotation: Optional[bool] = None,
+        logos_dir: Optional[str] = None,
     ) -> None:
         """Update OAuth settings.
 
@@ -216,6 +217,13 @@ class YamlWriter:
             oauth.get("refresh_token_rotation"), refresh_token_rotation
         ):
             oauth["refresh_token_rotation"] = refresh_token_rotation
+        if logos_dir is not None:
+            next_logos_dir = logos_dir or ""
+            if not is_unchanged(oauth.get("logos_dir"), next_logos_dir):
+                if logos_dir:
+                    oauth["logos_dir"] = logos_dir
+                else:
+                    oauth.pop("logos_dir", None)
 
         self._atomic_write(self.settings_file, data)
         get_config().reload()

--- a/src/nanoidp/templates/authorize.html
+++ b/src/nanoidp/templates/authorize.html
@@ -9,7 +9,7 @@
     <style>
         body {
             min-height: 100vh;
-            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+            background: {% if client and client.background_color %}{{ client.background_color }}{% else %}linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%){% endif %};
             display: flex;
             align-items: center;
             justify-content: center;
@@ -22,7 +22,7 @@
             box-shadow: 0 10px 40px rgba(0,0,0,0.3);
         }
         .authorize-header {
-            background: linear-gradient(135deg, #0d6efd 0%, #6610f2 100%);
+            background: {% if client and client.header_color %}{{ client.header_color }}{% else %}linear-gradient(135deg, #0d6efd 0%, #6610f2 100%){% endif %};
             color: #fff;
             padding: 2rem;
             border-radius: 1rem 1rem 0 0;
@@ -48,6 +48,12 @@
             font-size: 0.8rem;
             margin: 0.2rem;
         }
+        .authorize-footer {
+            background: {% if client and client.footer_color %}{{ client.footer_color }}{% else %}transparent{% endif %};
+            padding: 1rem;
+            border-radius: 0 0 1rem 1rem;
+            margin: 0 -2rem -2rem -2rem;
+        }
     </style>
 </head>
 <body>
@@ -67,9 +73,14 @@
 
             <div class="client-info">
                 <div class="d-flex align-items-center mb-2">
+                    {% if logo_url %}
+                    <img src="{{ logo_url }}" alt="" class="me-2" style="height:2rem;width:auto;">
+                    {% else %}
                     <i class="bi bi-app-indicator text-primary me-2 fs-4"></i>
+                    {% endif %}
                     <div>
-                        <strong>{{ client_id }}</strong>
+                        {% if not client or client.show_client_id %}<strong>{{ client_id }}</strong>{% endif %}
+                        {% if client and client.show_description and client.description %}<small class="text-muted d-block">{{ client.description }}</small>{% endif %}
                         <small class="text-muted d-block">wants to access your account</small>
                     </div>
                 </div>
@@ -112,7 +123,7 @@
                 </button>
             </form>
 
-            <div class="text-center mt-3">
+            <div class="authorize-footer text-center mt-3">
                 <small class="text-muted">
                     <i class="bi bi-info-circle me-1"></i>
                     Sign in to authorize this application

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -78,6 +78,78 @@
                             (RFC 6749 §3.1.2.3, OAuth 2.1 §4.1.1). Leave empty to accept any syntactically valid URI (dev default).
                         </div>
                     </div>
+
+                    <hr class="my-4">
+                    <h6 class="mb-3">
+                        <i class="bi bi-palette me-2"></i>Login Page Branding (Optional)
+                        {% if client %}
+                        <a href="{{ url_for('oauth.authorize', response_type='code', client_id=client.client_id, redirect_uri=client.redirect_uris[0] if client.redirect_uris else 'http://localhost:3000/callback') }}"
+                           target="_blank" rel="noopener" class="ms-2" title="Preview login page in a new tab">
+                            <i class="bi bi-box-arrow-up-right"></i>
+                        </a>
+                        {% endif %}
+                    </h6>
+
+                    <div class="mb-3">
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input color-enable-toggle" id="enable_background_color"
+                                   data-target="background_color"
+                                   {% if client and client.background_color %}checked{% endif %}>
+                            <label class="form-check-label" for="enable_background_color">Custom background color</label>
+                        </div>
+                        <input type="color" class="form-control form-control-color" id="background_color" name="background_color"
+                               value="{{ client.background_color if client and client.background_color else '#1a1a2e' }}"
+                               title="Color behind the login card"
+                               {% if not (client and client.background_color) %}disabled{% endif %}>
+                        <div class="form-text">Color behind the login dialog</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input color-enable-toggle" id="enable_header_color"
+                                   data-target="header_color"
+                                   {% if client and client.header_color %}checked{% endif %}>
+                            <label class="form-check-label" for="enable_header_color">Custom header color</label>
+                        </div>
+                        <input type="color" class="form-control form-control-color" id="header_color" name="header_color"
+                               value="{{ client.header_color if client and client.header_color else '#0d6efd' }}"
+                               title="Color for the header band"
+                               {% if not (client and client.header_color) %}disabled{% endif %}>
+                        <div class="form-text">Color for the card header band</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input color-enable-toggle" id="enable_footer_color"
+                                   data-target="footer_color"
+                                   {% if client and client.footer_color %}checked{% endif %}>
+                            <label class="form-check-label" for="enable_footer_color">Custom footer color</label>
+                        </div>
+                        <input type="color" class="form-control form-control-color" id="footer_color" name="footer_color"
+                               value="{{ client.footer_color if client and client.footer_color else '#ffffff' }}"
+                               title="Color for the footer band"
+                               {% if not (client and client.footer_color) %}disabled{% endif %}>
+                        <div class="form-text">Color for the card footer band</div>
+                    </div>
+
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" class="form-check-input" id="show_client_id" name="show_client_id"
+                               {% if not client or client.show_client_id %}checked{% endif %}>
+                        <label class="form-check-label" for="show_client_id">Show Client ID on login page</label>
+                    </div>
+
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" class="form-check-input" id="show_description" name="show_description"
+                               {% if client and client.show_description %}checked{% endif %}>
+                        <label class="form-check-label" for="show_description">Show description on login page</label>
+                    </div>
+
+                    <div class="alert alert-info" role="alert">
+                        <i class="bi bi-info-circle me-2"></i>
+                        <strong>Logo:</strong> To add a client logo to the login page, place an image file at
+                        <code>{{ logos_dir }}/<em>{{ 'client-id' if not client else client.client_id }}</em>.{svg,png,jpg,webp}</code>
+                        on the server — no configuration needed.
+                    </div>
                 </div>
             </div>
 
@@ -119,6 +191,15 @@ function generateSecret() {
         .replace(/=/g, '');
     document.getElementById('client_secret').value = secret;
 }
+
+// Color pickers always submit a value, so a disabled input (unchecked toggle)
+// is the only way to keep an untouched color field unset (#150).
+document.querySelectorAll('.color-enable-toggle').forEach(function(toggle) {
+    var target = document.getElementById(toggle.dataset.target);
+    toggle.addEventListener('change', function() {
+        target.disabled = !toggle.checked;
+    });
+});
 
 // Form validation
 (function() {

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -148,7 +148,7 @@
                         <i class="bi bi-info-circle me-2"></i>
                         <strong>Logo:</strong> To add a client logo to the login page, place an image file at
                         <code>{{ logos_dir }}/<em>{{ 'client-id' if not client else client.client_id }}</em>.{svg,png,jpg,webp}</code>
-                        on the server — no configuration needed.
+                        on the server - no configuration needed.
                     </div>
                 </div>
             </div>

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -103,6 +103,16 @@
                         </div>
                         <div class="form-text">Each refresh invalidates the used refresh token; reuse revokes its rotation family (forced on by oauth21).</div>
                     </div>
+
+                    <hr class="my-4">
+                    <h6 class="mb-3"><i class="bi bi-palette me-2"></i>Login Page Branding</h6>
+
+                    <div class="mb-3">
+                        <label for="logos_dir" class="form-label">Logos Directory</label>
+                        <input type="text" class="form-control" id="logos_dir" name="logos_dir"
+                               value="{{ settings.logos_dir or '' }}" placeholder="src/nanoidp/static/logos (default)">
+                        <div class="form-text">Directory where per-client logo files are looked up by filename (<code>&lt;client_id&gt;.svg/.png/.jpg/.webp</code>). Leave blank to use the default (the app's own <code>static/logos</code>).</div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -307,7 +317,8 @@ function updatePreview() {
             audience: document.getElementById('audience').value,
             token_expiry_minutes: parseInt(document.getElementById('token_expiry_minutes').value) || 60,
             require_pkce: document.getElementById('require_pkce').checked,
-            refresh_token_rotation: document.getElementById('refresh_token_rotation').checked
+            refresh_token_rotation: document.getElementById('refresh_token_rotation').checked,
+            logos_dir: document.getElementById('logos_dir').value.trim()
         },
         saml: {
             entity_id: document.getElementById('saml_entity_id').value,

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -1,0 +1,131 @@
+"""Tests for per-client login page branding utilities."""
+
+from nanoidp.branding import resolve_client_logo
+
+
+class TestResolveClientLogo:
+    """Test safe logo resolution."""
+
+    def test_resolve_client_logo_finds_svg(self, tmp_path):
+        """resolve_client_logo returns the filename when SVG exists."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.svg").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result == "my-client.svg"
+
+    def test_resolve_client_logo_finds_png(self, tmp_path):
+        """resolve_client_logo returns the filename when PNG exists."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.png").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result == "my-client.png"
+
+    def test_resolve_client_logo_finds_jpeg(self, tmp_path):
+        """resolve_client_logo returns the filename when JPEG exists."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.jpeg").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result == "my-client.jpeg"
+
+    def test_resolve_client_logo_finds_jpg(self, tmp_path):
+        """resolve_client_logo returns the filename when JPG exists."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.jpg").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result == "my-client.jpg"
+
+    def test_resolve_client_logo_finds_webp(self, tmp_path):
+        """resolve_client_logo returns the filename when WEBP exists."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.webp").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result == "my-client.webp"
+
+    def test_resolve_client_logo_not_found(self, tmp_path):
+        """resolve_client_logo returns None when no matching file exists."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result is None
+
+    def test_resolve_client_logo_prefers_first_extension(self, tmp_path):
+        """resolve_client_logo returns the first matching extension found."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.svg").touch()
+        (logos_dir / "my-client.png").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result == "my-client.svg"
+
+    def test_resolve_client_logo_rejects_path_traversal_double_dot(self, tmp_path):
+        """resolve_client_logo returns None for .. path traversal attempts."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        parent_dir = tmp_path / "parent.txt"
+        parent_dir.touch()
+
+        result = resolve_client_logo(str(logos_dir), "../parent")
+        assert result is None
+
+    def test_resolve_client_logo_rejects_path_traversal_slash(self, tmp_path):
+        """resolve_client_logo returns None for / path traversal attempts."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+
+        result = resolve_client_logo(str(logos_dir), "../../etc/passwd")
+        assert result is None
+
+    def test_resolve_client_logo_rejects_absolute_path(self, tmp_path):
+        """resolve_client_logo returns None for absolute path attempts."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+
+        result = resolve_client_logo(str(logos_dir), "/etc/passwd")
+        assert result is None
+
+    def test_resolve_client_logo_allows_underscores_and_hyphens(self, tmp_path):
+        """resolve_client_logo allows client IDs with underscores and hyphens."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my_client-app.png").touch()
+
+        result = resolve_client_logo(str(logos_dir), "my_client-app")
+        assert result == "my_client-app.png"
+
+    def test_resolve_client_logo_rejects_special_chars(self, tmp_path):
+        """resolve_client_logo rejects client IDs with special characters."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+
+        result = resolve_client_logo(str(logos_dir), "my-client;rm -rf/")
+        assert result is None
+
+    def test_resolve_client_logo_rejects_spaces(self, tmp_path):
+        """resolve_client_logo rejects client IDs with spaces."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+
+        result = resolve_client_logo(str(logos_dir), "my client")
+        assert result is None
+
+    def test_resolve_client_logo_with_relative_path(self, tmp_path, monkeypatch):
+        """resolve_client_logo works with relative paths."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        (logos_dir / "my-client.png").touch()
+
+        monkeypatch.chdir(str(tmp_path.parent))
+        result = resolve_client_logo(str(logos_dir.relative_to(tmp_path.parent)), "my-client")
+        assert result == "my-client.png"

--- a/tests/test_branding_colors.py
+++ b/tests/test_branding_colors.py
@@ -1,0 +1,141 @@
+"""Tests for per-client color validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from nanoidp.models import OAuthClient
+
+
+class TestClientColorValidation:
+    """Test color field validation in OAuthClient."""
+
+    def test_valid_hex_color_background(self):
+        """OAuthClient accepts valid hex background_color."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+            background_color="#123456",
+        )
+        assert client.background_color == "#123456"
+
+    def test_valid_hex_color_header(self):
+        """OAuthClient accepts valid hex header_color."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+            header_color="#abcdef",
+        )
+        assert client.header_color == "#abcdef"
+
+    def test_valid_hex_color_footer(self):
+        """OAuthClient accepts valid hex footer_color."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+            footer_color="#AABBCC",
+        )
+        assert client.footer_color == "#AABBCC"
+
+    def test_color_none_is_valid(self):
+        """OAuthClient accepts None for color fields (optional)."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+            background_color=None,
+            header_color=None,
+            footer_color=None,
+        )
+        assert client.background_color is None
+        assert client.header_color is None
+        assert client.footer_color is None
+
+    def test_color_defaults_to_none(self):
+        """OAuthClient color fields default to None."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+        )
+        assert client.background_color is None
+        assert client.header_color is None
+        assert client.footer_color is None
+
+    def test_invalid_hex_color_missing_hash(self):
+        """OAuthClient rejects hex color without # prefix."""
+        with pytest.raises(ValidationError):
+            OAuthClient(
+                client_id="test-client",
+                client_secret="secret",
+                background_color="123456",
+            )
+
+    def test_invalid_hex_color_wrong_length(self):
+        """OAuthClient rejects hex color with wrong length."""
+        with pytest.raises(ValidationError):
+            OAuthClient(
+                client_id="test-client",
+                client_secret="secret",
+                header_color="#12345",
+            )
+
+    def test_invalid_hex_color_non_hex_chars(self):
+        """OAuthClient rejects hex color with non-hex characters."""
+        with pytest.raises(ValidationError):
+            OAuthClient(
+                client_id="test-client",
+                client_secret="secret",
+                footer_color="#GGGGGG",
+            )
+
+    def test_color_validation_enforced_on_assignment(self):
+        """OAuthClient enforces color validation on attribute assignment."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+        )
+
+        with pytest.raises(ValidationError):
+            client.background_color = "#invalid"
+
+    def test_valid_color_assignment(self):
+        """OAuthClient accepts valid color on attribute assignment."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+        )
+
+        client.background_color = "#ff0000"
+        assert client.background_color == "#ff0000"
+
+    def test_show_client_id_defaults_true(self):
+        """OAuthClient.show_client_id defaults to True."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+        )
+        assert client.show_client_id is True
+
+    def test_show_description_defaults_false(self):
+        """OAuthClient.show_description defaults to False."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+        )
+        assert client.show_description is False
+
+    def test_show_client_id_explicit_false(self):
+        """OAuthClient accepts show_client_id=False."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+            show_client_id=False,
+        )
+        assert client.show_client_id is False
+
+    def test_show_description_explicit_true(self):
+        """OAuthClient accepts show_description=True."""
+        client = OAuthClient(
+            client_id="test-client",
+            client_secret="secret",
+            show_description=True,
+        )
+        assert client.show_description is True

--- a/tests/test_mcp_client_branding.py
+++ b/tests/test_mcp_client_branding.py
@@ -1,0 +1,187 @@
+"""Tests for MCP create_client/update_client exposing branding fields (#150)."""
+
+import pytest
+
+
+def _config(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "settings.yaml").write_text(
+        'oauth:\n'
+        '  issuer: "http://localhost:8000"\n'
+        '  clients:\n'
+        '    - client_id: "test"\n'
+        '      client_secret: "test"\n'
+    )
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    from nanoidp.config import ConfigManager
+    return ConfigManager(str(config_dir))
+
+
+class TestMCPClientBrandingFields:
+    """create_client / update_client expose branding fields (issue #150)."""
+
+    @pytest.mark.asyncio
+    async def test_create_client_with_branding_fields(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+
+        result = await _execute_tool(
+            "create_client",
+            {
+                "client_id": "branded",
+                "client_secret": "s",
+                "background_color": "#1a1a2e",
+                "header_color": "#0d6efd",
+                "footer_color": "#ffffff",
+                "show_client_id": False,
+                "show_description": True,
+            },
+            config,
+        )
+
+        assert result["success"] is True
+        assert result["client"]["background_color"] == "#1a1a2e"
+        assert result["client"]["header_color"] == "#0d6efd"
+        assert result["client"]["footer_color"] == "#ffffff"
+        assert result["client"]["show_client_id"] is False
+        assert result["client"]["show_description"] is True
+
+        client = config.get_client("branded")
+        assert client.background_color == "#1a1a2e"
+        assert client.show_client_id is False
+
+    @pytest.mark.asyncio
+    async def test_create_client_defaults_branding_to_none_and_defaults(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+
+        result = await _execute_tool(
+            "create_client", {"client_id": "plain", "client_secret": "s"}, config
+        )
+
+        assert result["success"] is True
+        assert result["client"]["background_color"] is None
+        assert result["client"]["header_color"] is None
+        assert result["client"]["footer_color"] is None
+        assert result["client"]["show_client_id"] is True
+        assert result["client"]["show_description"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_client_rejects_invalid_hex_color(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+
+        with pytest.raises(ValueError):
+            await _execute_tool(
+                "create_client",
+                {"client_id": "bad", "client_secret": "s", "background_color": "not-a-color"},
+                config,
+            )
+
+        assert config.get_client("bad") is None
+
+    @pytest.mark.asyncio
+    async def test_update_client_sets_branding_fields(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+        await _execute_tool("create_client", {"client_id": "c", "client_secret": "s"}, config)
+
+        result = await _execute_tool(
+            "update_client",
+            {
+                "client_id": "c",
+                "background_color": "#123456",
+                "show_description": True,
+            },
+            config,
+        )
+
+        assert result["success"] is True
+        client = config.get_client("c")
+        assert client.background_color == "#123456"
+        assert client.show_description is True
+
+    @pytest.mark.asyncio
+    async def test_update_client_clears_color_with_empty_string(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+        await _execute_tool(
+            "create_client",
+            {"client_id": "c", "client_secret": "s", "background_color": "#123456"},
+            config,
+        )
+
+        result = await _execute_tool(
+            "update_client", {"client_id": "c", "background_color": ""}, config
+        )
+
+        assert result["success"] is True
+        assert config.get_client("c").background_color is None
+
+    @pytest.mark.asyncio
+    async def test_update_client_invalid_color_does_not_partially_mutate(self, tmp_path):
+        """A bad color must not leave client_secret/description/other colors changed (#37/#150)."""
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+        await _execute_tool(
+            "create_client",
+            {
+                "client_id": "c",
+                "client_secret": "orig",
+                "description": "orig-desc",
+                "header_color": "#111111",
+            },
+            config,
+        )
+
+        with pytest.raises(ValueError):
+            await _execute_tool(
+                "update_client",
+                {
+                    "client_id": "c",
+                    "client_secret": "newsecret",
+                    "description": "newdesc",
+                    "header_color": "#222222",
+                    "background_color": "not-a-color",  # invalid -> must raise
+                },
+                config,
+            )
+
+        client = config.get_client("c")
+        assert client.client_secret == "orig"
+        assert client.description == "orig-desc"
+        assert client.header_color == "#111111"
+        assert client.background_color is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["create_client", "update_client"])
+    async def test_schema_exposes_branding_fields(self, tool_name, mcp_list_tools):
+        tools = await mcp_list_tools()
+        tool = next(t for t in tools if t.name == tool_name)
+        props = tool.input_schema["properties"]
+        for field in (
+            "background_color",
+            "header_color",
+            "footer_color",
+        ):
+            assert props[field]["type"] == "string"
+        for field in ("show_client_id", "show_description"):
+            assert props[field]["type"] == "boolean"
+
+    @pytest.mark.asyncio
+    async def test_get_client_reports_branding_fields(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+        config = _config(tmp_path)
+        await _execute_tool(
+            "create_client",
+            {"client_id": "c", "client_secret": "s", "footer_color": "#abcdef"},
+            config,
+        )
+
+        result = await _execute_tool("get_client", {"client_id": "c"}, config)
+
+        assert result["found"] is True
+        assert result["client"]["footer_color"] == "#abcdef"


### PR DESCRIPTION
optional per-client colors (background,
  header, footer, all as validated hex values), show/hide client_id and
  description on the `/authorize` login page, and per-client logo images
  stored locally in `static/logos/` keyed by client ID (no YAML config needed
  for logos; place the image file and it's served automatically; the
  directory is overridable via `oauth.logos_dir`). Colours and toggles are
  editable from the OAuth client form in the UI and from the MCP
  `create_client`/`update_client`/`get_client` tools, descriptions are
  already supported, and logos are deployed by the operator to the server
  filesystem. Designed for demos and prototyping; colours are structured
  (not free-form CSS) to prevent stored-XSS on the auth UI, and logos are
  local files only (no remote URLs) to avoid beacons.
implementation of #150 