### PR TITLE
fix: bind to 127.0.0.1 by default instead of 0.0.0.0 (GHSA-2473-px8h-rvg6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "rendered but unchecked" (persist `false`) is distinguishable from "not on
   this form" (leave unchanged).
 
+### Security
+- **Default server bind address is now `127.0.0.1` (loopback) instead of
+  `0.0.0.0`** (GHSA-2473-px8h-rvg6, CWE-306). The unauthenticated `/api/*`
+  management API (which can mint admin tokens, rotate signing keys and clear
+  the audit log) is a deliberate dev-tool convenience, but the previous
+  all-interfaces default exposed it to any network-reachable host without the
+  operator choosing to. The out-of-the-box experience is unchanged for local
+  development (clients still reach `localhost:8000`). To expose NanoIDP on a
+  network, set `server.host` (or `--host 0.0.0.0`) explicitly; a startup
+  warning is logged whenever the bind address covers all interfaces. This
+  aligns `nanoidp init` with the value `nanoidp wizard` already wrote, and the
+  bundled Docker image is unaffected (its entrypoint already passes
+  `--host 0.0.0.0`).
+
 ## [2.5.0] - 2026-07-19
 
 ### Added

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -46,7 +46,7 @@ mapping below, is described in [Tokens and claims](tokens.md).
 
 ```yaml
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"        # loopback by default; set 0.0.0.0 to expose on a network
   port: 8000
 
 oauth:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,5 +1,5 @@
 server:
-  host: 0.0.0.0
+  host: 127.0.0.1
   port: ${PORT:8000}
   debug: false
 oauth:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,6 +10,29 @@ By design, NanoIDP prioritizes developer convenience over security hardening. It
 
 ---
 
+## Network Binding
+
+NanoIDP binds to `127.0.0.1` (loopback only) by default, so out of the box it is reachable only from the local machine.
+
+This matters because the management API (`/api/*`) is **unauthenticated by design** (see [MCP Server Security](#mcp-server-security) for the equivalent concern on the MCP side). Those endpoints can mint a validly signed access token for any user, including `admin`, rotate the signing keys, and clear the audit log. Loopback binding keeps that surface off the network.
+
+### Exposing on a network
+
+If you deliberately need NanoIDP reachable from other hosts or containers, set the host explicitly:
+
+```bash
+# CLI flag
+python -m nanoidp --host 0.0.0.0
+
+# or in settings.yaml
+server:
+  host: "0.0.0.0"
+```
+
+The bundled Docker image already sets `--host 0.0.0.0`, because inside a container the isolation boundary is the container network rather than the host loopback. When you bind to all interfaces, NanoIDP logs a startup warning, since the unauthenticated management API then becomes reachable by any host that can route to the port. Only do this on a trusted, isolated network.
+
+---
+
 ## Security Profiles
 
 NanoIDP supports three security profiles to balance convenience with basic security controls:
@@ -250,7 +273,8 @@ discovery/token issuer mismatch.
 2. **Enable readonly mode** for MCP when only introspection is needed
 3. **Set MCP admin secret** if multiple developers share the same NanoIDP instance
 4. **Rotate keys periodically** to test token validation with multiple keys
-5. **Never expose NanoIDP to public networks**: it's designed for local/isolated use only
+5. **Keep the default `127.0.0.1` binding** unless you specifically need network access; only override it on a trusted, isolated network (see [Network Binding](#network-binding))
+6. **Never expose NanoIDP to public networks**: it's designed for local/isolated use only
 
 ---
 

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -54,7 +54,7 @@ DEFAULT_SETTINGS_YAML = """# NanoIDP Settings Configuration
 # Documentation: https://github.com/cdelmonte-zg/nanoidp
 
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"
   port: 8000
 
 oauth:
@@ -165,7 +165,7 @@ def main() -> None:
     parser.add_argument(
         "--host",
         default=None,
-        help="Host to bind to (default: from config or 0.0.0.0)",
+        help="Host to bind to (default: from config or 127.0.0.1)",
     )
     parser.add_argument(
         "--port",

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -159,8 +159,23 @@ def run_app(
         )
         effective_debug = False
 
+    effective_host = host or settings.host
+    # NanoIDP is a dev/test IdP whose management API (/api/*) is unauthenticated
+    # by design; binding to all interfaces exposes admin token minting and key
+    # rotation to any network-reachable host. The default is 127.0.0.1; warn
+    # loudly when that safe default is overridden.
+    if effective_host in ("0.0.0.0", "::", ""):
+        logging.getLogger(__name__).warning(
+            "Binding to %s exposes NanoIDP on all network interfaces. The "
+            "/api/* management endpoints are unauthenticated by design, so any "
+            "reachable host can mint admin tokens and rotate signing keys. Use "
+            "127.0.0.1 unless you intend network exposure (e.g. inside a "
+            "container).",
+            effective_host,
+        )
+
     app.run(
-        host=host or settings.host,
+        host=effective_host,
         port=port or settings.port,
         debug=effective_debug,
     )

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -123,7 +123,7 @@ class ConfigManager:
 
         self.settings = Settings(
             # Server
-            host=server.get("host", "0.0.0.0"),
+            host=server.get("host", "127.0.0.1"),
             port=server.get("port", 8000),
             debug=server.get("debug", False),
             # OAuth

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -122,7 +122,7 @@ class OAuthClient(BaseModel):
 class Settings(BaseModel):
     """Application settings with validation."""
     # Server
-    host: str = Field(default="0.0.0.0", description="Server host address")
+    host: str = Field(default="127.0.0.1", description="Server host address")
     port: int = Field(default=8000, ge=1, le=65535, description="Server port")
     debug: bool = Field(default=False, description="Enable debug mode")
 

--- a/src/nanoidp/wizard.py
+++ b/src/nanoidp/wizard.py
@@ -85,7 +85,7 @@ def run_wizard(config_dir: str = "./config") -> bool:
 
     # Server configuration
     _print_header("Server Configuration")
-    host = _prompt("Host", "0.0.0.0")
+    host = _prompt("Host", "127.0.0.1")
     port = _prompt("Port", "8000")
     issuer = _prompt("Issuer URL", f"http://localhost:{port}")
     audience = _prompt("Audience", "my-app")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -506,7 +506,7 @@ class TestSettingsPydanticValidation:
         """Test that Settings has sensible defaults."""
         settings = Settings()
 
-        assert settings.host == "0.0.0.0"
+        assert settings.host == "127.0.0.1"
         assert settings.port == 8000
         assert settings.debug is False
         assert settings.issuer == "http://localhost:8000"


### PR DESCRIPTION
Fix for security advisory GHSA-2473-px8h-rvg6 (CWE-306, CWE-1327): the default server bind address exposed the unauthenticated `/api/*` management API to the network without the operator choosing to.

- Default host changed from `0.0.0.0` to `127.0.0.1` in the settings model, config loader fallback, `nanoidp init` template, wizard default and `--host` help text, and the tracked `config/settings.yaml`.
- Startup warning in `run_app` whenever the effective bind address covers all interfaces (`0.0.0.0`, `::`, empty).
- New "Network Binding" section in `docs/SECURITY.md`; CHANGELOG entry under `### Security`.
- Docker image unaffected (entrypoint already passes `--host 0.0.0.0` explicitly).

909 tests green. Ships in 2.6.0; the advisory will be published alongside the release.