### PR TITLE
chore: bump version to 2.7.0rc1 for the pre-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.6.0"
+version = "2.7.0rc1"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Pre-release cut from current main so the 2.7.0 features (persona login #158, per-client branding #157, UI login gate #166) can be tested in real setups before the final release. CHANGELOG stays under [Unreleased]; the 2.7.0 section will be consolidated at the final release. Git tag will be v2.7.0-rc1 (hyphenated, so the Docker workflow's latest tag stays on 2.6.0); the Python version is 2.7.0rc1 per PEP 440, which pip only installs with --pre.