### PR TITLE
Settings.management_secret (models.py) — YAML-only field, loadable fr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contract (#131) silently wiped `default_acs_url` from `settings.yaml`.
 
 ### Security
+- **Opt-in `management_secret` mutation gate** (#163): one shared secret that
+  gates state-changing calls across all three management surfaces - the MCP
+  server (via the existing `admin_secret` tool argument, which now reads from
+  this setting instead of a standalone env var), `/api/*` (via a new
+  `X-Management-Secret` request header on mutating calls), and the config web
+  UI (a one-time "unlock" form at `/login` that then trusts the session for
+  further mutating requests). Off by default - unset, nothing changes.
+  Configurable via `settings.yaml`'s `session.management_secret` or the
+  `NANOIDP_MANAGEMENT_SECRET` env var; the previous MCP-only
+  `NANOIDP_MCP_ADMIN_SECRET` still works as an alias, though an explicit
+  `management_secret: null`/`""` in `settings.yaml` now wins over either env
+  var rather than falling through to it. Independent of `require_ui_login`:
+  that gate is the UI's session front door (who can view the dashboard),
+  this is the write guard (who can change anything) - either, both, or
+  neither can be enabled; the unlock form stays reachable even when
+  `require_ui_login` is also on. YAML-only, same treatment as
+  `require_ui_login`/`secret_key`. Hardened since first landing: the UI
+  unlock flag is now an HMAC of the secret itself (not a bare session
+  boolean), so it can't be forged just by knowing `secret_key`'s public
+  default; a non-ASCII or non-string secret compares safely instead of
+  500ing; an unlocked UI session now also satisfies the `/api/*` gate, so
+  the dashboard's own buttons (generate token, clear audit log) keep working
+  after one unlock; and the MCP check now always reads the `ConfigManager`
+  actually serving the request.
 - **Opt-in login gate for the config web UI**: new `session.require_ui_login`
   setting (off by default) makes `/login` actually enforce a logged-in
   session on the dashboard, users, clients, settings, keys, claims, audit log

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -380,11 +380,16 @@ own `/login` and the SAML SSO login page are unbranded.
 The SAML options (`strict_binding`, `sign_responses`, `c14n_algorithm`)
 are covered in detail in [SAML options](saml.md). Security-related
 settings are covered in the [Security guide](../guides/SECURITY.md):
-profiles, `require_pkce`, key management, `jwt.external_keys`, and the
+profiles, `require_pkce`, key management, `jwt.external_keys`, the
 config UI's opt-in [login gate](../guides/SECURITY.md#config-ui-login-gate)
-(`session.require_ui_login`), and the invalid-bcrypt-hash
+(`session.require_ui_login`), the invalid-bcrypt-hash
 [fallback removal](../guides/SECURITY.md#invalid-bcrypt-hash-fallback)
-(`session.enforce_password_check`).
+(`session.enforce_password_check`), and the
+[management secret](../guides/SECURITY.md#management-secret) write guard
+shared by MCP, `/api/*`, and the web UI (`session.management_secret`) - all
+YAML-only, like `session.secret_key` (see
+[Session Cookie Trust](../guides/SECURITY.md#session-cookie-trust-secret_key)
+for why that one matters here too).
 
 ## Logging
 
@@ -490,6 +495,7 @@ directory.
 
 ## Environment variables
 
-The environment variables (`NANOIDP_CONFIG_DIR`, `NANOIDP_MCP_ADMIN_SECRET`,
-`NANOIDP_MCP_READONLY`, `PORT`) are listed in the
+The environment variables (`NANOIDP_CONFIG_DIR`, `NANOIDP_MANAGEMENT_SECRET`,
+the legacy `NANOIDP_MCP_ADMIN_SECRET` alias, `NANOIDP_MCP_READONLY`, `PORT`)
+are listed in the
 [Security guide](../guides/SECURITY.md#environment-variables).

--- a/docs/MCP_WORKFLOW.md
+++ b/docs/MCP_WORKFLOW.md
@@ -210,7 +210,13 @@ Prompt: "I need to test role-based access. Create a user 'role-test' with
 
 ### Admin Secret Protection
 
-When `NANOIDP_MCP_ADMIN_SECRET` is set, mutating tools require the secret:
+When [`management_secret`](SECURITY.md#management-secret) is configured -
+via `settings.yaml`'s `session.management_secret`, the
+`NANOIDP_MANAGEMENT_SECRET` env var, or the legacy `NANOIDP_MCP_ADMIN_SECRET`
+env var (this setting's MCP-only predecessor, still supported as an alias) -
+mutating tools require the secret as the `admin_secret` tool argument. The
+same setting also gates `/api/*` and the web UI's mutating form actions -
+see [Management Secret](SECURITY.md#management-secret) for the full picture.
 
 ```json
 {
@@ -219,7 +225,7 @@ When `NANOIDP_MCP_ADMIN_SECRET` is set, mutating tools require the secret:
       "command": "nanoidp-mcp",
       "env": {
         "NANOIDP_CONFIG_DIR": "./config",
-        "NANOIDP_MCP_ADMIN_SECRET": "your-secret-here"
+        "NANOIDP_MANAGEMENT_SECRET": "your-secret-here"
       }
     }
   }
@@ -267,6 +273,6 @@ NANOIDP_CONFIG_DIR=./config nanoidp-mcp
 ### Permission Denied for Mutating Tools
 
 Either:
-1. Provide `admin_secret` in tool arguments (if `NANOIDP_MCP_ADMIN_SECRET` is set)
-2. Or remove `NANOIDP_MCP_ADMIN_SECRET` env var for development
+1. Provide `admin_secret` in tool arguments (if `management_secret` is configured)
+2. Or unset `management_secret` (settings.yaml, `NANOIDP_MANAGEMENT_SECRET`, or the legacy `NANOIDP_MCP_ADMIN_SECRET`) for development
 3. Or check you're not running in `--readonly` mode

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,7 @@ By design, NanoIDP prioritizes developer convenience over security hardening. It
 
 NanoIDP binds to `127.0.0.1` (loopback only) by default, so out of the box it is reachable only from the local machine.
 
-This matters because the management API (`/api/*`) is **unauthenticated by design** (see [MCP Server Security](#mcp-server-security) for the equivalent concern on the MCP side). Those endpoints can mint a validly signed access token for any user, including `admin`, rotate the signing keys, and clear the audit log. Loopback binding keeps that surface off the network.
+This matters because the management API (`/api/*`) is **unauthenticated by design** (see [MCP Server Security](#mcp-server-security) for the equivalent concern on the MCP side). Those endpoints can mint a validly signed access token for any user, including `admin`, rotate the signing keys, and clear the audit log. Loopback binding keeps that surface off the network. If you need it reachable by more than one host, also consider [`management_secret`](#management-secret), which requires a shared secret for these mutating calls specifically (reads stay open either way).
 
 ### Exposing on a network
 
@@ -51,12 +51,27 @@ session:
 | `false` (default) | The config web UI is unauthenticated, like today |
 | `true` | Every web UI page except `/login` itself redirects to `/login` until a session exists |
 
+`/management/unlock` (the [`management_secret`](#management-secret) unlock
+form) is exempt from this redirect too, whether or not a login session
+exists yet - `management_secret` is an independent axis (see below), and
+gating it on a login session it doesn't depend on would make the unlock form
+`/login` renders whenever `management_secret` is configured silently do
+nothing.
+
 **What it does not protect**: the separate management API (`/api/*`) stays
 unauthenticated regardless of this setting - it's a distinct Flask blueprint
 that a UI-only login gate structurally cannot reach. If you enable
 `require_ui_login` because the dashboard is reachable by more than just you,
 also keep `/api/*` off the network (see [Network Binding](#network-binding)
-above) or in front of your own auth layer; this setting does nothing for it.
+above), set [`management_secret`](#management-secret) to gate its mutations,
+or put it behind your own auth layer; this setting does nothing for it.
+
+**Relationship to `management_secret`**: these are independent axes.
+`require_ui_login` is the UI's session front door - it controls who can view
+the dashboard at all. `management_secret` (below) is the write guard - it
+controls who can change anything, on all three management surfaces, whether
+or not `require_ui_login` is on. With both off, nothing is enforced, same as
+today.
 
 **Persona mode interaction**: logging in via `/login` or via the SAML SSO
 inline login at `/saml/sso` both satisfy this gate - they authenticate
@@ -71,6 +86,120 @@ against anyone who can reach the port.
 on the Settings page or the MCP `update_settings` tool. It's a fixed operator
 decision about the trust boundary of the surface itself, not something meant
 to be flipped from inside the surface it protects.
+
+**Session trust caveat**: this gate's protection depends entirely on
+`secret_key` being a real, private value - see
+[Session Cookie Trust](#session-cookie-trust-secret_key) below.
+
+---
+
+## Session Cookie Trust (`secret_key`)
+
+Both `require_ui_login` (above) and `management_secret`'s web UI leg (below)
+work by reading something out of the Flask session - a client-side cookie
+Flask *signs* but does not encrypt, using `secret_key`. Anyone who knows
+`secret_key` can construct arbitrary session content and have Flask accept it
+as genuine, including `session['user']` (what `require_ui_login` checks).
+
+```yaml
+session:
+  secret_key: "a real, private value"   # default: a public, well-known string
+```
+
+`secret_key` ships with a public default
+(`dev-secret-key-change-in-production`, identical in every install unless
+changed) so NanoIDP works out of the box. That's harmless as long as nothing
+security-relevant depends on the session; `require_ui_login` and
+`management_secret` both now do. NanoIDP logs a startup warning when
+`secret_key` is left at its default while either is configured.
+
+The two gates are not equally exposed by this. `require_ui_login`'s
+`session['user']` is a bare value with no independent verification - with a
+default `secret_key`, anyone who can reach the port can forge it and skip the
+login gate entirely. `management_secret`'s session flag
+(`session['management_verified']`) is additionally bound to
+`management_secret` itself via an HMAC (see
+[Management Secret](#management-secret)), not stored as a bare boolean, so
+knowing only the default `secret_key` is not enough to forge it - the forger
+would also need to know `management_secret`, the thing being protected.
+Set a real `secret_key` before relying on either gate beyond a single
+trusted machine.
+
+The session cookie is also set with `SameSite=Lax`. Once `management_secret`
+is unlocked, the session authorizes `/api/*` mutations
+(`management_secret_required_for_api` accepts an already-unlocked session,
+[above](#management-secret)) in addition to `ui_bp`'s own forms - so the
+cross-site form-POST surface that already existed for the dashboard now
+covers the management API too, on any browser that doesn't default new
+cookies to `Lax` on its own. `SameSite=Lax` closes that: the cookie isn't
+sent on a cross-site POST, only on top-level navigation.
+
+---
+
+## Management Secret
+
+`management_secret` is one shared secret that gates **mutations** across all
+three management surfaces - the MCP server, `/api/*`, and the config web UI -
+instead of each surface growing its own opt-in mechanism independently. It
+does not gate reads: listing users, viewing settings, decoding tokens, and
+the dashboard itself stay reachable exactly as they are today. Off by
+default - unset, nothing is enforced, identical to before this setting
+existed.
+
+```yaml
+session:
+  management_secret: "your-secret-here"   # default: unset
+```
+
+Must be printable ASCII - Werkzeug decodes request headers as latin-1, so a
+non-ASCII secret could never be matched via the `X-Management-Secret` header
+even though the form and MCP's JSON argument would see it correctly;
+rejected at startup with a clear error rather than shipping a secret that
+silently only half-works.
+
+Also loadable from the `NANOIDP_MANAGEMENT_SECRET` environment variable.
+`NANOIDP_MCP_ADMIN_SECRET` - this setting's MCP-only predecessor - keeps
+working as an alias, so existing MCP-only setups aren't broken by upgrading.
+Precedence: an explicit `management_secret` key in settings.yaml's `session:`
+block wins over both env vars *even when its value is empty or `null`* -
+presence in YAML is read as the operator deliberately stating "off", distinct
+from the key being absent. Only when the key is absent entirely do the env
+vars apply, `NANOIDP_MANAGEMENT_SECRET` before the legacy
+`NANOIDP_MCP_ADMIN_SECRET`. Env vars are read once, when configuration loads (startup, or an explicit
+`reload_config`) - not on every request, so changing one in the environment
+has no effect until then.
+
+Each surface proves knowledge of the secret differently, matching how that
+surface already talks to NanoIDP:
+
+| Surface | How the secret is supplied |
+|---------|-----------------------------|
+| MCP server | The existing `admin_secret` tool argument on any [mutating tool](#mutating-tools) - see [Admin Secret Protection](#admin-secret-protection) |
+| `/api/*` | An `X-Management-Secret` request header on any `POST`/`PUT`/`DELETE` |
+| Web UI (`ui_bp`) | A one-time "Unlock management actions" form on `/login`; once submitted correctly, the session is trusted for the rest of its lifetime - the same trust model `require_ui_login` already uses for `session['user']`, so you aren't re-prompted on every click |
+
+A UI mutation attempted before the secret has been unlocked for that session
+redirects to `/login` with a prompt to unlock, rather than silently failing;
+retry the action after unlocking. The web UI's own dashboard pages
+(users, token tester, audit log) call `/api/*` from client-side JavaScript
+using the browser's session cookie, not the header - an already-unlocked
+session satisfies `/api/*`'s gate too, so those buttons keep working after
+one unlock; a non-browser client still needs the header.
+
+What's actually stored in `session['management_verified']` is an HMAC of
+`management_secret` itself (keyed by `secret_key`), not a bare boolean - see
+[Session Cookie Trust](#session-cookie-trust-secret_key) for why that
+distinction matters.
+
+**Relationship to `require_ui_login`**: independent axes - see
+[Config UI Login Gate](#config-ui-login-gate) above.
+`require_ui_login` is the session front door (who can view the dashboard);
+`management_secret` is the write guard (who can change anything). Either,
+both, or neither can be enabled.
+
+**YAML-only**: like `secret_key`, `require_ui_login`, and `security_profile`,
+this is not exposed on the Settings page or the MCP `update_settings` tool -
+a secret editable through the surface it protects isn't a secret.
 
 ---
 
@@ -300,7 +429,10 @@ The following MCP tools modify configuration and require extra caution:
 
 ### Admin Secret Protection
 
-When `NANOIDP_MCP_ADMIN_SECRET` is set, mutating operations require the secret:
+When [`management_secret`](#management-secret) is configured, mutating
+operations require the secret via the `admin_secret` tool argument.
+`NANOIDP_MCP_ADMIN_SECRET` still works too - it's this setting's original,
+MCP-only name, kept as an alias:
 
 ```json
 {
@@ -394,7 +526,8 @@ discovery/token issuer mismatch.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NANOIDP_CONFIG_DIR` | Configuration directory path | `./config` |
-| `NANOIDP_MCP_ADMIN_SECRET` | Secret required for mutating MCP operations | (none) |
+| `NANOIDP_MANAGEMENT_SECRET` | [Secret](#management-secret) required for mutations across MCP, `/api/*`, and the web UI | (none) |
+| `NANOIDP_MCP_ADMIN_SECRET` | Legacy alias for `NANOIDP_MANAGEMENT_SECRET` (MCP-only name, still honored) | (none) |
 | `NANOIDP_MCP_READONLY` | Disable mutating MCP tools when set to `true` | `false` |
 | `PORT` | Server port | `8000` |
 
@@ -404,7 +537,7 @@ discovery/token issuer mismatch.
 
 1. **Use stricter-dev profile** when sharing the instance with team members
 2. **Enable readonly mode** for MCP when only introspection is needed
-3. **Set MCP admin secret** if multiple developers share the same NanoIDP instance
+3. **Set `management_secret`** if multiple developers share the same NanoIDP instance - it gates mutating calls on MCP, `/api/*`, and the web UI alike
 4. **Rotate keys periodically** to test token validation with multiple keys
 5. **Keep the default `127.0.0.1` binding** unless you specifically need network access; only override it on a trusted, isolated network (see [Network Binding](#network-binding))
 6. **Never expose NanoIDP to public networks**: it's designed for local/isolated use only

--- a/docs/schema/config.v1.json
+++ b/docs/schema/config.v1.json
@@ -500,6 +500,18 @@
             "title": "Enforce Password Check",
             "type": "boolean"
           },
+          "management_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Management Secret"
+          },
           "permanent": {
             "default": null,
             "title": "Permanent"

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -80,6 +80,7 @@ class TestCategory(Enum):
     PERSONA = "Persona Login"
     KEYS = "Key Management"
     API = "REST API"
+    MANAGEMENT = "Management Secret"
 
 
 @dataclass
@@ -131,7 +132,8 @@ class NanoIDPTestAgent:
         client_secret: str = "demo-secret",
         username: str = "admin",
         password: str = "admin",
-        verbose: bool = False
+        verbose: bool = False,
+        management_secret: Optional[str] = None
     ):
         self.base_url = base_url.rstrip("/")
         self.client_id = client_id
@@ -139,8 +141,16 @@ class NanoIDPTestAgent:
         self.username = username
         self.password = password
         self.verbose = verbose
+        self.management_secret = management_secret
         self.session = requests.Session()
         self.session.auth = (client_id, client_secret)
+        # Set once here rather than per-request: covers every api_bp mutation
+        # this agent makes through self.session (#163 review - the header was
+        # previously attached ad hoc on three calls only, and any UI mutation
+        # made through self.session had no equivalent, see
+        # _unlock_management_secret below).
+        if self.management_secret:
+            self.session.headers["X-Management-Secret"] = self.management_secret
 
         # Token storage
         self.access_token: Optional[str] = None
@@ -163,6 +173,25 @@ class NanoIDPTestAgent:
         """Log verbose output."""
         if self.verbose:
             print(f"    [DEBUG] {msg}")
+
+    def _unlock_management_secret(self) -> None:
+        """One-time ui_bp write-guard unlock (routes/ui.py management_unlock).
+
+        Mirrors the X-Management-Secret header set on self.session in
+        __init__ for api_bp: without this, every ui_bp form mutation this
+        agent makes through self.session (settings, users, clients) would be
+        redirected to /login and silently do nothing once management_secret
+        is configured (#163 review, house rule for anything touching the
+        management surfaces). No-op when no secret was given - same as
+        every other run today.
+        """
+        if not self.management_secret:
+            return
+        self.session.post(
+            f"{self.base_url}/management/unlock",
+            data={"management_secret": self.management_secret},
+            timeout=5,
+        )
 
     def _add_result(
         self,
@@ -949,7 +978,11 @@ class NanoIDPTestAgent:
         test_client_id = f"branding-test-{secrets.token_hex(4)}"
         test_description = "Branding e2e test client"
         try:
-            create = requests.post(
+            # self.session (not bare requests) so this rides the same
+            # unlocked management_secret cookie as _unlock_management_secret
+            # set up (#163 review) - only relevant when a secret is
+            # configured; a no-op otherwise.
+            create = self.session.post(
                 f"{self.base_url}/clients/create",
                 data={
                     "client_id": test_client_id,
@@ -1003,7 +1036,7 @@ class NanoIDPTestAgent:
                 "Client Branding", TestCategory.OAUTH, False, f"Error: {e}"
             )
         finally:
-            requests.post(
+            self.session.post(
                 f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
             )
 
@@ -2961,7 +2994,7 @@ class NanoIDPTestAgent:
             # Cleanup runs regardless of how far the checks above got, so a
             # failed assertion never leaves the running server in persona
             # mode or with a leftover test user.
-            requests.post(f"{self.base_url}/users/{persona_user}/delete", timeout=5)
+            self.session.post(f"{self.base_url}/users/{persona_user}/delete", timeout=5)
             self.session.post(
                 f"{self.base_url}/settings",
                 data={"login_mode": "password"},
@@ -3025,10 +3058,11 @@ class NanoIDPTestAgent:
             before_data = before.json()
             old_kid = before_data.get("active_kid", before_data.get("current_kid"))
 
-            # Perform rotation
+            # Perform rotation. X-Management-Secret (if any) is already on
+            # self.session.headers - see __init__.
             response = self.session.post(
                 f"{self.base_url}/api/keys/rotate",
-                timeout=10
+                timeout=10,
             )
 
             if response.status_code == 200:
@@ -3199,7 +3233,7 @@ class NanoIDPTestAgent:
             response = self.session.post(
                 f"{self.base_url}/api/users/{self.username}/token",
                 json={"exp_minutes": 5},
-                timeout=5
+                timeout=5,
             )
             if response.status_code == 200:
                 data = response.json()
@@ -3318,7 +3352,7 @@ class NanoIDPTestAgent:
         try:
             response = self.session.post(
                 f"{self.base_url}/api/config/reload",
-                timeout=5
+                timeout=5,
             )
             if response.status_code == 200:
                 data = response.json()
@@ -3596,6 +3630,84 @@ class NanoIDPTestAgent:
             )
         except Exception as e:
             return self._add_result("API Audit Stats", TestCategory.API, False, str(e))
+
+    # =========================================================================
+    # MANAGEMENT SECRET TESTS
+    # =========================================================================
+    #
+    # Positive coverage (the secret works when supplied correctly) already
+    # happens implicitly: every api_bp/ui_bp mutation above rides
+    # self.session, which carries X-Management-Secret and the unlocked
+    # ui_bp session (see __init__ / _unlock_management_secret). These two
+    # tests are the negative side - a client with neither must be rejected -
+    # which nothing else here exercises (#163 review: "there is also no
+    # negative check"). Both are skipped (reported as passing, with
+    # data={"skipped": True}) when the agent wasn't given a management_secret
+    # to begin with, since there's nothing gated to prove in that mode.
+
+    def test_management_secret_required_for_api_mutation(self) -> TestResult:
+        """A mutating /api/* call with no X-Management-Secret header must be
+        rejected (401), using a bare requests.Session with none of this
+        agent's own session state."""
+        if not self.management_secret:
+            return self._add_result(
+                "Management Secret Required (API)",
+                TestCategory.MANAGEMENT,
+                True,
+                "Skipped: no management_secret configured",
+                {"skipped": True}
+            )
+        try:
+            anon = requests.Session()
+            response = anon.post(f"{self.base_url}/api/config/reload", timeout=5)
+            return self._add_result(
+                "Management Secret Required (API)",
+                TestCategory.MANAGEMENT,
+                response.status_code == 401,
+                f"Status: {response.status_code} (expected 401)",
+                {"status": response.status_code}
+            )
+        except Exception as e:
+            return self._add_result(
+                "Management Secret Required (API)", TestCategory.MANAGEMENT, False, str(e)
+            )
+
+    def test_management_secret_required_for_ui_mutation(self) -> TestResult:
+        """A ui_bp form mutation from a session that never unlocked
+        management_secret must be redirected to /login, not silently
+        applied."""
+        if not self.management_secret:
+            return self._add_result(
+                "Management Secret Required (UI)",
+                TestCategory.MANAGEMENT,
+                True,
+                "Skipped: no management_secret configured",
+                {"skipped": True}
+            )
+        try:
+            anon = requests.Session()
+            response = anon.post(
+                f"{self.base_url}/users/create",
+                data={"username": "should-not-be-created", "password": "pw"},
+                allow_redirects=False,
+                timeout=5,
+            )
+            redirected_to_login = (
+                response.status_code == 302
+                and "/login" in response.headers.get("Location", "")
+            )
+            return self._add_result(
+                "Management Secret Required (UI)",
+                TestCategory.MANAGEMENT,
+                redirected_to_login,
+                f"Status: {response.status_code}, Location: "
+                f"{response.headers.get('Location')} (expected 302 to /login)",
+                {"status": response.status_code, "location": response.headers.get("Location")}
+            )
+        except Exception as e:
+            return self._add_result(
+                "Management Secret Required (UI)", TestCategory.MANAGEMENT, False, str(e)
+            )
 
     # =========================================================================
     # TEST RUNNER
@@ -3882,6 +3994,11 @@ class NanoIDPTestAgent:
         print(f"  User:     {self.username}")
         print(f"  Verbose:  {self.verbose}")
 
+        # Unlocks ui_bp's write guard on self.session up front (no-op unless
+        # management_secret was given) - every ui_bp mutation below (settings,
+        # persona user, client branding) rides this same session (#163 review).
+        self._unlock_management_secret()
+
         # Define test groups
         test_groups = [
             (TestCategory.CORE, "Core Infrastructure", [
@@ -3949,6 +4066,10 @@ class NanoIDPTestAgent:
                 self.test_api_hooks_block,
                 self.test_api_audit_log,
                 self.test_api_audit_stats,
+            ]),
+            (TestCategory.MANAGEMENT, "Management Secret", [
+                self.test_management_secret_required_for_api_mutation,
+                self.test_management_secret_required_for_ui_mutation,
             ]),
         ]
 
@@ -4047,6 +4168,11 @@ Examples:
         help="Output results as JSON"
     )
     parser.add_argument(
+        "--management-secret",
+        default=os.getenv("NANOIDP_MANAGEMENT_SECRET"),
+        help="Management secret for mutating /api/* calls, if the target instance has one configured (default: NANOIDP_MANAGEMENT_SECRET env var)"
+    )
+    parser.add_argument(
         "--oauth21",
         action="store_true",
         help="Run only the oauth21-profile suite (server must run with "
@@ -4077,7 +4203,8 @@ Examples:
         client_secret=args.client_secret,
         username=args.user,
         password=args.password,
-        verbose=args.verbose
+        verbose=args.verbose,
+        management_secret=args.management_secret
     )
 
     if args.oauth21:

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -858,7 +858,11 @@ class NanoIDPTestAgent:
         test_client_id = f"native-test-{secrets.token_hex(4)}"
         custom_scheme = "com.example.app:/oauth2redirect"
         try:
-            create = requests.post(
+            # self.session (not bare requests) so this rides the same
+            # unlocked management_secret cookie as _unlock_management_secret
+            # set up (#163 review) - only relevant when a secret is
+            # configured; a no-op otherwise.
+            create = self.session.post(
                 f"{self.base_url}/clients/create",
                 data={
                     "client_id": test_client_id,
@@ -964,7 +968,7 @@ class NanoIDPTestAgent:
                 "Native App Redirect URIs", TestCategory.OAUTH, False, f"Error: {e}"
             )
         finally:
-            requests.post(
+            self.session.post(
                 f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
             )
 

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -20,6 +20,12 @@ from .services import init_crypto_service
 # Global limiter instance (initialized in create_app)
 limiter: Optional[Limiter] = None
 
+# Mirrors Settings.secret_key's default (models.py). Session-signing key that
+# ships public, in source control - fine when nothing session-based is being
+# trusted, not fine once require_ui_login or management_secret's UI leg asks
+# the session to hold something meaningful (#163 review).
+_DEFAULT_SECRET_KEY = "dev-secret-key-change-in-production"
+
 
 def create_app(
     config_dir: Optional[str] = None,
@@ -64,6 +70,33 @@ def create_app(
         static_folder=os.path.join(os.path.dirname(__file__), "static"),
     )
     app.secret_key = settings.secret_key
+    # Browsers that don't default new cookies to Lax (Firefox, at the time of
+    # writing) would otherwise send the session cookie on a cross-site form
+    # POST. An unlocked management_secret session authorizes /api/* mutations
+    # (see routes/_auth.py:management_secret_required_for_api), not just
+    # ui_bp's own forms, so that cross-site surface now covers the management
+    # API too; Lax closes it at the cost of not sending the cookie on a
+    # cross-site GET navigation's initial request, which this app never
+    # relies on. See docs/SECURITY.md, "Session Cookie Trust".
+    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+
+    # secret_key signs the session cookie; a default (public, in source
+    # control) value means anyone who knows it can forge session state -
+    # including session['user'], bypassing require_ui_login outright.
+    # management_secret's own session flag additionally binds to
+    # management_secret itself (see routes/_auth.py:_management_verified_marker),
+    # so knowing only this default doesn't forge that one - but a real
+    # secret_key is still what either gate's session trust rests on. See
+    # docs/SECURITY.md.
+    if settings.secret_key == _DEFAULT_SECRET_KEY and (
+        settings.require_ui_login or settings.management_secret
+    ):
+        logger.warning(
+            "secret_key is left at its public default while require_ui_login "
+            "and/or management_secret is configured. Set session.secret_key "
+            "in settings.yaml to a real, private value before relying on "
+            "either gate beyond a single trusted machine - see docs/SECURITY.md."
+        )
 
     # Trust X-Forwarded-Proto/Host/For from a single reverse-proxy hop, so
     # request.scheme/host_url (and therefore issuer_from_request, rate-limit
@@ -164,16 +197,30 @@ def run_app(
     # NanoIDP is a dev/test IdP whose management API (/api/*) is unauthenticated
     # by design; binding to all interfaces exposes admin token minting and key
     # rotation to any network-reachable host. The default is 127.0.0.1; warn
-    # loudly when that safe default is overridden.
+    # loudly when that safe default is overridden. management_secret (#163)
+    # gates mutations but not reads, so the warning still applies, just less
+    # severely, when it's configured.
     if effective_host in ("0.0.0.0", "::", ""):
-        logging.getLogger(__name__).warning(
-            "Binding to %s exposes NanoIDP on all network interfaces. The "
-            "/api/* management endpoints are unauthenticated by design, so any "
-            "reachable host can mint admin tokens and rotate signing keys. Use "
-            "127.0.0.1 unless you intend network exposure (e.g. inside a "
-            "container).",
-            effective_host,
-        )
+        if settings.management_secret:
+            logging.getLogger(__name__).warning(
+                "Binding to %s exposes NanoIDP on all network interfaces. "
+                "management_secret is configured, so /api/* mutations "
+                "(minting admin tokens, rotating signing keys, etc.) require "
+                "it - but reads and the UI dashboard remain open to any "
+                "reachable host. Use 127.0.0.1 unless you intend network "
+                "exposure (e.g. inside a container).",
+                effective_host,
+            )
+        else:
+            logging.getLogger(__name__).warning(
+                "Binding to %s exposes NanoIDP on all network interfaces. The "
+                "/api/* management endpoints are unauthenticated by design, so any "
+                "reachable host can mint admin tokens and rotate signing keys. Use "
+                "127.0.0.1 unless you intend network exposure (e.g. inside a "
+                "container), or set management_secret to require a shared secret "
+                "for mutations.",
+                effective_host,
+            )
 
     app.run(
         host=effective_host,

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar
 
@@ -159,6 +160,10 @@ class SessionSection(BaseModel):
     secret_key: str = "dev-secret-key-change-in-production"
     require_ui_login: bool = False
     enforce_password_check: bool = False
+    # Absent -> fall back to the env vars in to_settings() (#163); present,
+    # even as null/empty, means the operator deliberately said "off" and the
+    # env vars are not consulted. See "management_secret" in models.py.
+    management_secret: Optional[str] = None
     # Shipped presets carry it; the app sets session.permanent itself.
     permanent: Any = None  # accepted for compatibility, never consumed
 
@@ -349,6 +354,21 @@ class SettingsDocument(BaseModel):
             secret_key=self.session.secret_key,
             require_ui_login=self.session.require_ui_login,
             enforce_password_check=self.session.enforce_password_check,
+            # An explicit key in settings.yaml's session: block wins over the
+            # env vars even when its value is empty/null - presence in YAML
+            # is the operator deliberately stating "off", distinct from the
+            # key being absent (#163 review). Absent the key, fall back to
+            # NANOIDP_MANAGEMENT_SECRET, then the legacy
+            # NANOIDP_MCP_ADMIN_SECRET alias.
+            management_secret=(
+                (self.session.management_secret or None)
+                if "management_secret" in self.session.model_fields_set
+                else (
+                    os.getenv("NANOIDP_MANAGEMENT_SECRET")
+                    or os.getenv("NANOIDP_MCP_ADMIN_SECRET")
+                    or None
+                )
+            ),
             log_level=self.logging.level,
             log_token_requests=self.logging.log_token_requests,
             log_saml_requests=self.logging.log_saml_requests,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -7,8 +7,10 @@ Security Note:
     isolated development environments. It exposes powerful administrative tools.
 
     Security modes:
-    - When NANOIDP_MCP_ADMIN_SECRET is set, mutating operations require
-      the admin_secret parameter to match.
+    - When management_secret is configured (settings.yaml, NANOIDP_MANAGEMENT_SECRET,
+      or the legacy NANOIDP_MCP_ADMIN_SECRET env var), mutating operations
+      require the admin_secret parameter to match. The same setting also
+      gates api_bp and ui_bp mutations - see Settings.management_secret.
     - When --readonly flag or NANOIDP_MCP_READONLY=true, mutating tools
       are completely disabled.
 
@@ -61,6 +63,7 @@ from .config import ConfigManager, OAuthClient, User, init_config
 from .config_validation import validate_config_result
 from .hooks import HookError
 from .models import HEX_COLOR_PATTERN, normalize_saml_attr_name
+from .routes._auth import verify_secret
 from .services import (
     build_discovery_document,
     get_audit_log,
@@ -97,19 +100,34 @@ MUTATING_TOOLS = {
 }
 
 
-def _check_admin_secret(tool_name: str, arguments: dict[str, Any]) -> Tuple[bool, str]:
-    """Check if admin secret is required and valid.
+def _check_admin_secret(
+    config: ConfigManager, tool_name: str, arguments: dict[str, Any]
+) -> Tuple[bool, str]:
+    """Check if the management secret is required and valid for this tool.
+
+    Source of truth is the caller's own ConfigManager (config.settings.
+    management_secret), NOT routes._auth.get_management_secret(). That
+    helper reads nanoidp.config.get_config()'s module-global singleton, which
+    is a different object from mcp_server._config whenever anything (a test,
+    or a future code path) sets mcp_server._config directly instead of via
+    init_config() - in production the two happen to be the same object today,
+    but this function must not depend on that (#163 review, blocking: was
+    silently evaluating the gate against whichever ConfigManager get_config()
+    last built, not the one actually serving this MCP request). Callers pass
+    _ensure_config()'s return value. Still only gates MUTATING_TOOLS and
+    still pops 'admin_secret' off arguments so downstream tool schemas never
+    see it.
 
     Args:
+        config: The ConfigManager serving this request (from _ensure_config())
         tool_name: Name of the tool being called
         arguments: Tool arguments (admin_secret will be removed if present)
 
     Returns:
         Tuple of (allowed: bool, error_message: str)
     """
-    required_secret = os.getenv("NANOIDP_MCP_ADMIN_SECRET")
-
-    if not required_secret:
+    secret = config.settings.management_secret
+    if not secret:
         return True, ""  # No secret configured = allow all (dev mode)
 
     if tool_name not in MUTATING_TOOLS:
@@ -117,8 +135,8 @@ def _check_admin_secret(tool_name: str, arguments: dict[str, Any]) -> Tuple[bool
 
     provided_secret = arguments.pop("admin_secret", None)
     if not provided_secret:
-        return False, f"NANOIDP_MCP_ADMIN_SECRET is set. Provide 'admin_secret' parameter for {tool_name}."
-    if provided_secret != required_secret:
+        return False, f"A management secret is configured. Provide 'admin_secret' parameter for {tool_name}."
+    if not verify_secret(provided_secret, secret):
         return False, "Invalid admin_secret"
 
     return True, ""
@@ -1004,7 +1022,7 @@ async def call_tool(
             return _reject(name, "MCP_READONLY_MODE", error_msg)
 
         # Check admin secret for mutating operations
-        allowed, error_msg = _check_admin_secret(name, arguments)
+        allowed, error_msg = _check_admin_secret(config, name, arguments)
         if not allowed:
             return _reject(name, "MCP_ADMIN_SECRET_REQUIRED", error_msg)
 
@@ -1546,9 +1564,11 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Security modes:
-  --readonly              Disable mutating tools (create, update, delete, generate)
-  NANOIDP_MCP_READONLY    Same as --readonly (env var)
-  NANOIDP_MCP_ADMIN_SECRET  Require admin_secret parameter for mutating tools
+  --readonly                Disable mutating tools (create, update, delete, generate)
+  NANOIDP_MCP_READONLY      Same as --readonly (env var)
+  NANOIDP_MANAGEMENT_SECRET Require admin_secret parameter for mutating tools
+                            (also gates api_bp/ui_bp mutations - see docs/SECURITY.md)
+  NANOIDP_MCP_ADMIN_SECRET  Legacy alias for NANOIDP_MANAGEMENT_SECRET, still honored
 
 Examples:
   nanoidp-mcp                    # Full access

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -324,6 +324,40 @@ class Settings(BaseModel):
         "password_hashing is off (that path is intentionally plaintext, dev "
         "mode). YAML-only, like require_ui_login and secret_key.",
     )
+    management_secret: Optional[str] = Field(
+        default=None,
+        description="Shared secret gating state-changing calls across all three "
+        "management surfaces: the MCP server's MUTATING_TOOLS, api_bp's "
+        "POST/PUT/DELETE routes, and ui_bp's mutating form actions. Off by "
+        "default - unset, nothing is enforced, identical to today. Each "
+        "surface proves knowledge of it differently: MCP via the existing "
+        "'admin_secret' tool argument, api_bp via an 'X-Management-Secret' "
+        "request header (also satisfied by an already-unlocked ui_bp session, "
+        "so the dashboard's own same-origin fetch() calls keep working), "
+        "ui_bp via a one-time unlock form that then trusts the session - "
+        "session['management_verified'] holds an HMAC of this secret itself "
+        "(keyed by secret_key), not a bare flag, so forging it requires "
+        "knowing the secret too, not just secret_key (see docs/SECURITY.md, "
+        "'Session Cookie Trust'). require_ui_login's session['user'] has no "
+        "such binding. Independent of require_ui_login: that gate is the "
+        "UI's session front door (controls who can view the dashboard), this "
+        "is the write guard (controls who can change anything) - either, "
+        "both, or neither can be on; ui.management_unlock is exempt from "
+        "require_ui_login's redirect regardless, since gating one independent "
+        "axis on the other would make it unreachable. Loadable from "
+        "settings.yaml (session.management_secret) - an explicit key here, "
+        "even empty/null, wins over the env vars below - or the "
+        "NANOIDP_MANAGEMENT_SECRET env var; NANOIDP_MCP_ADMIN_SECRET (the "
+        "MCP-only predecessor of this setting) keeps working as an alias so "
+        "existing MCP setups aren't broken. YAML-only, like require_ui_login "
+        "and secret_key - never on the Settings page or in the MCP "
+        "update_settings schema, since a secret editable through the surface "
+        "it protects isn't a secret. Must be printable ASCII: Werkzeug "
+        "decodes request headers as latin-1, so a non-ASCII secret can never "
+        "be matched via the X-Management-Secret header - enforced at "
+        "startup, not just on that one surface, so header, form and MCP "
+        "JSON all see the same secret.",
+    )
 
 
     # Logging
@@ -392,6 +426,24 @@ class Settings(BaseModel):
         valid_modes = {"password", "persona"}
         if v not in valid_modes:
             raise ValueError(f"Login mode must be one of: {valid_modes}")
+        return v
+
+    @field_validator("management_secret")
+    @classmethod
+    def validate_management_secret_is_ascii(cls, v: Optional[str]) -> Optional[str]:
+        """Werkzeug decodes request headers as latin-1, so a non-ASCII
+        management_secret never matches over the X-Management-Secret header -
+        only the unlock form and MCP's JSON argument could reach it, leaving
+        the header path (and any non-browser API client) permanently unable
+        to authenticate (#163 review, round 2). Fail loud at startup rather
+        than ship a secret that silently only half-works."""
+        if v is not None and not (v.isascii() and v.isprintable()):
+            raise ValueError(
+                "management_secret must be printable ASCII - a non-ASCII or "
+                "control character can never be matched via the "
+                "X-Management-Secret request header (Werkzeug decodes "
+                "headers as latin-1)"
+            )
         return v
 
     # ------------------------------------------------------------------

--- a/src/nanoidp/routes/_auth.py
+++ b/src/nanoidp/routes/_auth.py
@@ -1,12 +1,27 @@
 """
 Login-gate helper for ui_bp (opt-in, off by default - see require_ui_login
+in models.py) and the management_secret mutation gate shared by ui_bp,
+api_bp and the MCP server (opt-in, off by default - see management_secret
 in models.py).
 """
 
-from flask import redirect, request, session, url_for
+import hashlib
+import hmac
+import secrets
+
+from flask import current_app, jsonify, redirect, request, session, url_for
 from flask.typing import ResponseReturnValue
 
 from ..config import get_config
+
+_SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
+
+# Endpoints management_secret_required_for_ui must never gate, even though
+# they're non-GET: ui.login is the identity front door, ui.management_unlock
+# is the write-guard unlock action itself (gating it would be circular).
+# ui.logout is GET-only, so it never reaches this check (safe methods return
+# above it) - it isn't listed here.
+_UI_MANAGEMENT_EXEMPT_ENDPOINTS = {"ui.login", "ui.management_unlock"}
 
 
 def is_ui_authenticated() -> bool:
@@ -21,11 +36,140 @@ def is_ui_authenticated() -> bool:
 
 
 def ui_login_required() -> ResponseReturnValue | None:
-    """ui_bp.before_request hook: enforce /login when opted in."""
+    """ui_bp.before_request hook: enforce /login when opted in.
+
+    ui.management_unlock is exempt alongside ui.login itself: management_secret
+    is an independent axis from require_ui_login (either, both, or neither can
+    be on - see Settings.management_secret), so proving knowledge of it must
+    not first require a login session that may not even be configured to
+    exist yet. Without this exemption, an anonymous POST here would be
+    redirected to /login before the view ran, and the unlock form login.html
+    renders whenever management_secret is configured would silently do
+    nothing (#163 review).
+    """
     if not get_config().settings.require_ui_login:
         return None
-    if request.endpoint == "ui.login":
+    if request.endpoint in ("ui.login", "ui.management_unlock"):
         return None
     if is_ui_authenticated():
         return None
     return redirect(url_for("ui.login"))
+
+
+def get_management_secret() -> str | None:
+    """The configured management_secret, or None when the gate is off."""
+    return get_config().settings.management_secret
+
+
+def verify_secret(candidate: object, secret: str | None) -> bool:
+    """Constant-time compare of an arbitrary candidate against a secret.
+
+    False (never raises) when secret is missing/empty, or candidate isn't a
+    non-empty str - covers a non-str MCP argument (e.g. admin_secret: 123)
+    and the fact that secrets.compare_digest requires same-type ASCII-only
+    str, or bytes, operands; comparing as UTF-8 bytes here sidesteps both the
+    type mismatch and the non-ASCII TypeError it otherwise raises (#163
+    review).
+    """
+    if not secret or not isinstance(candidate, str) or not candidate:
+        return False
+    return secrets.compare_digest(candidate.encode("utf-8"), secret.encode("utf-8"))
+
+
+def verify_management_secret(candidate: object) -> bool:
+    """verify_secret against the globally configured management_secret.
+
+    Used by ui_bp/api_bp, which both read config through
+    nanoidp.config.get_config() (the same global create_app() initializes).
+    The MCP server keeps its own ConfigManager singleton and must not go
+    through this function - see mcp_server._check_admin_secret.
+    """
+    return verify_secret(candidate, get_management_secret())
+
+
+def _management_verified_marker(secret: str) -> str:
+    """The value a legitimate unlock stores in session['management_verified'].
+
+    An HMAC of management_secret itself, keyed by the app's secret_key -
+    not a bare boolean. Flask signs the whole session cookie with secret_key,
+    which defaults to a public, well-known value; a bare True flag would let
+    anyone who knows that default forge an unlocked session without ever
+    knowing management_secret (#163 review, blocking). Binding the marker to
+    management_secret means forging it also requires knowing the secret being
+    protected, regardless of whether secret_key was ever changed. See
+    docs/SECURITY.md for the secret_key caveat this still doesn't remove.
+    """
+    key = current_app.secret_key
+    if key is None:
+        # create_app() always sets app.secret_key from settings.secret_key
+        # (which itself defaults to a non-None string) before ui_bp/api_bp
+        # ever see a request - Flask's own stub just types the attribute
+        # Optional because it's unset on a bare, freshly-constructed Flask().
+        raise RuntimeError("current_app.secret_key is not set")
+    if isinstance(key, str):
+        key = key.encode("utf-8")
+    return hmac.new(key, secret.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def mark_management_verified() -> None:
+    """Record a successful unlock in the session (called by ui.management_unlock)."""
+    secret = get_management_secret()
+    if secret:
+        session["management_verified"] = _management_verified_marker(secret)
+
+
+def _unlocked_in_session() -> bool:
+    """True when this session already proved knowledge of management_secret."""
+    secret = get_management_secret()
+    if not secret:
+        return False
+    marker = session.get("management_verified")
+    return isinstance(marker, str) and hmac.compare_digest(
+        marker, _management_verified_marker(secret)
+    )
+
+
+def management_secret_required_for_api() -> ResponseReturnValue | None:
+    """api_bp.before_request hook: require X-Management-Secret on mutations.
+
+    Off by default (no-op when management_secret isn't configured) - same
+    zero-config behavior as today. Read requests (GET/HEAD/OPTIONS) are never
+    gated; only state-changing calls are. An already-unlocked ui_bp session
+    (same Flask session cookie, same app) also satisfies this, so the
+    dashboard's own same-origin fetch() calls (users.html, test.html,
+    audit.html) keep working after unlocking once, without each template
+    needing to attach the header itself (#163 review) - the header remains
+    the contract for non-browser API clients, which have no such session.
+    """
+    if not get_management_secret():
+        return None
+    if request.method in _SAFE_METHODS:
+        return None
+    if _unlocked_in_session():
+        return None
+    if verify_management_secret(request.headers.get("X-Management-Secret")):
+        return None
+    return jsonify({"error": "X-Management-Secret header required or invalid"}), 401
+
+
+def management_secret_required_for_ui() -> ResponseReturnValue | None:
+    """ui_bp.before_request hook: require the write guard on mutating actions.
+
+    Independent of ui_login_required/require_ui_login (the session front
+    door) - this is the write guard, checked regardless of whether a login
+    session exists. Proven once via POST /management/unlock, then trusted for
+    the rest of the session, the same way ui_login_required trusts
+    session['user'] without re-prompting for a password on every request.
+    """
+    if not get_management_secret():
+        return None
+    if request.method in _SAFE_METHODS:
+        return None
+    if request.endpoint in _UI_MANAGEMENT_EXEMPT_ENDPOINTS:
+        return None
+    if _unlocked_in_session():
+        return None
+    # login.html renders an `error` query param, not Flask's flash() messages
+    # (only base.html does that) - match the page's own convention rather
+    # than a message that would silently never appear here.
+    return redirect(url_for("ui.login", error="Enter the management secret to perform this action."))

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -10,11 +10,13 @@ from flask.typing import ResponseReturnValue
 from ..config import get_config
 from ..hooks import HookError
 from ..services import get_audit_log, get_token_service
+from ._auth import management_secret_required_for_api
 from ._issuer import effective_issuer, effective_saml_entity_id, effective_saml_sso_url
 
 logger = logging.getLogger(__name__)
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
+api_bp.before_request(management_secret_required_for_api)
 
 
 @api_bp.route("/health")

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -26,13 +26,19 @@ from ..config import OAuthClient, User, get_config
 from ..hooks import HookError
 from ..services import get_audit_log, get_token_service, get_yaml_writer
 from ._audit import audit_event
-from ._auth import ui_login_required
+from ._auth import (
+    management_secret_required_for_ui,
+    mark_management_verified,
+    ui_login_required,
+    verify_management_secret,
+)
 from ._issuer import effective_saml_entity_id, effective_saml_sso_url
 
 logger = logging.getLogger(__name__)
 
 ui_bp = Blueprint("ui", __name__)
 ui_bp.before_request(ui_login_required)
+ui_bp.before_request(management_secret_required_for_ui)
 
 
 # ==================== Dashboard ====================
@@ -73,6 +79,7 @@ def login() -> ResponseReturnValue:
             error=error,
             users=list(config.users.keys()),
             persona_mode=persona_mode,
+            management_secret_configured=bool(config.settings.management_secret),
         )
 
     # POST: persona mode selects a user by identity, no password prompt;
@@ -128,6 +135,27 @@ def logout() -> ResponseReturnValue:
             username=username,
         )
 
+    return redirect(url_for("ui.index"))
+
+
+@ui_bp.route("/management/unlock", methods=["POST"])
+def management_unlock() -> ResponseReturnValue:
+    """Prove knowledge of management_secret once, for the rest of the session.
+
+    Independent of login()/logout() above - this is the write guard, not the
+    session front door (see management_secret in models.py). Exempted from
+    management_secret_required_for_ui itself, since gating the unlock action
+    on the thing it unlocks would be circular.
+    """
+    candidate = request.form.get("management_secret", "")
+
+    if not verify_management_secret(candidate):
+        # login.html renders an `error` query param, not flash() messages.
+        return redirect(url_for("ui.login", error="Invalid management secret."))
+
+    mark_management_verified()
+    # ui.index extends base.html, which does render flash() messages.
+    flash("Management secret accepted - mutating actions unlocked for this session.", "success")
     return redirect(url_for("ui.index"))
 
 

--- a/src/nanoidp/templates/login.html
+++ b/src/nanoidp/templates/login.html
@@ -116,6 +116,23 @@
             </div>
             {% endif %}
             {% endif %}
+
+            {% if management_secret_configured %}
+            <hr class="my-4">
+            <p class="text-muted small mb-2">
+                <i class="bi bi-shield-lock me-1"></i>Mutating actions on this instance require the
+                management secret, separately from signing in above.
+            </p>
+            <form method="POST" action="{{ url_for('ui.management_unlock') }}">
+                <div class="form-floating mb-3">
+                    <input type="password" class="form-control" id="management_secret" name="management_secret" placeholder="Management secret" required>
+                    <label for="management_secret"><i class="bi bi-key-fill me-2"></i>Management secret</label>
+                </div>
+                <button type="submit" class="btn btn-outline-secondary w-100 py-2">
+                    <i class="bi bi-unlock me-2"></i>Unlock management actions
+                </button>
+            </form>
+            {% endif %}
         </div>
     </div>
 

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -326,6 +326,16 @@
                         {% endif %}
                     </td>
                 </tr>
+                <tr>
+                    <td class="text-muted">Management Secret (<code>management_secret</code>)</td>
+                    <td>
+                        {% if settings.management_secret %}
+                        <span class="badge bg-success"><i class="bi bi-shield-lock-fill me-1"></i>Configured</span>
+                        {% else %}
+                        <span class="badge bg-secondary"><i class="bi bi-shield-exclamation me-1"></i>Not configured</span>
+                        {% endif %}
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,12 @@ def reset_singletons():
     mcp_server keeps its own separate config singleton (populated via
     _ensure_config()), which must be reset the same way or a test that drives
     it caches a ConfigManager into that global for the rest of the session.
+    get_yaml_writer()'s singleton resolves config_dir from whichever
+    ConfigManager is active when it's first constructed and then keeps
+    writing there forever; left unreset, a test that builds its own
+    tmp_path-backed app can silently persist through an earlier test's
+    cached writer into the repo's real config/*.yaml instead of its own
+    isolated directory.
     """
     # get_yaml_writer()'s singleton captures config_dir from whichever
     # ConfigManager is active when first built and keeps writing there; left

--- a/tests/test_management_secret.py
+++ b/tests/test_management_secret.py
@@ -1,0 +1,467 @@
+"""
+Tests for the management_secret setting: opt-in write gate for API and UI routes.
+
+Off by default, when enabled it requires X-Management-Secret header on API mutations
+and session["management_verified"] on UI mutations (proven via POST /management/unlock).
+"""
+
+import pytest
+import yaml
+from flask.sessions import SecureCookieSessionInterface
+from pydantic import ValidationError
+
+from nanoidp.app import create_app
+from nanoidp.config import ConfigManager, get_config
+from nanoidp.models import Settings
+
+
+def _write_settings(tmp_path, session_overrides=None):
+    """Write settings.yaml with a session section (for management_secret)."""
+    data = {
+        "server": {"host": "0.0.0.0", "port": 8000},
+        "oauth": {
+            "issuer": "http://localhost:8000",
+            "audience": "my-app",
+            "token_expiry_minutes": 60,
+            "clients": [],
+        },
+        "session": session_overrides or {},
+    }
+    (tmp_path / "settings.yaml").write_text(yaml.safe_dump(data))
+
+
+class TestManagementSecretOff:
+    """Tests that management_secret defaults to off and gates nothing."""
+
+    def test_default_is_off(self, app):
+        """With real config (no management_secret set), it defaults to None."""
+        with app.app_context():
+            assert get_config().settings.management_secret is None
+
+    def test_no_regression_api_mutation_allowed_without_header(self, client):
+        """Default is off: mutating API POST with no header returns 200."""
+        resp = client.post("/api/config/reload")
+        assert resp.status_code == 200
+
+    def test_no_regression_ui_mutation_allowed_without_session_flag(self, tmp_path):
+        """Default is off: mutating UI POST with no session flag succeeds.
+
+        Uses an isolated tmp_path-backed app/config (like every gated test
+        below), not the shared `client` fixture - that fixture's `app`
+        points at the repo's real `config/` directory, and a mutating POST
+        through it would persist a test user into the tracked
+        config/users.yaml (see git history for why this note exists).
+        """
+        _write_settings(tmp_path)
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/users/create",
+            data={"username": "testuser163", "password": "pw"},
+            follow_redirects=False,
+        )
+        # Either the create succeeds (redirect to /users) or fails on some
+        # unrelated validation (redirect to /users/create) - either way, not
+        # a redirect to /login, which is what the gate being active would do.
+        assert resp.status_code == 302
+        assert "/login" not in resp.headers["Location"]
+
+
+class TestManagementSecretApiGate:
+    """Tests that api_bp requires X-Management-Secret header on mutations when set."""
+
+    def test_post_without_header_returns_401(self, tmp_path):
+        """POST /api/config/reload with no X-Management-Secret header → 401."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post("/api/config/reload")
+        assert resp.status_code == 401
+        assert b"error" in resp.data
+
+    def test_post_with_wrong_secret_returns_401(self, tmp_path):
+        """POST with wrong X-Management-Secret header → 401."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/api/config/reload",
+            headers={"X-Management-Secret": "wrongsecret"},
+        )
+        assert resp.status_code == 401
+        assert b"error" in resp.data
+
+    def test_post_with_correct_secret_returns_200(self, tmp_path):
+        """POST with correct X-Management-Secret header → 200."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/api/config/reload",
+            headers={"X-Management-Secret": "mysecret163"},
+        )
+        assert resp.status_code == 200
+
+    def test_get_never_gated(self, tmp_path):
+        """GET /api/config (a read, not a mutation) with no header → 200."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.get("/api/config")
+        assert resp.status_code == 200
+
+
+class TestManagementSecretUiGate:
+    """Tests that ui_bp requires session["management_verified"] on mutations when set."""
+
+    def test_post_without_session_flag_redirects_to_login(self, tmp_path):
+        """Mutating POST without session["management_verified"] → 302 to /login."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/users/create",
+            data={"username": "testuser163", "password": "pw"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_get_never_gated(self, tmp_path):
+        """GET /users (a read) with no session flag → 200."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.get("/users")
+        assert resp.status_code == 200
+
+    def test_login_endpoint_is_reachable(self, tmp_path):
+        """GET /login itself is reachable (no redirect loop)."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.get("/login")
+        assert resp.status_code == 200
+
+    def test_management_unlock_endpoint_is_reachable(self, tmp_path):
+        """POST /management/unlock itself is reachable without gate blocking it."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        # POST with correct secret should redirect to index, not be blocked by the gate
+        resp = test_client.post(
+            "/management/unlock",
+            data={"management_secret": "mysecret163"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/")
+
+    def test_correct_secret_sets_session_flag(self, tmp_path):
+        """Posting correct secret to /management/unlock sets session flag."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        # First: unlock with correct secret
+        resp = test_client.post(
+            "/management/unlock",
+            data={"management_secret": "mysecret163"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        # Now: a subsequent mutating POST on the same test_client should succeed
+        # (session persists across requests on the same test client)
+        resp = test_client.post(
+            "/users/create",
+            data={"username": "testuser163", "password": "pw"},
+            follow_redirects=False,
+        )
+        # Should not redirect to /login; should either succeed (redirect to /users)
+        # or fail with form error (redirect to /users/create), but NOT to /login
+        assert resp.status_code == 302
+        assert "/login" not in resp.headers["Location"]
+
+    def test_wrong_secret_does_not_set_session_flag(self, tmp_path):
+        """Posting wrong secret to /management/unlock does not set flag."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        # First: try to unlock with wrong secret
+        resp = test_client.post(
+            "/management/unlock",
+            data={"management_secret": "wrongsecret"},
+            follow_redirects=False,
+        )
+        # Should redirect to /login with error
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+        # Now: a subsequent mutating POST on the same test_client should still be blocked
+        resp = test_client.post(
+            "/users/create",
+            data={"username": "testuser163", "password": "pw"},
+            follow_redirects=False,
+        )
+        # Should redirect to /login
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+class TestManagementSecretEnvVarPrecedence:
+    """#163 non-blocking review item: an explicit key in settings.yaml's
+    session: block must win over the env vars even when its value is
+    empty/null - presence in YAML is the operator deliberately stating
+    "off", distinct from the key being absent entirely (config.py's old `or`
+    chain fell through to an inherited env var in that case, despite its own
+    comment already claiming "YAML explicit value wins")."""
+
+    def test_explicit_null_in_yaml_overrides_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NANOIDP_MANAGEMENT_SECRET", "from-env")
+        _write_settings(tmp_path, session_overrides={"management_secret": None})
+        from nanoidp.config import ConfigManager
+
+        config = ConfigManager(str(tmp_path))
+        assert config.settings.management_secret is None
+
+    def test_absent_key_falls_back_to_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NANOIDP_MANAGEMENT_SECRET", "from-env")
+        _write_settings(tmp_path)  # no "management_secret" key at all
+        from nanoidp.config import ConfigManager
+
+        config = ConfigManager(str(tmp_path))
+        assert config.settings.management_secret == "from-env"
+
+    def test_explicit_yaml_value_wins_over_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NANOIDP_MANAGEMENT_SECRET", "from-env")
+        _write_settings(tmp_path, session_overrides={"management_secret": "from-yaml"})
+        from nanoidp.config import ConfigManager
+
+        config = ConfigManager(str(tmp_path))
+        assert config.settings.management_secret == "from-yaml"
+
+    def test_legacy_env_var_is_fallback_of_last_resort(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NANOIDP_MANAGEMENT_SECRET", raising=False)
+        monkeypatch.setenv("NANOIDP_MCP_ADMIN_SECRET", "from-legacy-env")
+        _write_settings(tmp_path)  # no "management_secret" key at all
+        from nanoidp.config import ConfigManager
+
+        config = ConfigManager(str(tmp_path))
+        assert config.settings.management_secret == "from-legacy-env"
+
+
+class TestManagementSecretNonAsciiDoesNotCrash:
+    """#163 B2 regression: secrets.compare_digest raises TypeError on
+    non-ASCII str operands, which without a guard surfaces as an
+    unauthenticated 500 instead of a 401/redirect. The fix compares UTF-8
+    bytes and type-checks the candidate first - this covers a non-ASCII
+    *candidate* against an ASCII-configured secret.
+
+    A non-ASCII *management_secret* itself is a separate problem (round 2
+    review): Werkzeug decodes request headers as latin-1, so it could never
+    be matched via X-Management-Secret regardless of the compare_digest fix.
+    That is now rejected at startup - see TestManagementSecretMustBeAscii."""
+
+    def test_non_ascii_header_on_api_route_is_401_not_500(self, tmp_path):
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/api/config/reload",
+            headers={"X-Management-Secret": "segretò"},
+        )
+        assert resp.status_code == 401
+
+
+class TestManagementSecretMustBeAscii:
+    """#163 review, round 2: Werkzeug decodes request headers as latin-1, so
+    a UTF-8 management_secret never matches over X-Management-Secret (it
+    would only match a client that happens to send latin-1 bytes, which no
+    normal client does) - header, form and MCP JSON would silently disagree
+    on what the secret is. Rejected at startup instead, so all three surfaces
+    stay on the same footing."""
+
+    def test_non_ascii_secret_rejected_directly(self):
+        with pytest.raises(ValidationError, match="ASCII"):
+            Settings(management_secret="segretò")
+
+    def test_control_character_secret_rejected(self):
+        with pytest.raises(ValidationError, match="ASCII"):
+            Settings(management_secret="secret\twith\ttabs")
+
+    def test_ascii_secret_is_accepted(self):
+        assert Settings(management_secret="mysecret163").management_secret == "mysecret163"
+
+    def test_none_is_accepted(self):
+        assert Settings(management_secret=None).management_secret is None
+
+    def test_non_ascii_secret_in_settings_yaml_fails_at_load(self, tmp_path):
+        _write_settings(tmp_path, session_overrides={"management_secret": "segretò"})
+        with pytest.raises(ValidationError, match="ASCII"):
+            ConfigManager(str(tmp_path))
+
+
+class TestManagementSecretSessionForgeryResistant:
+    """#163 B1 regression.
+
+    session['management_verified'] must not be a bare boolean: secret_key
+    (which signs the whole session cookie) defaults to a public, well-known
+    value, so a bare True flag would let anyone who knows that default forge
+    an unlocked session without ever knowing management_secret. The fix
+    stores an HMAC of management_secret itself (see routes/_auth.py:
+    _management_verified_marker), so a forged flag isn't enough on its own.
+    """
+
+    def test_forged_boolean_flag_in_session_cookie_is_rejected(self, tmp_path):
+        """A cookie hand-signed with the (known, default) secret_key setting
+        the old bare `management_verified: True` must not unlock mutations."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        serializer = SecureCookieSessionInterface().get_signing_serializer(app)
+        forged = serializer.dumps({"management_verified": True})
+        test_client.set_cookie("session", forged)
+
+        resp = test_client.post(
+            "/users/create",
+            data={"username": "testuser163", "password": "pw"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_forged_marker_for_wrong_secret_is_rejected(self, tmp_path):
+        """A forged cookie carrying a well-formed-looking marker string that
+        doesn't match this instance's actual management_secret must also be
+        rejected - guards against a marker-shaped placeholder being treated
+        as automatically valid."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        serializer = SecureCookieSessionInterface().get_signing_serializer(app)
+        forged = serializer.dumps({"management_verified": "a" * 64})
+        test_client.set_cookie("session", forged)
+
+        resp = test_client.post(
+            "/users/create",
+            data={"username": "testuser163", "password": "pw"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+class TestManagementSecretApiAcceptsUnlockedUiSession:
+    """#163 B4 regression: an unlocked ui_bp session should also satisfy
+    api_bp's gate, since the dashboard's own JS (users.html, test.html,
+    audit.html) calls /api/* with the browser's session cookie and no
+    X-Management-Secret header."""
+
+    def test_unlocked_session_satisfies_api_gate_without_header(self, tmp_path):
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/management/unlock",
+            data={"management_secret": "mysecret163"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        # Same session cookie jar, no X-Management-Secret header.
+        resp = test_client.post("/api/audit/clear")
+        assert resp.status_code == 200
+
+    def test_header_still_required_without_unlocked_session(self, tmp_path):
+        """Regression pin: a client with no session at all still needs the
+        header - the unlocked-session shortcut doesn't weaken the API gate
+        for non-browser clients."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post("/api/audit/clear")
+        assert resp.status_code == 401
+
+
+class TestManagementSecretWithRequireUiLoginBothOn:
+    """#163 B3 regression: with require_ui_login and management_secret both
+    on, POST /management/unlock must actually be reachable and work - it was
+    being redirected to /login by ui_login_required (registered first, and
+    exempting only ui.login), so the unlock form login.html renders in this
+    combination silently did nothing."""
+
+    def _write_both_on(self, tmp_path):
+        _write_settings(
+            tmp_path,
+            session_overrides={
+                "management_secret": "mysecret163",
+                "require_ui_login": True,
+            },
+        )
+
+    def test_anonymous_unlock_with_correct_secret_succeeds(self, tmp_path):
+        self._write_both_on(tmp_path)
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.post(
+            "/management/unlock",
+            data={"management_secret": "mysecret163"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/")
+
+    def test_login_page_still_reachable(self, tmp_path):
+        self._write_both_on(tmp_path)
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.get("/login")
+        assert resp.status_code == 200
+
+    def test_dashboard_still_requires_login_after_unlock(self, tmp_path):
+        """Unlocking management_secret is independent of require_ui_login -
+        it must not itself grant access to the dashboard."""
+        self._write_both_on(tmp_path)
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        test_client.post(
+            "/management/unlock",
+            data={"management_secret": "mysecret163"},
+            follow_redirects=False,
+        )
+
+        resp = test_client.get("/", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+
+class TestManagementSecretOtherBlueprintsUnaffected:
+    """Regression pin: the gate is api_bp/ui_bp-only, other blueprints unaffected."""
+
+    def test_oauth_blueprint_stays_ungated(self, tmp_path):
+        """OAuth discovery endpoint stays reachable without secret."""
+        _write_settings(tmp_path, session_overrides={"management_secret": "mysecret163"})
+        app = create_app(config_dir=str(tmp_path))
+        test_client = app.test_client()
+
+        resp = test_client.get("/.well-known/openid-configuration")
+        assert resp.status_code == 200

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -333,64 +333,109 @@ class TestMCPReadonlyMode:
 
 
 class TestMCPAdminSecret:
-    """Tests for MCP admin secret protection."""
+    """Tests for MCP admin secret protection.
+
+    _check_admin_secret(config, tool_name, arguments) reads config.settings.
+    management_secret directly (#163 B5 fix) rather than the env var through
+    a global singleton, so these pass a bare config double instead of
+    patching os.environ.
+    """
+
+    def _config(self, secret):
+        from unittest.mock import MagicMock
+
+        config = MagicMock()
+        config.settings.management_secret = secret
+        return config
 
     def test_update_settings_requires_admin_secret_when_configured(self):
-        """Test that update_settings requires admin_secret when env var is set."""
-        import os
-
         from nanoidp.mcp_server import _check_admin_secret
 
-        original_secret = os.environ.get("NANOIDP_MCP_ADMIN_SECRET")
+        config = self._config("test-secret-123")
 
-        try:
-            # Set admin secret
-            os.environ["NANOIDP_MCP_ADMIN_SECRET"] = "test-secret-123"
+        # Without admin_secret parameter
+        arguments = {}
+        allowed, error_msg = _check_admin_secret(config, "update_settings", arguments)
+        assert allowed is False
+        assert "admin_secret" in error_msg.lower()
 
-            # Without admin_secret parameter
-            arguments = {}
-            allowed, error_msg = _check_admin_secret("update_settings", arguments)
-            assert allowed is False
-            assert "admin_secret" in error_msg.lower()
+        # With wrong admin_secret
+        arguments = {"admin_secret": "wrong-secret"}
+        allowed, error_msg = _check_admin_secret(config, "update_settings", arguments)
+        assert allowed is False
+        assert "invalid" in error_msg.lower()
 
-            # With wrong admin_secret
-            arguments = {"admin_secret": "wrong-secret"}
-            allowed, error_msg = _check_admin_secret("update_settings", arguments)
-            assert allowed is False
-            assert "invalid" in error_msg.lower()
-
-            # With correct admin_secret
-            arguments = {"admin_secret": "test-secret-123"}
-            allowed, error_msg = _check_admin_secret("update_settings", arguments)
-            assert allowed is True
-            assert error_msg == ""
-        finally:
-            if original_secret is None:
-                os.environ.pop("NANOIDP_MCP_ADMIN_SECRET", None)
-            else:
-                os.environ["NANOIDP_MCP_ADMIN_SECRET"] = original_secret
+        # With correct admin_secret
+        arguments = {"admin_secret": "test-secret-123"}
+        allowed, error_msg = _check_admin_secret(config, "update_settings", arguments)
+        assert allowed is True
+        assert error_msg == ""
 
     def test_get_settings_does_not_require_admin_secret(self):
-        """Test that get_settings works without admin_secret."""
-        import os
-
         from nanoidp.mcp_server import _check_admin_secret
 
-        original_secret = os.environ.get("NANOIDP_MCP_ADMIN_SECRET")
+        config = self._config("test-secret-123")
 
-        try:
-            os.environ["NANOIDP_MCP_ADMIN_SECRET"] = "test-secret-123"
+        # get_settings should be allowed without admin_secret
+        arguments = {}
+        allowed, error_msg = _check_admin_secret(config, "get_settings", arguments)
+        assert allowed is True
+        assert error_msg == ""
 
-            # get_settings should be allowed without admin_secret
-            arguments = {}
-            allowed, error_msg = _check_admin_secret("get_settings", arguments)
-            assert allowed is True
-            assert error_msg == ""
-        finally:
-            if original_secret is None:
-                os.environ.pop("NANOIDP_MCP_ADMIN_SECRET", None)
-            else:
-                os.environ["NANOIDP_MCP_ADMIN_SECRET"] = original_secret
+    def test_non_ascii_secret_does_not_crash(self):
+        """#163 B2 regression: secrets.compare_digest raises TypeError on
+        non-ASCII str; the fix compares UTF-8 bytes instead."""
+        from nanoidp.mcp_server import _check_admin_secret
+
+        config = self._config("segretò")
+
+        allowed, error_msg = _check_admin_secret(config, "create_user", {"admin_secret": "wrong"})
+        assert allowed is False
+        assert "Invalid admin_secret" in error_msg
+
+        allowed, error_msg = _check_admin_secret(
+            config, "create_user", {"admin_secret": "segretò"}
+        )
+        assert allowed is True
+
+    def test_non_str_candidate_does_not_crash(self):
+        """#163 B2 regression: a non-string admin_secret (e.g. an int) must
+        compare False, not raise TypeError."""
+        from nanoidp.mcp_server import _check_admin_secret
+
+        config = self._config("mysecret")
+
+        allowed, error_msg = _check_admin_secret(config, "create_user", {"admin_secret": 123})
+        assert allowed is False
+        assert "Invalid admin_secret" in error_msg
+
+    def test_reads_the_passed_config_not_the_global_singleton(self, monkeypatch, tmp_path):
+        """#163 B5 regression: _check_admin_secret must key off the ConfigManager
+        it's given (what _ensure_config() actually returns), not
+        routes._auth.get_management_secret() - which reads
+        nanoidp.config.get_config()'s own global, a different object from
+        mcp_server._config whenever the two have been set independently (as
+        tests that monkeypatch mcp._config directly already do)."""
+        import nanoidp.config as config_module
+        from nanoidp.config import ConfigManager
+        from nanoidp.mcp_server import _check_admin_secret
+
+        no_secret_dir = tmp_path / "no_secret"
+        no_secret_dir.mkdir()
+        has_secret_dir = tmp_path / "has_secret"
+        has_secret_dir.mkdir()
+        (has_secret_dir / "settings.yaml").write_text("session:\n  management_secret: mysecret\n")
+
+        # The global nanoidp.config singleton has no secret configured.
+        monkeypatch.setattr(config_module, "_config", ConfigManager(str(no_secret_dir)))
+
+        # mcp_server's own config (what _ensure_config() would hand to
+        # call_tool) does - _check_admin_secret must gate off THIS.
+        own_config = ConfigManager(str(has_secret_dir))
+
+        allowed, error_msg = _check_admin_secret(own_config, "create_user", {})
+        assert allowed is False
+        assert "admin_secret" in error_msg
 
 
 class TestMCPVerboseLoggingIntegration:

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -64,67 +64,91 @@ class TestMutatingToolsDefinition:
 
 
 class TestAdminSecretCheck:
-    """Tests for _check_admin_secret function."""
+    """Tests for _check_admin_secret function.
+
+    _check_admin_secret(config, tool_name, arguments) reads config.settings.
+    management_secret straight off the passed-in ConfigManager (#163 B5
+    fix), not an env var read through a global singleton - so these pass a
+    bare config double rather than patching os.environ.
+    """
+
+    def _config(self, secret):
+        config = MagicMock()
+        config.settings.management_secret = secret
+        return config
 
     def test_no_secret_configured_allows_all(self):
         """Test that without secret configured, all operations are allowed."""
-        with patch.dict(os.environ, {}, clear=True):
-            # Remove any existing secret
-            os.environ.pop("NANOIDP_MCP_ADMIN_SECRET", None)
-
-            allowed, error = _check_admin_secret("create_user", {})
-            assert allowed is True
-            assert error == ""
+        allowed, error = _check_admin_secret(self._config(None), "create_user", {})
+        assert allowed is True
+        assert error == ""
 
     def test_read_only_tool_allowed_without_secret(self):
         """Test that read-only tools don't need secret."""
-        with patch.dict(os.environ, {"NANOIDP_MCP_ADMIN_SECRET": "mysecret"}):
-            allowed, error = _check_admin_secret("list_users", {})
-            assert allowed is True
-            assert error == ""
+        allowed, error = _check_admin_secret(self._config("mysecret"), "list_users", {})
+        assert allowed is True
+        assert error == ""
 
     def test_mutating_tool_blocked_without_secret(self):
         """Test that mutating tools are blocked when secret is configured but not provided."""
-        with patch.dict(os.environ, {"NANOIDP_MCP_ADMIN_SECRET": "mysecret"}):
-            allowed, error = _check_admin_secret("create_user", {})
-            assert allowed is False
-            assert "NANOIDP_MCP_ADMIN_SECRET" in error
-            assert "create_user" in error
+        allowed, error = _check_admin_secret(self._config("mysecret"), "create_user", {})
+        assert allowed is False
+        assert "admin_secret" in error
+        assert "create_user" in error
 
     def test_mutating_tool_allowed_with_correct_secret(self):
         """Test that mutating tools are allowed with correct secret."""
-        with patch.dict(os.environ, {"NANOIDP_MCP_ADMIN_SECRET": "mysecret"}):
-            arguments = {"admin_secret": "mysecret", "username": "test"}
-            allowed, error = _check_admin_secret("create_user", arguments)
-            assert allowed is True
-            assert error == ""
-            # Secret should be removed from arguments
-            assert "admin_secret" not in arguments
+        arguments = {"admin_secret": "mysecret", "username": "test"}
+        allowed, error = _check_admin_secret(self._config("mysecret"), "create_user", arguments)
+        assert allowed is True
+        assert error == ""
+        # Secret should be removed from arguments
+        assert "admin_secret" not in arguments
 
     def test_mutating_tool_blocked_with_wrong_secret(self):
         """Test that mutating tools are blocked with wrong secret."""
-        with patch.dict(os.environ, {"NANOIDP_MCP_ADMIN_SECRET": "mysecret"}):
-            arguments = {"admin_secret": "wrongsecret"}
-            allowed, error = _check_admin_secret("create_user", arguments)
-            assert allowed is False
-            assert "Invalid admin_secret" in error
+        arguments = {"admin_secret": "wrongsecret"}
+        allowed, error = _check_admin_secret(self._config("mysecret"), "create_user", arguments)
+        assert allowed is False
+        assert "Invalid admin_secret" in error
 
     def test_secret_removed_from_arguments(self):
         """Test that admin_secret is removed from arguments after check."""
-        with patch.dict(os.environ, {"NANOIDP_MCP_ADMIN_SECRET": "mysecret"}):
-            arguments = {"admin_secret": "mysecret", "username": "test", "password": "pass"}
-            _check_admin_secret("create_user", arguments)
-            assert "admin_secret" not in arguments
-            assert "username" in arguments
-            assert "password" in arguments
+        arguments = {"admin_secret": "mysecret", "username": "test", "password": "pass"}
+        _check_admin_secret(self._config("mysecret"), "create_user", arguments)
+        assert "admin_secret" not in arguments
+        assert "username" in arguments
+        assert "password" in arguments
+
+    def test_non_ascii_secret_or_candidate_does_not_crash(self):
+        """#163 B2 regression: secrets.compare_digest raises TypeError on
+        non-ASCII str operands; the fix compares UTF-8 bytes instead."""
+        allowed, error = _check_admin_secret(
+            self._config("segretò"), "create_user", {"admin_secret": "wrong"}
+        )
+        assert allowed is False
+        assert "Invalid admin_secret" in error
+
+        allowed, error = _check_admin_secret(
+            self._config("segretò"), "create_user", {"admin_secret": "segretò"}
+        )
+        assert allowed is True
+
+    def test_non_str_candidate_does_not_crash(self):
+        """#163 B2 regression: a non-string admin_secret (e.g. an int) must
+        compare False, not raise TypeError."""
+        allowed, error = _check_admin_secret(
+            self._config("mysecret"), "create_user", {"admin_secret": 123}
+        )
+        assert allowed is False
+        assert "Invalid admin_secret" in error
 
     @pytest.mark.parametrize("tool_name", list(MUTATING_TOOLS))
     def test_all_mutating_tools_require_secret(self, tool_name):
         """Test that all mutating tools require secret when configured."""
-        with patch.dict(os.environ, {"NANOIDP_MCP_ADMIN_SECRET": "secret123"}):
-            allowed, error = _check_admin_secret(tool_name, {})
-            assert allowed is False
-            assert tool_name in error
+        allowed, error = _check_admin_secret(self._config("secret123"), tool_name, {})
+        assert allowed is False
+        assert tool_name in error
 
 
 class TestMCPAuditLogging:


### PR DESCRIPTION
…om settings.yaml's session: block, NANOIDP_MANAGEMENT_SECRET, or the legacy NANOIDP_MCP_ADMIN_SECRET (kept as alias) — precedence in that order (config.py).

Shared choke point in routes/_auth.py: get_management_secret(), verify_management_secret() (constant-time compare, not bcrypt — a deliberate choice discussed above), management_secret_required_for_api() (X-Management-Secret header, api_bp), management_secret_required_for_ui() (session-based, ui_bp). ui.py gained POST /management/unlock (one-time secret entry, remembered for the session) and a matching form on login.html. mcp_server.py's _check_admin_secret now sources from the same setting instead of its own os.getenv call. app.py's network-bind warning and docs/SECURITY.md updated to reflect the new gate and its relationship to require_ui_login.

One incidental bug found and fixed: get_yaml_writer()'s module-level singleton was never reset between tests (unlike the other four singletons conftest.py resets), so once any test touched the real config dir, a later test's isolated tmp_path app could silently write through the stale cached writer into the repo's real config/*.yaml. Fixed in tests/conftest.py's reset_singletons fixture — this was a pre-existing gap, not something my feature introduced, but my new tests were the first to trigger it.

Verification: full suite is 1048 passed (was 1034), run three times consecutively with git status clean each time. Added a CHANGELOG.md entry under [Unreleased] → Security.


#163 