### PR TITLE
fix: --profile overrides YAML for every value and survives reloads (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local files only (no remote URLs) to avoid beacons.
 
 ### Fixed
+- **`--profile` overrides settings.yaml for every value and survives reloads**
+  (#172). An explicit `--profile dev` could not bring a file configured with
+  `oauth21`/`stricter-dev` back to `dev` (the flag defaulted to `dev`, so the
+  code could not tell "asked for dev" from "omitted"), and any CLI profile was
+  dropped by the first configuration reload, i.e. by the first web UI or MCP
+  save. Worse, the `stricter-dev` runtime hardening (`require_pkce`,
+  `password_hashing`, `rate_limit_enabled`, debug off) was applied once in
+  `create_app()` and silently lost on that same first reload, even when the
+  profile came from `settings.yaml` itself. The override now lives on
+  `ConfigManager` (`--profile` defaults to none, `init_config(...,
+  profile_override=)`), the effective profile and its hardening are re-derived
+  after every settings load, and a save never writes the override into the
+  operator's file. `GET /api/config` exposes `security_profile`,
+  `profile_override` and the derived `effective` values; the e2e agent checks
+  they are stable across a reload.
 - **Example presets now bind to `127.0.0.1`** (#164). All four pre-2.6.0
   presets (`cli-device-flow`, `microservices-client-credentials`,
   `react-spa-pkce`, `spring-boot-saml`) still shipped an explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profile came from `settings.yaml` itself. The override now lives on
   `ConfigManager` (`--profile` defaults to none, `init_config(...,
   profile_override=)`), the effective profile and its hardening are re-derived
-  after every settings load, and a save never writes the override into the
-  operator's file. `GET /api/config` exposes `security_profile`,
+  after every settings load, and a save serializes the DECLARED state
+  (`ConfigManager.persistable_settings()`), so neither the override nor
+  the hardening it implies is ever written into the operator's file. `GET /api/config` exposes `security_profile`,
   `profile_override` and the derived `effective` values; the e2e agent checks
   they are stable across a reload.
 - **Example presets now bind to `127.0.0.1`** (#164). All four pre-2.6.0

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -146,7 +146,9 @@ saml:
   roles_attr_name: "roles"   # attribute name used when export_roles is on
   groups_attr_name: "groups" # attribute name used when export_groups is on
 
-# Optional; also settable at startup with --profile (which wins over YAML)
+# Optional; also settable at startup with --profile, which wins over this value
+# for that run only (any of the three, including an explicit dev), is never
+# written back here and survives every reload (#172)
 # security_profile: oauth21   # dev (default) | stricter-dev | oauth21
 
 # Optional; local dev/testing convenience, off by default - see "Login mode" above

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -99,6 +99,16 @@ python -m nanoidp --profile stricter-dev
 python -m nanoidp --profile oauth21
 ```
 
+`--profile` is a per-run override: when given (any of the three values,
+including an explicit `dev`) it wins over `security_profile` in
+`settings.yaml`, is never written back to the file, and is re-applied after
+every configuration reload, including the reload that follows each web UI or
+MCP save. The `stricter-dev` runtime hardening (`require_pkce`,
+`password_hashing`, `rate_limit_enabled`, debug off) is derived from the
+effective profile on every reload the same way, whether the profile came from
+the flag or from YAML. `GET /api/config` reports the effective profile,
+whether it came from an override, and the derived values (#172).
+
 ### Feature Comparison
 
 | Feature | `dev` | `stricter-dev` | `oauth21` |

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -3143,6 +3143,48 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("API Config Reload", TestCategory.API, False, str(e))
 
+    def test_api_config_profile_survives_reload(self) -> TestResult:
+        """REST API - The effective security profile is stable across reloads (#172).
+
+        /api/config reports the EFFECTIVE profile (CLI --profile override
+        applied, stricter-dev hardening derived). Before #172 a reload - which
+        every UI/MCP save triggers - rebuilt Settings from YAML and silently
+        dropped both the CLI override and the stricter-dev hardening, so the
+        same document read before and after a reload must be identical.
+        """
+        try:
+            keys = ("security_profile", "profile_override", "effective")
+            before = self.session.get(f"{self.base_url}/api/config", timeout=5).json()
+            missing = [k for k in keys if k not in before]
+            if missing:
+                return self._add_result(
+                    "API Profile Survives Reload",
+                    TestCategory.API,
+                    False,
+                    f"/api/config lacks {missing}",
+                    before,
+                )
+            self.session.post(f"{self.base_url}/api/config/reload", timeout=5)
+            after = self.session.get(f"{self.base_url}/api/config", timeout=5).json()
+            snapshot_before = {k: before[k] for k in keys}
+            snapshot_after = {k: after.get(k) for k in keys}
+            same = snapshot_before == snapshot_after
+            hardened = (
+                before["security_profile"] != "stricter-dev"
+                or before["effective"].get("require_pkce") is True
+            )
+            return self._add_result(
+                "API Profile Survives Reload",
+                TestCategory.API,
+                same and hardened,
+                f"profile={before['security_profile']} override={before['profile_override']} "
+                f"{'unchanged' if same else 'CHANGED'} after reload"
+                + ("" if hardened else "; stricter-dev without require_pkce"),
+                {"before": snapshot_before, "after": snapshot_after},
+            )
+        except Exception as e:
+            return self._add_result("API Profile Survives Reload", TestCategory.API, False, str(e))
+
     def test_api_audit_log(self) -> TestResult:
         """REST API - Audit log."""
         try:
@@ -3550,6 +3592,7 @@ class NanoIDPTestAgent:
                 self.test_api_config,
                 self.test_api_verbose_logging_setting,
                 self.test_api_config_reload,
+                self.test_api_config_profile_survives_reload,
                 self.test_api_audit_log,
                 self.test_api_audit_stats,
             ]),

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 from nanoidp import __version__
+from nanoidp.models import SECURITY_PROFILES
 
 # Add src to path for development
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -185,10 +186,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--profile",
-        choices=["dev", "stricter-dev", "oauth21"],
-        default="dev",
-        help="Security profile: dev (default), stricter-dev (runtime hardening) "
-        "or oauth21 (draft OAuth 2.1 protocol strictness)",
+        choices=list(SECURITY_PROFILES),
+        default=None,
+        help="Security profile: dev, stricter-dev (runtime hardening) or oauth21 "
+        "(draft OAuth 2.1 protocol strictness). When given it overrides "
+        "settings.yaml's security_profile for this run only; when omitted the "
+        "YAML value applies (default: dev)",
     )
 
     args = parser.parse_args()

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -26,23 +26,13 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
     global limiter
 
     # Initialize configuration
-    config = init_config(config_dir)
+    # The CLI --profile (any of the three values, including an explicit
+    # "dev") wins over settings.yaml's security_profile and survives every
+    # reload(); the stricter-dev runtime hardening is derived from the
+    # EFFECTIVE profile inside ConfigManager, so YAML and CLI mean the same
+    # thing and neither is lost on the first UI/MCP save (#68 review, #172).
+    config = init_config(config_dir, profile_override=profile)
     settings = config.settings
-
-    # Apply profile overrides. The CLI --profile wins over settings.yaml's
-    # security_profile; the runtime mutations key off the EFFECTIVE profile,
-    # so YAML and CLI mean the same thing (#68 review). oauth21 needs no
-    # mutations here: its protocol behavior is derived from security_profile
-    # via Settings properties (#68).
-    if profile in ("stricter-dev", "oauth21"):
-        settings.security_profile = profile
-    if settings.security_profile == "stricter-dev":
-        settings.rate_limit_enabled = True
-        settings.password_hashing = True
-        # PKCE required and 'plain' rejected in stricter-dev (#47)
-        settings.require_pkce = True
-        # Block debug mode in stricter-dev
-        settings.debug = False
 
     # Configure logging
     logging.basicConfig(

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -15,6 +15,7 @@ import yaml
 # Re-exported for compatibility: the models were defined here until #86, and
 # every consumer (routes, services, MCP, tests) imports them from this module.
 from .models import (  # noqa: F401
+    SECURITY_PROFILES,
     OAuthClient,
     Settings,
     User,
@@ -35,8 +36,19 @@ logger = logging.getLogger(__name__)
 class ConfigManager:
     """Manages configuration loading and access."""
 
-    def __init__(self, config_dir: Optional[str] = None) -> None:
+    def __init__(
+        self, config_dir: Optional[str] = None, profile_override: Optional[str] = None
+    ) -> None:
         self.config_dir = Path(config_dir or self._find_config_dir())
+        # A transient CLI/programmatic `--profile` (#172). Kept here, not on
+        # Settings, because it must survive every reload() - which rebuilds
+        # Settings from YAML - and must never be written back to the file.
+        if profile_override is not None and profile_override not in SECURITY_PROFILES:
+            raise ValueError(
+                f"Invalid profile override {profile_override!r}; "
+                f"expected one of {', '.join(SECURITY_PROFILES)}"
+            )
+        self.profile_override: Optional[str] = profile_override
         self.settings: Settings = Settings()
         self.users: Dict[str, User] = {}
         self.default_user: str = "admin"
@@ -70,7 +82,35 @@ class ConfigManager:
         logger.info(f"Loaded {len(self.users)} users")
 
     def _load_settings(self) -> None:
-        """Load settings from settings.yaml."""
+        """Load settings from settings.yaml, then apply the effective profile."""
+        self._read_settings()
+        self._apply_profile()
+
+    def _apply_profile(self) -> None:
+        """Make the effective security profile real on the freshly built Settings.
+
+        Two things used to happen once in create_app() and were lost on the
+        first reload() - i.e. on the first UI/MCP save (#172): the CLI
+        --profile override, and the stricter-dev runtime hardening
+        (require_pkce, password_hashing, rate_limit_enabled, debug off). Both
+        belong here, next to the only place Settings is rebuilt, so every
+        reload re-derives them. The YAML value is never touched: the override
+        lives in memory and _save_settings() preserves the on-disk profile.
+        oauth21 needs no mutation; its protocol strictness derives from
+        security_profile via Settings properties (#68).
+        """
+        if self.profile_override is not None:
+            self.settings.security_profile = self.profile_override
+        if self.settings.security_profile == "stricter-dev":
+            self.settings.rate_limit_enabled = True
+            self.settings.password_hashing = True
+            # PKCE required and 'plain' rejected in stricter-dev (#47)
+            self.settings.require_pkce = True
+            # Block debug mode in stricter-dev
+            self.settings.debug = False
+
+    def _read_settings(self) -> None:
+        """Build Settings from settings.yaml (defaults when the file is absent)."""
         settings_file = self.config_dir / "settings.yaml"
 
         if not settings_file.exists():
@@ -364,7 +404,15 @@ class ConfigManager:
         """
         settings_file = self.config_dir / "settings.yaml"
         document = load_yaml_document(settings_file)
+        on_disk_profile = document.get("security_profile")
         apply_settings_document(document, self.settings)
+        if self.profile_override is not None:
+            # A transient --profile must not rewrite the operator's file (#172):
+            # keep whatever security_profile the YAML declared (or didn't).
+            if on_disk_profile is None:
+                document.pop("security_profile", None)
+            else:
+                document["security_profile"] = on_disk_profile
         atomic_write_yaml(settings_file, document)
 
 
@@ -383,8 +431,15 @@ def get_config() -> ConfigManager:
     return _config
 
 
-def init_config(config_dir: Optional[str] = None) -> ConfigManager:
-    """Initialize the global config instance."""
+def init_config(
+    config_dir: Optional[str] = None, profile_override: Optional[str] = None
+) -> ConfigManager:
+    """Initialize the global config instance.
+
+    profile_override is the CLI --profile: it wins over settings.yaml's
+    security_profile for the life of the process and is re-applied on every
+    reload() without ever being persisted (#172).
+    """
     global _config
-    _config = ConfigManager(config_dir)
+    _config = ConfigManager(config_dir, profile_override=profile_override)
     return _config

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -8,7 +8,7 @@ import logging
 import os
 import threading
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import yaml
 
@@ -49,6 +49,7 @@ class ConfigManager:
                 f"expected one of {', '.join(SECURITY_PROFILES)}"
             )
         self.profile_override: Optional[str] = profile_override
+        self._declared: Dict[str, Any] = {}
         self.settings: Settings = Settings()
         self.users: Dict[str, User] = {}
         self.default_user: str = "admin"
@@ -86,28 +87,57 @@ class ConfigManager:
         self._read_settings()
         self._apply_profile()
 
+    # Settings fields the stricter-dev profile forces at runtime (#47, #68).
+    # Listed once so _apply_profile() and persistable_settings() cannot drift:
+    # adding a derived field here is all it takes for it to be both applied
+    # on every reload and kept out of the operator's file.
+    _STRICTER_DEV_HARDENING: Dict[str, Any] = {
+        "rate_limit_enabled": True,
+        "password_hashing": True,
+        # PKCE required and 'plain' rejected in stricter-dev (#47)
+        "require_pkce": True,
+        # Block debug mode in stricter-dev
+        "debug": False,
+    }
+
     def _apply_profile(self) -> None:
         """Make the effective security profile real on the freshly built Settings.
 
         Two things used to happen once in create_app() and were lost on the
         first reload() - i.e. on the first UI/MCP save (#172): the CLI
-        --profile override, and the stricter-dev runtime hardening
-        (require_pkce, password_hashing, rate_limit_enabled, debug off). Both
+        --profile override, and the stricter-dev runtime hardening. Both
         belong here, next to the only place Settings is rebuilt, so every
-        reload re-derives them. The YAML value is never touched: the override
-        lives in memory and _save_settings() preserves the on-disk profile.
-        oauth21 needs no mutation; its protocol strictness derives from
-        security_profile via Settings properties (#68).
+        reload re-derives them.
+
+        self.settings is the EFFECTIVE state. Every value this method forces
+        is recorded in self._declared with the value the file declared (or
+        the model default), so persistable_settings() can hand the writer
+        the declared state and neither the override nor its derived effects
+        ever reach settings.yaml (#172 review). oauth21 needs no mutation;
+        its protocol strictness derives from security_profile via Settings
+        properties (#68).
         """
+        self._declared = {}
         if self.profile_override is not None:
+            self._declared["security_profile"] = self.settings.security_profile
             self.settings.security_profile = self.profile_override
         if self.settings.security_profile == "stricter-dev":
-            self.settings.rate_limit_enabled = True
-            self.settings.password_hashing = True
-            # PKCE required and 'plain' rejected in stricter-dev (#47)
-            self.settings.require_pkce = True
-            # Block debug mode in stricter-dev
-            self.settings.debug = False
+            for field, forced in self._STRICTER_DEV_HARDENING.items():
+                self._declared[field] = getattr(self.settings, field)
+                setattr(self.settings, field, forced)
+
+    def persistable_settings(self) -> Settings:
+        """The declared configuration state, as opposed to the effective one.
+
+        Identical to self.settings except for the fields _apply_profile()
+        forced, which carry the value the file declared. This is what the
+        writer serializes: a transient --profile, or the hardening a profile
+        implies, must never be written into the operator's file, where it
+        would survive the next start without the flag.
+        """
+        if not self._declared:
+            return self.settings
+        return self.settings.model_copy(update=self._declared)
 
     def _read_settings(self) -> None:
         """Build Settings from settings.yaml (defaults when the file is absent)."""
@@ -404,15 +434,8 @@ class ConfigManager:
         """
         settings_file = self.config_dir / "settings.yaml"
         document = load_yaml_document(settings_file)
-        on_disk_profile = document.get("security_profile")
-        apply_settings_document(document, self.settings)
-        if self.profile_override is not None:
-            # A transient --profile must not rewrite the operator's file (#172):
-            # keep whatever security_profile the YAML declared (or didn't).
-            if on_disk_profile is None:
-                document.pop("security_profile", None)
-            else:
-                document["security_profile"] = on_disk_profile
+        # Declared state, not effective state (#172): see persistable_settings().
+        apply_settings_document(document, self.persistable_settings())
         atomic_write_yaml(settings_file, document)
 
 

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -58,6 +58,12 @@ def _coerce_additional_audiences(raw: Any, client_id: str) -> List[str]:
     return _coerce_client_str_list(raw, client_id, "additional_audiences")
 
 
+# The three security profiles, in one place: Settings.security_profile's
+# validator, the CLI --profile choices and ConfigManager's override check all
+# read this tuple (#172).
+SECURITY_PROFILES: tuple[str, ...] = ("dev", "stricter-dev", "oauth21")
+
+
 class User(BaseModel):
     """Represents a user in the system."""
     model_config = ConfigDict(extra="allow")
@@ -348,9 +354,8 @@ class Settings(BaseModel):
     @classmethod
     def validate_security_profile(cls, v: str) -> str:
         """Validate security profile."""
-        valid_profiles = {"dev", "stricter-dev", "oauth21"}
-        if v not in valid_profiles:
-            raise ValueError(f"Security profile must be one of: {valid_profiles}")
+        if v not in SECURITY_PROFILES:
+            raise ValueError(f"Security profile must be one of: {set(SECURITY_PROFILES)}")
         return v
 
     @field_validator("login_mode")

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -166,6 +166,17 @@ def get_configuration() -> ResponseReturnValue:
         },
         "authority_prefixes": settings.authority_prefixes,
         "allowed_identity_classes": settings.allowed_identity_classes,
+        # Effective profile, i.e. after the CLI --profile override and the
+        # stricter-dev hardening are applied (#172). profile_override tells
+        # a client whether the value comes from the process, not the YAML.
+        "security_profile": settings.security_profile,
+        "profile_override": config.profile_override,
+        "effective": {
+            "require_pkce": settings.require_pkce,
+            "password_hashing": settings.password_hashing,
+            "rate_limit_enabled": settings.rate_limit_enabled,
+            "debug": settings.debug,
+        },
         "users_count": len(config.users),
     })
 

--- a/tests/test_profile_override.py
+++ b/tests/test_profile_override.py
@@ -1,0 +1,161 @@
+"""
+#172: the CLI --profile override wins over settings.yaml for every value
+(including an explicit "dev"), survives reload(), is never persisted, and the
+stricter-dev runtime hardening is re-derived on every reload instead of being
+applied once in create_app().
+"""
+
+import pytest
+import yaml
+
+from nanoidp.config import ConfigManager, get_config, init_config
+from nanoidp.models import SECURITY_PROFILES
+
+
+def _write_config(tmp_path, security_profile=None):
+    settings = {"server": {"host": "127.0.0.1", "port": 8000}}
+    if security_profile is not None:
+        settings["security_profile"] = security_profile
+    (tmp_path / "settings.yaml").write_text(yaml.safe_dump(settings))
+    (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {}}))
+    return str(tmp_path)
+
+
+class TestProfileOverrideWinsOverYaml:
+    @pytest.mark.parametrize("cli_profile", SECURITY_PROFILES)
+    @pytest.mark.parametrize("yaml_profile", SECURITY_PROFILES)
+    def test_explicit_cli_profile_overrides_any_yaml_value(self, tmp_path, cli_profile, yaml_profile):
+        config = ConfigManager(_write_config(tmp_path, yaml_profile), profile_override=cli_profile)
+        assert config.settings.security_profile == cli_profile
+
+    def test_explicit_dev_overrides_stricter_yaml(self, tmp_path):
+        """The original report: --profile dev could not bring oauth21 back to dev."""
+        config = ConfigManager(_write_config(tmp_path, "oauth21"), profile_override="dev")
+        assert config.settings.security_profile == "dev"
+
+    @pytest.mark.parametrize("yaml_profile", SECURITY_PROFILES)
+    def test_omitted_flag_leaves_yaml_value(self, tmp_path, yaml_profile):
+        config = ConfigManager(_write_config(tmp_path, yaml_profile))
+        assert config.profile_override is None
+        assert config.settings.security_profile == yaml_profile
+
+    def test_invalid_override_rejected_at_construction(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid profile override"):
+            ConfigManager(_write_config(tmp_path), profile_override="prod")
+
+    def test_create_app_passes_override_through(self, tmp_path):
+        from nanoidp.app import create_app
+
+        create_app(config_dir=_write_config(tmp_path, "oauth21"), profile="dev")
+        assert get_config().profile_override == "dev"
+        assert get_config().settings.security_profile == "dev"
+
+
+class TestOverrideSurvivesReload:
+    def test_reload_keeps_cli_profile(self, tmp_path):
+        config = init_config(_write_config(tmp_path), profile_override="stricter-dev")
+        config.reload()
+        assert config.settings.security_profile == "stricter-dev"
+
+    def test_yaml_writer_save_keeps_cli_profile(self, tmp_path):
+        """dshvedchenko's repro: stricter-dev -> switch login mode in UI -> back to dev."""
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        init_config(_write_config(tmp_path), profile_override="stricter-dev")
+        YamlWriter(str(tmp_path)).update_login_settings(mode="persona")
+        assert get_config().settings.security_profile == "stricter-dev"
+        assert get_config().settings.login_mode == "persona"
+
+    def test_override_is_never_persisted(self, tmp_path):
+        config = init_config(_write_config(tmp_path), profile_override="oauth21")
+        config.save()
+        on_disk = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert "security_profile" not in on_disk
+
+    def test_override_preserves_explicit_yaml_profile_on_save(self, tmp_path):
+        config = init_config(_write_config(tmp_path, "stricter-dev"), profile_override="dev")
+        config.save()
+        on_disk = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert on_disk["security_profile"] == "stricter-dev"
+        # and the in-memory override still stands after the save's reload
+        assert config.settings.security_profile == "dev"
+
+    def test_yaml_profile_is_persisted_normally_without_override(self, tmp_path):
+        config = init_config(_write_config(tmp_path))
+        config.settings.security_profile = "oauth21"
+        config.save()
+        on_disk = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert on_disk["security_profile"] == "oauth21"
+
+
+class TestStricterDevHardeningSurvivesReload:
+    EXPECTED = {"require_pkce": True, "password_hashing": True, "rate_limit_enabled": True, "debug": False}
+
+    def _assert_hardened(self, settings):
+        for field, value in self.EXPECTED.items():
+            assert getattr(settings, field) is value, field
+
+    def test_yaml_stricter_dev_hardening_after_reload(self, tmp_path):
+        """Before #172 every reload silently dropped require_pkce & co. even
+        with security_profile: stricter-dev in the YAML itself."""
+        config = ConfigManager(_write_config(tmp_path, "stricter-dev"))
+        self._assert_hardened(config.settings)
+        config.reload()
+        assert config.settings.security_profile == "stricter-dev"
+        self._assert_hardened(config.settings)
+
+    def test_cli_stricter_dev_hardening_after_reload(self, tmp_path):
+        config = ConfigManager(_write_config(tmp_path), profile_override="stricter-dev")
+        config.reload()
+        self._assert_hardened(config.settings)
+
+    def test_dev_profile_does_not_harden(self, tmp_path):
+        config = ConfigManager(_write_config(tmp_path))
+        assert config.settings.require_pkce is False
+        assert config.settings.password_hashing is False
+        assert config.settings.rate_limit_enabled is False
+
+    def test_explicit_dev_override_undoes_yaml_stricter_hardening(self, tmp_path):
+        config = ConfigManager(_write_config(tmp_path, "stricter-dev"), profile_override="dev")
+        assert config.settings.require_pkce is False
+        assert config.settings.rate_limit_enabled is False
+
+
+class TestCliDefault:
+    def test_profile_flag_defaults_to_none(self):
+        import inspect
+
+        import nanoidp.__main__ as main_mod
+
+        src = inspect.getsource(main_mod)
+        assert 'default=None' in src.split('"--profile"')[1].split("help=")[0]
+        assert 'choices=list(SECURITY_PROFILES)' in src
+
+
+class TestApiConfigExposesEffectiveProfile:
+    def test_api_config_reports_override_and_hardening(self, tmp_path):
+        from nanoidp.app import create_app
+
+        app = create_app(config_dir=_write_config(tmp_path, "oauth21"), profile="stricter-dev")
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            doc = client.get("/api/config").get_json()
+        assert doc["security_profile"] == "stricter-dev"
+        assert doc["profile_override"] == "stricter-dev"
+        assert doc["effective"] == {
+            "require_pkce": True,
+            "password_hashing": True,
+            "rate_limit_enabled": True,
+            "debug": False,
+        }
+
+    def test_api_config_without_override(self, tmp_path):
+        from nanoidp.app import create_app
+
+        app = create_app(config_dir=_write_config(tmp_path))
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            doc = client.get("/api/config").get_json()
+        assert doc["security_profile"] == "dev"
+        assert doc["profile_override"] is None
+        assert doc["effective"]["require_pkce"] is False

--- a/tests/test_profile_override.py
+++ b/tests/test_profile_override.py
@@ -88,6 +88,72 @@ class TestOverrideSurvivesReload:
         assert on_disk["security_profile"] == "oauth21"
 
 
+class TestDerivedHardeningIsNeverPersisted:
+    """#172 review: the override's EFFECTS must stay out of the file too.
+
+    Before the fix, --profile stricter-dev never wrote "stricter-dev" but
+    save() wrote `oauth.require_pkce: true` (and the other forced fields),
+    so the next start without the flag kept PKCE enforced.
+    """
+
+    FORCED = ("require_pkce", "password_hashing", "rate_limit_enabled")
+
+    def _on_disk(self, tmp_path):
+        return yaml.safe_load((tmp_path / "settings.yaml").read_text())
+
+    def test_cli_stricter_dev_save_writes_neither_profile_nor_effects(self, tmp_path):
+        config = init_config(_write_config(tmp_path), profile_override="stricter-dev")
+        config.save()
+        on_disk = self._on_disk(tmp_path)
+        assert "security_profile" not in on_disk
+        # The writer materializes managed keys at their DECLARED value (false,
+        # the model default here); what must never appear is the forced true.
+        flat = yaml.safe_dump(on_disk)
+        for field in self.FORCED:
+            assert f"{field}: true" not in flat, flat
+        assert (on_disk.get("oauth") or {}).get("require_pkce") is not True
+        # the effective state is untouched by the save
+        assert config.settings.require_pkce is True
+        assert config.settings.security_profile == "stricter-dev"
+
+    def test_cli_stricter_dev_save_keeps_explicit_declared_values(self, tmp_path):
+        """File says require_pkce: false explicitly; the flag forces True at
+        runtime; the save must keep the declared false."""
+        settings = {
+            "server": {"host": "127.0.0.1", "port": 8000},
+            "oauth": {"require_pkce": False},
+        }
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(settings))
+        (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {}}))
+        config = init_config(str(tmp_path), profile_override="stricter-dev")
+        assert config.settings.require_pkce is True
+        config.save()
+        assert self._on_disk(tmp_path)["oauth"]["require_pkce"] is False
+
+    def test_yaml_stricter_dev_save_does_not_materialize_effects(self, tmp_path):
+        """Profile declared in YAML: the hardening is implied by the profile
+        line and must not be spelled out by a save either."""
+        config = init_config(_write_config(tmp_path, "stricter-dev"))
+        config.save()
+        on_disk = self._on_disk(tmp_path)
+        assert on_disk["security_profile"] == "stricter-dev"
+        assert "require_pkce: true" not in yaml.safe_dump(on_disk)
+        assert (on_disk.get("oauth") or {}).get("require_pkce") is not True
+
+    def test_persistable_settings_is_effective_settings_without_profile(self, tmp_path):
+        config = ConfigManager(_write_config(tmp_path))
+        assert config.persistable_settings() is config.settings
+
+    def test_next_start_without_flag_is_not_hardened(self, tmp_path):
+        """End to end: run with the flag, save, restart without it."""
+        init_config(_write_config(tmp_path), profile_override="stricter-dev").save()
+        fresh = ConfigManager(str(tmp_path))
+        assert fresh.settings.security_profile == "dev"
+        assert fresh.settings.require_pkce is False
+        assert fresh.settings.password_hashing is False
+        assert fresh.settings.rate_limit_enabled is False
+
+
 class TestStricterDevHardeningSurvivesReload:
     EXPECTED = {"require_pkce": True, "password_hashing": True, "rate_limit_enabled": True, "debug": False}
 


### PR DESCRIPTION
Closes #172.

## What was wrong

- `--profile` defaulted to `dev`, so the code could not tell "asked for dev" from "omitted" and only honoured `stricter-dev`/`oauth21`; an explicit `--profile dev` could not bring a YAML `oauth21` back to `dev`.
- The override only mutated the in-memory `Settings` once in `create_app()`. Every `YamlWriter` mutation ends with `get_config().reload()`, which rebuilds `Settings` from YAML, so the first UI/MCP save silently dropped the CLI profile (dshvedchenko's repro in the issue).
- Found while fixing: the `stricter-dev` runtime hardening (`require_pkce`, `password_hashing`, `rate_limit_enabled`, debug off) was applied in the same one-shot block and lost on the same first reload, even when `security_profile: stricter-dev` came from `settings.yaml` itself. Repro on main: YAML stricter-dev, `create_app()`, `reload()` -> `require_pkce=False`, `password_hashing=False`, `rate_limit_enabled=False` while `security_profile` still reads `stricter-dev`.

## What changed

- `ConfigManager(config_dir, profile_override=None)` / `init_config(..., profile_override=)` own the override; `_load_settings()` is now read + `_apply_profile()`, so the effective profile and its hardening are re-derived after every load. `create_app()` just passes the flag through.
- `--profile` defaults to `None`; choices come from a single `SECURITY_PROFILES` tuple in `models.py` shared with the validator.
- `_save_settings()` preserves the on-disk `security_profile` when an override is active: a transient flag never rewrites the operator's file.
- `GET /api/config` exposes `security_profile`, `profile_override` and the derived `effective` values (the document did not report the profile at all, which is why this could not be observed from outside).
- `examples/test_agent.py`: new `API Profile Survives Reload` check (reads the document, reloads, asserts it is identical and that stricter-dev implies `require_pkce`).
- Docs: `configuration.md` comment, SECURITY.md paragraph, CHANGELOG.

## Verification

- 27 new unit tests (`tests/test_profile_override.py`): full CLI x YAML matrix, omitted flag, invalid override rejected, reload and `YamlWriter` save keep the override, override never persisted and an explicit YAML profile preserved on save, stricter-dev hardening after reload from YAML and from CLI, `/api/config` exposure. 1061 passed, ruff and mypy clean.
- Live: server with YAML `security_profile: oauth21` and `--profile stricter-dev`, `/api/config` reports `stricter-dev` with `require_pkce: true` before and after `POST /api/config/reload`, YAML still says `oauth21`. `test_agent.py` 50/50 including the new check.
