### PR TITLE
chore: enforce import contracts with import-linter (#149)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           mypy src
 
+      - name: Check import contracts
+        run: |
+          lint-imports
+
       - name: Run tests
         run: |
           pytest tests/ -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Import contracts enforced in CI** (#149): `import-linter` now pins the
+  package layering (`routes -> services -> config`) and the invariant that
+  `serialization.py` has no runtime imports from the package (it is what
+  lets `config.py` import it without a cycle). Both used to live only in
+  comments; `lint-imports` runs next to ruff and mypy in the Tests workflow
+  and fails when a change adds a forbidden import.
 - **Persona login mode** (#156): opt-in `login.mode: persona` lists the
   configured users on every interactive login surface (`/login`,
   `/authorize`, `/saml/sso` and the device flow's verification page) and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,17 @@ ruff check src tests
 
 # Fix linting issues automatically
 ruff check --fix src tests
+
+# Check architectural import contracts (#149)
+lint-imports
 ```
+
+`lint-imports` enforces the package layering `routes -> services -> config`
+and keeps `serialization.py` free of runtime imports from the package (that is
+what lets `config.py` import it without a cycle). The contracts live in
+`[tool.importlinter]` in `pyproject.toml`; a type-checking-only import does not
+count. If a change needs a new edge between layers, adjust the contract in the
+same PR and say why.
 
 ## Code Style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
     "types-PyYAML",
     "types-jsonschema",
     "requests>=2.31.0",  # examples/test_agent.py (e2e)
-    "import-linter>=2.0",  # architectural import contracts (#149), see [tool.importlinter]
+    "import-linter>=2.1",  # wildcard forbidden_modules; architectural import contracts (#149), see [tool.importlinter]
 ]
 
 [project.scripts]
@@ -114,11 +114,11 @@ exclude_type_checking_imports = true
 name = "serialization has no runtime package imports"
 type = "forbidden"
 source_modules = ["nanoidp.serialization"]
-forbidden_modules = [
-    "nanoidp.services",
-    "nanoidp.routes",
-    "nanoidp.config",
-]
+# Every sibling in the package, not a hand-picked list: the invariant is "no
+# runtime import from the package at all" (models included - today it is a
+# TYPE_CHECKING import, and turning it into a runtime one is the likeliest
+# regression). Wildcards need import-linter >= 2.1.
+forbidden_modules = ["nanoidp.*"]
 
 [[tool.importlinter.contracts]]
 name = "layers: routes -> services -> config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "types-PyYAML",
     "types-jsonschema",
     "requests>=2.31.0",  # examples/test_agent.py (e2e)
+    "import-linter>=2.0",  # architectural import contracts (#149), see [tool.importlinter]
 ]
 
 [project.scripts]
@@ -96,6 +97,36 @@ include = [
     "/config",
     "/README.md",
     "/LICENSE",
+]
+
+# Architectural import contracts (#149), enforced by `lint-imports` in CI.
+# The package layering is routes -> services -> config -> serialization/models;
+# higher layers may import lower ones, never the reverse. The only declared
+# back-edge is serialization -> config, which exists purely under
+# TYPE_CHECKING so config.py can import serialization at runtime without a
+# cycle; exclude_type_checking_imports keeps those annotations-only edges out
+# of the graph so the contracts describe runtime dependencies.
+[tool.importlinter]
+root_package = "nanoidp"
+exclude_type_checking_imports = true
+
+[[tool.importlinter.contracts]]
+name = "serialization has no runtime package imports"
+type = "forbidden"
+source_modules = ["nanoidp.serialization"]
+forbidden_modules = [
+    "nanoidp.services",
+    "nanoidp.routes",
+    "nanoidp.config",
+]
+
+[[tool.importlinter.contracts]]
+name = "layers: routes -> services -> config"
+type = "layers"
+layers = [
+    "nanoidp.routes",
+    "nanoidp.services",
+    "nanoidp.config",
 ]
 
 [tool.black]


### PR DESCRIPTION
Closes #149.

Adds import-linter with the two contracts from the issue in `[tool.importlinter]` (pyproject.toml), and a `Check import contracts` step in the Tests workflow after mypy.

- `exclude_type_checking_imports = true` is supported natively by import-linter 2.13 / grimp 3.15, so the `serialization -> config` TYPE_CHECKING edge is excluded without an `ignore_imports` hack. The exclusion is load-bearing: with it off, contract 1 false-positives on that edge.
- Import graph verified against the package before writing the contracts; it matches the issue (`app.py` and `mcp_server.py` sit above routes/services and are outside both contracts).
- Negative tests done locally: a runtime `from .services import ...` in `serialization.py` and a `from .routes import ...` in `config.py` each break their contract (`Contracts: 0 kept, 2 broken`, with the offending lines reported), reverted before commit.
- Clean branch: `Analyzed 28 files, 56 dependencies. Contracts: 2 kept, 0 broken.` Full suite 1034 passed, ruff and mypy clean.
- CONTRIBUTING.md gets a short paragraph on the contracts; CHANGELOG entry under Unreleased.
