### PR TITLE
fix: expose saml.default_acs_url in /api/config + CHANGELOG repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Persona login mode** (#156): opt-in `login.mode: persona` lists the
+  configured users on every interactive login surface (`/login`,
+  `/authorize`, `/saml/sso` and the device flow's verification page) and
+  signs in by selecting one, with no password prompt - a local
+  development/testing convenience, off by default. `User.password` is now
+  optional: a password-less user can only authenticate via persona-mode
+  interactive login, never via password-mode login or the OAuth password
+  grant. Persona-authenticated sessions emit SAML
+  `AuthnContextClassRef: unspecified` instead of falsely claiming
+  `PasswordProtectedTransport`. New MCP tool `create_persona_user`, a
+  `persona-login` example preset, settings-UI persistence and e2e coverage.
+- **Per-client login page branding**: optional per-client colors (background,
+  header, footer, all as validated hex values), show/hide client_id and
+  description on the `/authorize` login page, and per-client logo images
+  stored locally in `static/logos/` keyed by client ID (no YAML config needed
+  for logos; place the image file and it's served automatically; the
+  directory is overridable via `oauth.logos_dir`). Colours and toggles are
+  editable from the OAuth client form in the UI and from the MCP
+  `create_client`/`update_client`/`get_client` tools, descriptions are
+  already supported, and logos are deployed by the operator to the server
+  filesystem. Designed for demos and prototyping; colours are structured
+  (not free-form CSS) to prevent stored-XSS on the auth UI, and logos are
+  local files only (no remote URLs) to avoid beacons.
+
+### Fixed
+- **`/api/config` now exposes `saml.default_acs_url`** (#165). The e2e agent
+  rebuilds the settings form from that document, so the missing field was
+  posted back blank on every run and the "present-but-blank = clear"
+  contract (#131) silently wiped `default_acs_url` from `settings.yaml`.
+
 ### Security
 - **Opt-in login gate for the config web UI**: new `session.require_ui_login`
   setting (off by default) makes `/login` actually enforce a logged-in
@@ -35,18 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the security caveats inline.
 
 ### Added
-- **Per-client login page branding**: optional per-client colors (background,
-  header, footer, all as validated hex values), show/hide client_id and
-  description on the `/authorize` login page, and per-client logo images
-  stored locally in `static/logos/` keyed by client ID (no YAML config needed
-  for logos; place the image file and it's served automatically; the
-  directory is overridable via `oauth.logos_dir`). Colours and toggles are
-  editable from the OAuth client form in the UI and from the MCP
-  `create_client`/`update_client`/`get_client` tools, descriptions are
-  already supported, and logos are deployed by the operator to the server
-  filesystem. Designed for demos and prototyping; colours are structured
-  (not free-form CSS) to prevent stored-XSS on the auth UI, and logos are
-  local files only (no remote URLs) to avoid beacons.
 - **First-class group support**: users gain a `groups` list alongside `roles`,
   modelled exactly the same way. It is loaded from and persisted to
   `users.yaml` (omitted when empty), emitted as a `groups` claim on the access

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -148,6 +148,11 @@ def get_configuration() -> ResponseReturnValue:
         "saml": {
             "entity_id": settings.saml_entity_id,
             "sso_url": settings.saml_sso_url,
+            # The e2e agent rebuilds the /settings form from this document, so
+            # every form-editable SAML field must appear here - omitting one
+            # makes the round-trip post it blank and the "blank = clear"
+            # contract (#131) wipes it from settings.yaml (#165).
+            "default_acs_url": settings.default_acs_url,
             "sign_responses": settings.saml_sign_responses,
             "c14n_algorithm": settings.saml_c14n_algorithm,
             "strict_binding": settings.strict_saml_binding,

--- a/tests/test_api_config_parity.py
+++ b/tests/test_api_config_parity.py
@@ -1,0 +1,54 @@
+"""
+Regression tests for #165: /api/config must expose every form-editable field.
+
+The e2e agent rebuilds the /settings form from /api/config's document; a
+field missing there gets posted blank, and the "present-but-blank = clear"
+contract (#131) then wipes it from settings.yaml. That is exactly what
+happened to saml.default_acs_url on every e2e run.
+"""
+
+
+class TestApiConfigSamlParity:
+    def test_default_acs_url_exposed(self, client):
+        """/api/config's saml section carries default_acs_url."""
+        resp = client.get("/api/config")
+        assert resp.status_code == 200
+        saml = resp.get_json()["saml"]
+        assert "default_acs_url" in saml
+
+    def test_e2e_round_trip_preserves_default_acs_url(self, client, app):
+        """Replaying the e2e agent's settings round-trip (form rebuilt from
+        /api/config, posted back unchanged) must not clear default_acs_url."""
+        from nanoidp.config import get_config
+
+        with app.app_context():
+            config = get_config()
+            original = config.settings.default_acs_url
+            assert original, "fixture config must define a default_acs_url"
+
+        doc = client.get("/api/config").get_json()
+        saml = doc["saml"]
+        oauth = doc["oauth"]
+        # The exact form the e2e agent's c14n test builds from /api/config.
+        resp = client.post(
+            "/settings",
+            data={
+                "issuer": oauth["issuer"],
+                "audience": oauth["audience"],
+                "token_expiry_minutes": oauth["token_expiry_minutes"],
+                "saml_entity_id": saml["entity_id"],
+                "saml_sso_url": saml["sso_url"],
+                "default_acs_url": saml.get("default_acs_url", ""),
+                "saml_sign_responses": "true" if saml["sign_responses"] else "",
+                "strict_saml_binding": "true" if saml["strict_binding"] else "",
+                "saml_c14n_algorithm": saml["c14n_algorithm"],
+                "allowed_identity_classes": "\n".join(
+                    doc["allowed_identity_classes"]
+                ),
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        with app.app_context():
+            assert get_config().settings.default_acs_url == original


### PR DESCRIPTION
Closes #165.

- **/api/config** now exposes `saml.default_acs_url`: the e2e agent rebuilds the settings form from that document, so the missing field was posted back blank on every run and the "present-but-blank = clear" contract (#131) wiped it from settings.yaml. Verified live: a full e2e run (49/49) now leaves settings.yaml byte-identical. The regression tests replay the exact round-trip and were confirmed to fail without the fix.
- **CHANGELOG repair** (second commit): the #158 rebase after the 2.6.0 release dropped the persona-login entry entirely, and #157's rebase let its branding entry merge textually into the already-released [2.6.0] section. Restored/moved both under [Unreleased], plus the #165 Fixed entry. Same family as the #132/#152 stacked-changelog lesson.