### PR TITLE
chore: bump to 2.7.0rc3; smoke-test the built wheel before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,8 +47,47 @@ jobs:
           name: dist
           path: dist/
 
-  publish-testpypi:
+  # Install and exercise the BUILT wheel before anything is published: the
+  # test job above runs against `pip install -e .`, which does not catch
+  # packaging defects (missing package data, broken entry points, metadata
+  # fallbacks) in the artifact actually being shipped.
+  wheel-smoke:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Install the wheel in a clean venv
+        run: |
+          python -m venv smoke
+          smoke/bin/pip install --quiet dist/*.whl
+
+      - name: Smoke test the installed wheel
+        run: |
+          smoke/bin/python -c "import nanoidp; print('version:', nanoidp.__version__)"
+          smoke/bin/nanoidp --help > /dev/null
+          command -v smoke/bin/nanoidp-mcp > /dev/null
+          mkdir smoke-cfg && cd smoke-cfg
+          ../smoke/bin/nanoidp init
+          grep -q '127.0.0.1' config/settings.yaml
+          ../smoke/bin/nanoidp --port 8765 &
+          SERVER=$!
+          for i in $(seq 1 30); do curl -sf http://127.0.0.1:8765/api/health > /dev/null && break; sleep 1; done
+          curl -sf http://127.0.0.1:8765/api/health | grep -q ok
+          curl -sf http://127.0.0.1:8765/.well-known/openid-configuration > /dev/null
+          kill $SERVER
+
+  publish-testpypi:
+    needs: wheel-smoke
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.7.0rc2"
+version = "2.7.0rc3"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Re-cut of the pre-release from current main, per the rc2 review verdict: rc2 stays as the public RC, but main gained #169 (`/api/config` `default_acs_url` + CHANGELOG repair), #170 (preset loopback sweep) and #171 (logo path containment) hours after its tag, so it is no longer the candidate to promote.

Also closes the known release-pipeline gap: `publish.yml` now has a **wheel-smoke** job between `build` and `publish-testpypi` that installs the built wheel in a clean venv and exercises import, `--help`, the `nanoidp-mcp` entry point, `init` (asserting the loopback default), startup, `/api/health` and discovery - the existing `test` job runs against `pip install -e .` and cannot catch packaging defects in the shipped artifact. The rc3 tag itself will exercise the new job.

The `--profile dev` override gap from the same review is tracked as #172 for the final.