### PR TITLE
fix(ci): keep :latest off pre-release tags and publish pre-releases to PyPI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # latest=false: the metadata-action's default 'latest=auto' flavor
+          # adds :latest on ANY tag push, ignoring the enable= guard on the
+          # raw rule below - that is exactly how v2.7.0-rc1 briefly captured
+          # :latest. With auto disabled, the guarded raw rule is the only
+          # source of :latest, so hyphenated pre-release tags never move it.
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,10 @@ jobs:
     needs: publish-testpypi
     runs-on: ubuntu-latest
     environment: pypi
-    # Only publish to PyPI for non-prerelease tags
-    if: ${{ !contains(github.ref, '-') }}
+    # Pre-release tags publish to PyPI too: pip only installs pre-releases
+    # with an explicit --pre (or an exact ==2.7.0rc1 pin), so plain
+    # `pip install nanoidp` keeps resolving to the latest final release.
+    # TestPyPI above stays as the rehearsal step for every tag.
     permissions:
       id-token: write
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.7.0rc1"
+version = "2.7.0rc2"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Two release-workflow fixes surfaced by the v2.7.0-rc1 cut, plus the version bump for the re-cut as v2.7.0-rc2:

- **docker.yml**: the metadata-action default `flavor: latest=auto` added `:latest` on the rc tag push, overriding the `enable=` guard on the raw rule - that is how `:latest` briefly pointed at the rc (restored to v2.6.0 separately). `latest=false` makes the guarded raw rule the only source of `:latest`.
- **publish.yml**: the hyphen guard kept pre-release tags off PyPI entirely (TestPyPI only), contradicting the rc's purpose; pip's `--pre` gate already protects plain installs. TestPyPI stays as the rehearsal step for every tag.
- **pyproject**: 2.7.0rc1 -> 2.7.0rc2. The rc1 tag ran the old workflow definitions (workflows are read from the tagged commit), so the fix requires a re-cut; rc1's release and tag will be deleted.