### PR TITLE
fix: add containment barrier to resolve_client_logo (CodeQL alert 23)

### DIFF
--- a/src/nanoidp/branding.py
+++ b/src/nanoidp/branding.py
@@ -23,11 +23,19 @@ def resolve_client_logo(logos_dir: str, client_id: str) -> Optional[str]:
     """
     if not _SAFE_CLIENT_ID.fullmatch(client_id):
         return None
-    logos_path = os.path.abspath(logos_dir)
+    # realpath (not abspath) so a symlinked logos_dir still contains its own
+    # files after resolution.
+    logos_root = os.path.realpath(logos_dir)
     for ext in _LOGO_EXTENSIONS:
         filename = f"{client_id}{ext}"
-        path = os.path.join(logos_path, filename)
-        if os.path.isfile(path):
+        resolved = os.path.realpath(os.path.join(logos_root, filename))
+        # The charset whitelist above already excludes every traversal
+        # character; this containment check is defense-in-depth, and holds
+        # even if the whitelist ever loosens (a logo that is itself a
+        # symlink escaping the directory is rejected too).
+        if not resolved.startswith(logos_root + os.sep):
+            return None
+        if os.path.isfile(resolved):
             return filename
     return None
 

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -129,3 +129,27 @@ class TestResolveClientLogo:
         monkeypatch.chdir(str(tmp_path.parent))
         result = resolve_client_logo(str(logos_dir.relative_to(tmp_path.parent)), "my-client")
         assert result == "my-client.png"
+
+    def test_resolve_client_logo_through_symlinked_dir(self, tmp_path):
+        """A logos_dir that is itself a symlink still resolves its own files
+        (the containment check compares against the resolved root)."""
+        real_dir = tmp_path / "real-logos"
+        real_dir.mkdir()
+        (real_dir / "my-client.svg").touch()
+        link_dir = tmp_path / "logos-link"
+        link_dir.symlink_to(real_dir)
+
+        result = resolve_client_logo(str(link_dir), "my-client")
+        assert result == "my-client.svg"
+
+    def test_resolve_client_logo_rejects_symlink_escaping_dir(self, tmp_path):
+        """A logo that is a symlink pointing outside logos_dir is rejected
+        (defense-in-depth containment, CodeQL alert 23)."""
+        logos_dir = tmp_path / "logos"
+        logos_dir.mkdir()
+        outside = tmp_path / "outside.svg"
+        outside.touch()
+        (logos_dir / "my-client.svg").symlink_to(outside)
+
+        result = resolve_client_logo(str(logos_dir), "my-client")
+        assert result is None


### PR DESCRIPTION
Addresses [code-scanning alert 23](https://github.com/cdelmonte-zg/nanoidp/security/code-scanning/23) (py/path-injection, high, on `branding.py` from #157).

The code was already safe in practice: the `[a-zA-Z0-9_-]+` fullmatch precedes any path construction, and traversal probes (plain and URL-encoded `..`, backslash, null byte) all returned 404 in the live review. CodeQL simply does not model a regex fullmatch as a sanitizer. Rather than dismissing a high-severity alert, this adds the realpath + `startswith(root + os.sep)` containment idiom CodeQL recognizes as a barrier:

- defense-in-depth if the charset whitelist ever loosens;
- a logo that is itself a symlink escaping the logos directory is now rejected;
- a symlinked `logos_dir` keeps resolving its own files (root is realpath'd too, covered by a new test).

1034 tests, ruff, mypy green. The alert should auto-close on the next CodeQL analysis of main.