### PR TITLE
fix: example presets bind to 127.0.0.1 with a commented 0.0.0.0 opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local files only (no remote URLs) to avoid beacons.
 
 ### Fixed
+- **Example presets now bind to `127.0.0.1`** (#164). All four pre-2.6.0
+  presets (`cli-device-flow`, `microservices-client-credentials`,
+  `react-spa-pkce`, `spring-boot-saml`) still shipped an explicit
+  `host: "0.0.0.0"`, overriding the loopback default introduced with
+  GHSA-2473-px8h-rvg6 for anyone who copied them. Each now ships loopback
+  with a commented `# host: "0.0.0.0"` opt-in line, matching the
+  `persona-login` preset and the reverse-proxy guide's framing.
 - **`/api/config` now exposes `saml.default_acs_url`** (#165). The e2e agent
   rebuilds the settings form from that document, so the missing field was
   posted back blank on every run and the "present-but-blank = clear"

--- a/examples/cli-device-flow/settings.yaml
+++ b/examples/cli-device-flow/settings.yaml
@@ -2,7 +2,8 @@
 # Copy this file to your config directory
 
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"
+  # host: "0.0.0.0"  # LAN access is intentionally opt-in (GHSA-2473-px8h-rvg6)
   port: 8000
 
 oauth:

--- a/examples/microservices-client-credentials/settings.yaml
+++ b/examples/microservices-client-credentials/settings.yaml
@@ -2,7 +2,8 @@
 # Copy this file to your config directory
 
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"
+  # host: "0.0.0.0"  # LAN access is intentionally opt-in (GHSA-2473-px8h-rvg6)
   port: 8000
 
 oauth:

--- a/examples/react-spa-pkce/settings.yaml
+++ b/examples/react-spa-pkce/settings.yaml
@@ -2,7 +2,8 @@
 # Copy this file to your config directory
 
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"
+  # host: "0.0.0.0"  # LAN access is intentionally opt-in (GHSA-2473-px8h-rvg6)
   port: 8000
 
 oauth:

--- a/examples/spring-boot-saml/settings.yaml
+++ b/examples/spring-boot-saml/settings.yaml
@@ -2,7 +2,8 @@
 # Copy this file to your config directory
 
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"
+  # host: "0.0.0.0"  # LAN access is intentionally opt-in (GHSA-2473-px8h-rvg6)
   port: 8000
 
 oauth:


### PR DESCRIPTION
Closes #164.

All four pre-2.6.0 presets (`cli-device-flow`, `microservices-client-credentials`, `react-spa-pkce`, `spring-boot-saml`) still shipped an explicit `host: "0.0.0.0"`, overriding the loopback default introduced with GHSA-2473-px8h-rvg6 for anyone copying them. Each now ships `127.0.0.1` with a commented `# host: "0.0.0.0"` opt-in line, matching the `persona-login` preset (#158) and the reverse-proxy guide's framing (#161). No README changes needed (none reference LAN/multi-device use). Verified live: the `cli-device-flow` preset boots and binds `127.0.0.1` (ss-confirmed).