### PR TITLE
chore: release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.6.0] - 2026-08-21
 
 ### Documentation
 - **New guide: [Running behind a TLS-terminating reverse proxy](book/src/guides/reverse-proxy.md)**,
@@ -701,6 +701,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Key rotation with JWKS support for multiple keys
 - External key import support
 
+[2.6.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.2.0...v2.3.0

--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -24,7 +24,7 @@ docker run --rm -p 8000:8000 \
   ghcr.io/cdelmonte-zg/nanoidp:latest
 ```
 
-Container tags are derived from release tags (for example `v2.5.0`);
+Container tags are derived from release tags (for example `v2.6.0`);
 `latest` points at the newest non-prerelease.
 
 ## From source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.5.0"
+version = "2.6.0"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release housekeeping for 2.6.0:

- `pyproject.toml` version 2.5.0 -> 2.6.0
- CHANGELOG: `[Unreleased]` -> `[2.6.0] - 2026-08-21` + compare link
- install guide example tag v2.5.0 -> v2.6.0

Wheel smoke test performed on this commit: built `nanoidp-2.6.0-py3-none-any.whl`, installed in a clean venv; `import nanoidp` (metadata version 2.6.0), `nanoidp --help`, `nanoidp init` (writes `host: "127.0.0.1"`), server startup with `/api/health` OK on loopback and unreachable from the LAN interface, `nanoidp-mcp` entrypoint OK.