### PR TITLE
feat: accept native-app redirect URIs per RFC 8252 (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   /api/config` and the MCP `get_settings` tool expose the effective value;
   the e2e agent asserts it. Bumps only on renames, removals or semantic
   changes (with a loader migration), never on optional additions.
+- **Native-app redirect URIs** (#81, RFC 8252): `/authorize` accepts
+  private-use scheme redirect URIs such as `com.example.app:/oauth2redirect`
+  (§7.1: a scheme and a path, no authority) as absolute URIs, and a
+  registered loopback URI (`http://127.0.0.1:{port}/...`,
+  `http://[::1]:{port}/...`) matches any port (§7.3), since native apps
+  bind an ephemeral port. Everything else keeps exact string matching (RFC
+  6749 §3.1.2.3): scheme, host, path and query of a loopback URI, every
+  port of a non-loopback or `localhost` registration. Fragments are now
+  rejected explicitly (§3.1.2). One shared matcher,
+  `services/redirect_uri.py`, serves both legs of `/authorize`; MCP tool
+  descriptions and `examples/test_agent.py` updated.
 - **Persona login mode** (#156): opt-in `login.mode: persona` lists the
   configured users on every interactive login surface (`/login`,
   `/authorize`, `/saml/sso` and the device flow's verification page) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes (with a loader migration), never on optional additions.
 - **Native-app redirect URIs** (#81, RFC 8252): `/authorize` accepts
   private-use scheme redirect URIs such as `com.example.app:/oauth2redirect`
-  (§7.1: a scheme and a path, no authority) as absolute URIs, and a
+  (§7.1: a scheme and a path, no authority) as absolute URIs and applies
+  §7.1's minimum rule to them (a non-`http(s)` scheme without a period,
+  such as `myapp://`, is rejected with a message naming the rule; domain
+  ownership is not verified), and a
   registered loopback URI (`http://127.0.0.1:{port}/...`,
   `http://[::1]:{port}/...`) matches any port (§7.3), since native apps
   bind an ephemeral port. Everything else keeps exact string matching (RFC

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -215,7 +215,12 @@ any absolute URI, the permissive dev default.
 **Native apps (RFC 8252)**: two things a native client needs are built
 in. A private-use scheme URI such as `com.example.app:/oauth2redirect`
 (§7.1: a scheme and a path, no host) is a valid `redirect_uri` and can be
-registered like any other. A registered loopback URI,
+registered like any other. §7.1 requires such schemes to be a domain the
+app controls, in reverse order; NanoIDP applies the minimum rule the RFC
+asks of an authorization server, rejecting any non-`http(s)` scheme that
+contains no period (`myapp://callback` is answered with `400
+invalid_request` naming the rule), and does not verify domain ownership.
+A registered loopback URI,
 `http://127.0.0.1:{port}/callback` or `http://[::1]:{port}/callback`,
 matches any port (§7.3), because the app binds an ephemeral port at
 runtime; register it with any placeholder port (`:0` reads well). Only

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -210,7 +210,27 @@ list gets exact-string matching on `/authorize` (RFC 6749 §3.1.2.3,
 OAuth 2.1 §4.1.1): no prefix, host or path normalization, and a mismatch
 is answered with `400 invalid_request` directly, never by redirecting to
 the unvalidated URI (§3.1.2.4). Clients without the field keep accepting
-any syntactically valid URI, the permissive dev default.
+any absolute URI, the permissive dev default.
+
+**Native apps (RFC 8252)**: two things a native client needs are built
+in. A private-use scheme URI such as `com.example.app:/oauth2redirect`
+(§7.1: a scheme and a path, no host) is a valid `redirect_uri` and can be
+registered like any other. A registered loopback URI,
+`http://127.0.0.1:{port}/callback` or `http://[::1]:{port}/callback`,
+matches any port (§7.3), because the app binds an ephemeral port at
+runtime; register it with any placeholder port (`:0` reads well). Only
+the port is variable: scheme, host, path and query stay exact, and
+`localhost` gets no port flexibility (§7.3 and §8.3 recommend the IP
+literals precisely because `localhost` can be remapped). The `oauth21`
+profile keeps the loopback exception, as the OAuth 2.1 draft does.
+
+```yaml
+    - client_id: "native-client"
+      client_secret: "secret"
+      redirect_uris:
+        - "com.example.app:/oauth2redirect"   # private-use scheme, exact
+        - "http://127.0.0.1:0/callback"       # loopback: any port matches
+```
 
 **Login page branding**: for demos and prototyping, a client can show its
 `client_id` and `description` on the `/authorize` login page and use custom

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -32,6 +32,13 @@ oauth:
     footer_color: '#e8f4f8'
     show_client_id: true
     show_description: true
+  - client_id: ui-native
+    client_secret: 's'
+    description: ''
+    show_client_id: false
+    redirect_uris:
+    - com.example.app:/oauth2redirect
+    - http://127.0.0.1:0/callback
   issuer_from_request: false
   issuer_from_proxy_headers: false
   # logos_dir: ./static/logos  # optional override; defaults to src/nanoidp/static/logos

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -814,6 +814,125 @@ class NanoIDPTestAgent:
                 "Redirect URI Exact Match", TestCategory.OAUTH, False, f"Error: {e}"
             )
 
+    def test_native_app_redirect_uris(self) -> TestResult:
+        """Native-app redirect URIs per RFC 8252 (issue #81).
+
+        Registers a client (clients UI form, so the form path is exercised
+        too) with a private-use scheme URI (section 7.1) and a loopback URI
+        with a placeholder port (section 7.3), then runs the accept/reject
+        matrix on /authorize: custom scheme accepted, loopback on another
+        port accepted, localhost on another port rejected, non-loopback host
+        on another port rejected. Rejections must be 400 without a redirect
+        (RFC 6749 section 3.1.2.4).
+        """
+        test_client_id = f"native-test-{secrets.token_hex(4)}"
+        custom_scheme = "com.example.app:/oauth2redirect"
+        try:
+            create = requests.post(
+                f"{self.base_url}/clients/create",
+                data={
+                    "client_id": test_client_id,
+                    "client_secret": "native-test-secret",
+                    "description": "Native-app e2e test client",
+                    "redirect_uris": "\n".join([
+                        custom_scheme,
+                        "http://127.0.0.1:0/callback",
+                        "http://localhost:3000/callback",
+                        "https://app.example.com/cb",
+                    ]),
+                },
+                allow_redirects=False,
+                timeout=5,
+            )
+            if create.status_code not in (302, 303):
+                return self._add_result(
+                    "Native App Redirect URIs", TestCategory.OAUTH, False,
+                    f"Client creation failed: status={create.status_code}",
+                )
+
+            def authorize(redirect_uri: str) -> requests.Response:
+                return requests.get(
+                    f"{self.base_url}/authorize",
+                    params={
+                        "response_type": "code",
+                        "client_id": test_client_id,
+                        "redirect_uri": redirect_uri,
+                        "scope": "openid",
+                    },
+                    allow_redirects=False,
+                    timeout=5,
+                )
+
+            def rejected(resp: requests.Response) -> bool:
+                if resp.status_code != 400 or "Location" in resp.headers:
+                    return False
+                try:
+                    return resp.json().get("error") == "invalid_request"
+                except ValueError:
+                    return False
+
+            custom = authorize(custom_scheme)
+            loopback_other_port = authorize("http://127.0.0.1:51234/callback")
+            loopback_no_port = authorize("http://127.0.0.1/callback")
+            localhost_other_port = authorize("http://localhost:3001/callback")
+            web_other_port = authorize("https://app.example.com:444/cb")
+            loopback_other_path = authorize("http://127.0.0.1:51234/other")
+
+            checks = {
+                "custom_scheme_accepted": custom.status_code == 200,
+                "loopback_other_port_accepted": loopback_other_port.status_code == 200,
+                "loopback_no_port_accepted": loopback_no_port.status_code == 200,
+                "localhost_other_port_rejected": rejected(localhost_other_port),
+                "web_other_port_rejected": rejected(web_other_port),
+                "loopback_other_path_rejected": rejected(loopback_other_path),
+            }
+
+            # Complete the loopback flow: the code must land on the port the
+            # app asked for, not on the registered placeholder.
+            login = requests.post(
+                f"{self.base_url}/authorize",
+                data={
+                    "response_type": "code",
+                    "client_id": test_client_id,
+                    "redirect_uri": "http://127.0.0.1:51234/callback",
+                    "scope": "openid",
+                    "username": self.username,
+                    "password": self.password,
+                },
+                allow_redirects=False,
+                timeout=5,
+            )
+            location = login.headers.get("Location", "")
+            checks["loopback_flow_redirects_to_requested_port"] = (
+                login.status_code == 302
+                and location.startswith("http://127.0.0.1:51234/callback?")
+                and "code=" in location
+            )
+
+            success = all(checks.values())
+            return self._add_result(
+                "Native App Redirect URIs",
+                TestCategory.OAUTH,
+                success,
+                "RFC 8252: custom scheme + loopback port variability accepted, "
+                "localhost/non-loopback ports and other paths rejected",
+                {**checks, "statuses": {
+                    "custom": custom.status_code,
+                    "loopback_other_port": loopback_other_port.status_code,
+                    "localhost_other_port": localhost_other_port.status_code,
+                    "web_other_port": web_other_port.status_code,
+                    "login": login.status_code,
+                }},
+            )
+        except Exception as e:
+            return self._add_result(
+                "Native App Redirect URIs", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+        finally:
+            requests.post(
+                f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
+            )
+
     def test_client_branding(self) -> TestResult:
         """Per-client login page branding is created and rendered end-to-end (#150).
 
@@ -3565,6 +3684,7 @@ class NanoIDPTestAgent:
                 self.test_issuer_from_proxy_headers,
                 self.test_authorization_code_pkce,
                 self.test_redirect_uri_exact_matching,
+                self.test_native_app_redirect_uris,
                 self.test_client_branding,
                 self.test_id_token_audience,
                 self.test_id_token_time_claims,

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -877,6 +877,9 @@ class NanoIDPTestAgent:
             localhost_other_port = authorize("http://localhost:3001/callback")
             web_other_port = authorize("https://app.example.com:444/cb")
             loopback_other_path = authorize("http://127.0.0.1:51234/other")
+            # RFC 8252 section 7.1 minimum rule: a private-use scheme without
+            # a period is rejected at the syntactic gate, registered or not.
+            private_scheme_no_period = authorize("myapp://callback")
 
             checks = {
                 "custom_scheme_accepted": custom.status_code == 200,
@@ -885,6 +888,8 @@ class NanoIDPTestAgent:
                 "localhost_other_port_rejected": rejected(localhost_other_port),
                 "web_other_port_rejected": rejected(web_other_port),
                 "loopback_other_path_rejected": rejected(loopback_other_path),
+                "private_scheme_without_period_rejected": rejected(private_scheme_no_period)
+                and "RFC 8252" in private_scheme_no_period.json().get("error_description", ""),
             }
 
             # Complete the loopback flow: the code must land on the port the
@@ -914,8 +919,8 @@ class NanoIDPTestAgent:
                 "Native App Redirect URIs",
                 TestCategory.OAUTH,
                 success,
-                "RFC 8252: custom scheme + loopback port variability accepted, "
-                "localhost/non-loopback ports and other paths rejected",
+                "RFC 8252: reverse-domain scheme + loopback port variability accepted, "
+                "localhost/non-loopback ports, other paths and myapp:// rejected",
                 {**checks, "statuses": {
                     "custom": custom.status_code,
                     "loopback_other_port": loopback_other_port.status_code,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -589,7 +589,7 @@ _TOOLS: list[Tool] = [
                 "redirect_uris": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Registered redirect URIs; when non-empty, /authorize enforces exact matching, except a registered loopback URI (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any port per RFC 8252 section 7.3; private-use schemes like com.example.app:/cb are accepted (optional)",
+                    "description": "Registered redirect URIs; when non-empty, /authorize enforces exact matching, except a registered loopback URI (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any port per RFC 8252 section 7.3; reverse-domain private-use schemes like com.example.app:/cb are accepted, schemes without a period such as myapp:// are rejected per section 7.1 (optional)",
                 },
             },
             "required": ["client_id", "client_secret"],
@@ -641,7 +641,7 @@ _TOOLS: list[Tool] = [
                 "redirect_uris": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Replace the client's registered redirect URIs (loopback URIs match any port per RFC 8252 section 7.3, private-use schemes accepted); empty list removes the restriction (optional)",
+                    "description": "Replace the client's registered redirect URIs (loopback URIs match any port per RFC 8252 section 7.3, reverse-domain private-use schemes accepted, myapp:// rejected per section 7.1); empty list removes the restriction (optional)",
                 },
             },
             "required": ["client_id"],

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -589,7 +589,7 @@ _TOOLS: list[Tool] = [
                 "redirect_uris": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Registered redirect URIs; when non-empty, /authorize enforces exact matching (optional)",
+                    "description": "Registered redirect URIs; when non-empty, /authorize enforces exact matching, except a registered loopback URI (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any port per RFC 8252 section 7.3; private-use schemes like com.example.app:/cb are accepted (optional)",
                 },
             },
             "required": ["client_id", "client_secret"],
@@ -641,7 +641,7 @@ _TOOLS: list[Tool] = [
                 "redirect_uris": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Replace the client's registered redirect URIs; empty list removes the restriction (optional)",
+                    "description": "Replace the client's registered redirect URIs (loopback URIs match any port per RFC 8252 section 7.3, private-use schemes accepted); empty list removes the restriction (optional)",
                 },
             },
             "required": ["client_id"],

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -145,8 +145,11 @@ class OAuthClient(BaseModel):
         default_factory=list,
         description=(
             "Registered redirect URIs; when non-empty, /authorize enforces exact "
-            "string matching (RFC 6749 §3.1.2.3, OAuth 2.1 §4.1.1). Empty = any "
-            "syntactically valid URI is accepted (dev default)."
+            "string matching (RFC 6749 §3.1.2.3, OAuth 2.1 §4.1.1), except that a "
+            "registered loopback URI (http://127.0.0.1:{port}/..., "
+            "http://[::1]:{port}/...) matches any port (RFC 8252 §7.3, native "
+            "apps). Private-use scheme URIs (com.example.app:/cb, RFC 8252 §7.1) "
+            "are accepted. Empty = any absolute URI is accepted (dev default)."
         ),
     )
 

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -149,7 +149,9 @@ class OAuthClient(BaseModel):
             "registered loopback URI (http://127.0.0.1:{port}/..., "
             "http://[::1]:{port}/...) matches any port (RFC 8252 §7.3, native "
             "apps). Private-use scheme URIs (com.example.app:/cb, RFC 8252 §7.1) "
-            "are accepted. Empty = any absolute URI is accepted (dev default)."
+            "are accepted when the scheme is reverse-domain based (contains a "
+            "period); myapp://cb is rejected. Empty = any absolute URI with an "
+            "acceptable scheme is accepted (dev default)."
         ),
     )
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -7,7 +7,7 @@ import logging
 import os
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Union
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 import jwt as pyjwt
 from flask import (
@@ -37,6 +37,7 @@ from ..services import (
     get_token_service,
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
+from ..services.redirect_uri import is_absolute_redirect_uri, redirect_uri_is_registered
 from ..services.token import resolve_user_claim, sanitize_claim_names
 from ._audit import audit_event
 from ._issuer import effective_issuer
@@ -188,24 +189,28 @@ def authorize() -> ResponseReturnValue:
             "error_description": "Unknown client_id"
         }), 400
 
-    # Syntactic validation: must at least parse as an absolute URL.
-    try:
-        parsed = urlparse(redirect_uri)
-        if not parsed.scheme or not parsed.netloc:
-            raise ValueError("Invalid URL")
-    except Exception:
+    # Syntactic validation (RFC 6749 §3.1.2): an absolute URI with no
+    # fragment. A scheme is required; an authority is not, so native-app
+    # private-use scheme URIs like com.example.app:/oauth2redirect (RFC 8252
+    # §7.1) pass (#81). See services/redirect_uri.py.
+    if not is_absolute_redirect_uri(redirect_uri):
         return jsonify({
             "error": "invalid_request",
             "error_description": "Invalid redirect_uri"
         }), 400
 
-    # Exact matching against registered redirect URIs (issue #67). RFC 6749
+    # Matching against registered redirect URIs (issue #67). RFC 6749
     # §3.1.2.3 / OAuth 2.1 §4.1.1 require simple string comparison - no
-    # prefix, host or path normalization. Clients without registered URIs
-    # keep the permissive dev behavior (hardening is opt-in, principle 3).
-    # A mismatch MUST NOT redirect (§3.1.2.4): the error is returned
-    # directly, never sent to the unvalidated URI.
-    if client.redirect_uris and redirect_uri not in client.redirect_uris:
+    # prefix, host or path normalization - with the single exception RFC
+    # 8252 §7.3 mandates for native apps: a registered loopback URI
+    # (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any
+    # port (#81). Clients without registered URIs keep the permissive dev
+    # behavior (hardening is opt-in, principle 3). A mismatch MUST NOT
+    # redirect (§3.1.2.4): the error is returned directly, never sent to
+    # the unvalidated URI.
+    if client.redirect_uris and not redirect_uri_is_registered(
+        redirect_uri, client.redirect_uris
+    ):
         audit_event(
             "authorization_request",
             "failed",

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -37,7 +37,7 @@ from ..services import (
     get_token_service,
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
-from ..services.redirect_uri import is_absolute_redirect_uri, redirect_uri_is_registered
+from ..services.redirect_uri import redirect_uri_is_registered, redirect_uri_rejection_reason
 from ..services.token import resolve_user_claim, sanitize_claim_names
 from ._audit import audit_event
 from ._issuer import effective_issuer
@@ -192,11 +192,13 @@ def authorize() -> ResponseReturnValue:
     # Syntactic validation (RFC 6749 §3.1.2): an absolute URI with no
     # fragment. A scheme is required; an authority is not, so native-app
     # private-use scheme URIs like com.example.app:/oauth2redirect (RFC 8252
-    # §7.1) pass (#81). See services/redirect_uri.py.
-    if not is_absolute_redirect_uri(redirect_uri):
+    # §7.1) pass (#81), while a private-use scheme without a period (myapp://)
+    # is rejected per §7.1's minimum rule. See services/redirect_uri.py.
+    rejection = redirect_uri_rejection_reason(redirect_uri)
+    if rejection is not None:
         return jsonify({
             "error": "invalid_request",
-            "error_description": "Invalid redirect_uri"
+            "error_description": rejection
         }), 400
 
     # Matching against registered redirect URIs (issue #67). RFC 6749

--- a/src/nanoidp/services/redirect_uri.py
+++ b/src/nanoidp/services/redirect_uri.py
@@ -115,19 +115,41 @@ def is_loopback_redirect_uri(uri: str) -> bool:
     return parsed.scheme == "http" and hostname in _LOOPBACK_HOSTS
 
 
-def _without_port(uri: str) -> str:
-    """The URI with its port component removed, for loopback comparison."""
-    parsed = urlparse(uri)
-    hostname = parsed.hostname or ""
-    if ":" in hostname:  # IPv6 literal: restore the brackets
-        hostname = f"[{hostname}]"
-    netloc = hostname
-    if parsed.username is not None:
-        userinfo = parsed.username
-        if parsed.password is not None:
-            userinfo = f"{userinfo}:{parsed.password}"
-        netloc = f"{userinfo}@{netloc}"
-    return parsed._replace(netloc=netloc).geturl()
+def _strip_loopback_port(uri: str) -> str | None:
+    """``uri`` with only its port substring removed, or None if unusable.
+
+    The port exception (RFC 8252 §7.3) must not relax anything but the
+    port, so this never re-serializes the URI: ``urlparse`` is used only to
+    locate the authority and to validate the port (``.port`` raises on a
+    non-numeric or out-of-range value such as ``:evil``), and the original
+    string is then sliced so that scheme case, an empty query, trailing
+    characters and everything else stay byte-identical for the comparison
+    (#81 review). Returns None when the authority cannot be located or the
+    port is invalid, which callers treat as "no match".
+    """
+    try:
+        parsed = urlparse(uri)
+        port = parsed.port  # ValueError on ":evil", ":99999", ...
+    except ValueError:
+        return None
+    if not parsed.netloc:
+        return None
+    authority_start = uri.find("//")
+    if authority_start == -1:
+        return None
+    authority_start += 2
+    authority_end = authority_start + len(parsed.netloc)
+    if uri[authority_start:authority_end] != parsed.netloc:
+        return None
+    if port is None:
+        return uri
+    suffix = f":{port}"
+    netloc = parsed.netloc
+    if not netloc.endswith(suffix):
+        # e.g. ":0080" would parse as 80 but is not the literal suffix;
+        # refuse rather than guess.
+        return None
+    return uri[:authority_end - len(suffix)] + uri[authority_end:]
 
 
 def redirect_uri_matches(requested: str, registered: str) -> bool:
@@ -146,7 +168,11 @@ def redirect_uri_matches(requested: str, registered: str) -> bool:
         return False
     if not is_loopback_redirect_uri(requested):
         return False
-    return _without_port(requested) == _without_port(registered)
+    requested_stripped = _strip_loopback_port(requested)
+    registered_stripped = _strip_loopback_port(registered)
+    if requested_stripped is None or registered_stripped is None:
+        return False
+    return requested_stripped == registered_stripped
 
 
 def redirect_uri_is_registered(requested: str, registered_uris: Iterable[str]) -> bool:

--- a/src/nanoidp/services/redirect_uri.py
+++ b/src/nanoidp/services/redirect_uri.py
@@ -1,0 +1,111 @@
+"""
+Redirect URI validation and registration matching (issues #67, #81).
+
+Single home for the two questions /authorize asks about a ``redirect_uri``,
+so the GET and POST legs of the authorization endpoint (and any future
+surface) cannot drift:
+
+1. Is it syntactically acceptable at all? RFC 6749 §3.1.2: an absolute URI
+   without a fragment component. "Absolute" means a scheme is present;
+   an authority is NOT required, because native apps use private-use
+   scheme URIs such as ``com.example.app:/oauth2redirect`` (RFC 8252 §7.1)
+   that have a path but no host.
+
+2. Does it match one of the client's registered URIs? RFC 6749 §3.1.2.3 /
+   OAuth 2.1 draft §4.1.1: simple string comparison, with exactly one
+   RFC-mandated exception. RFC 8252 §7.3 requires the authorization server
+   to allow any port on loopback redirect URIs (``http://127.0.0.1:{port}/``
+   and ``http://[::1]:{port}/``), because a native app binds an ephemeral
+   port at runtime and cannot register it in advance. The OAuth 2.1 draft
+   keeps that carve-out (§4.1.1: "except for port numbers in localhost
+   redirection URIs of native apps", referring to RFC 8252 §7.3), so the
+   ``oauth21`` profile does not tighten it. Only the port component is
+   variable: scheme, host, path and query stay exact.
+
+``localhost`` is deliberately NOT a loopback host here: RFC 8252 §7.3 and
+§8.3 recommend the literal IP addresses because ``localhost`` can be
+remapped by the resolver, so a registered ``http://localhost:3000/cb`` keeps
+exact matching, port included.
+"""
+
+from typing import Iterable
+from urllib.parse import urlparse
+
+# RFC 8252 §7.3: loopback interface redirection is defined for the IPv4 and
+# IPv6 loopback literals only. urlparse().hostname strips the brackets from
+# an IPv6 literal, so "[::1]" is seen as "::1".
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
+
+
+def is_absolute_redirect_uri(uri: str) -> bool:
+    """True when ``uri`` is an absolute URI without a fragment (RFC 6749 §3.1.2).
+
+    Accepts web URIs (``https://host/path``), private-use scheme URIs with a
+    path and no authority (``com.example.app:/oauth2redirect``, RFC 8252
+    §7.1) and loopback URIs. Rejects relative references, scheme-only
+    strings and anything carrying a fragment.
+    """
+    try:
+        parsed = urlparse(uri)
+    except ValueError:
+        return False
+    if not parsed.scheme:
+        return False
+    if not parsed.netloc and not parsed.path:
+        return False
+    if parsed.fragment or uri.endswith("#"):
+        return False
+    return True
+
+
+def is_loopback_redirect_uri(uri: str) -> bool:
+    """True for ``http://127.0.0.1[:port]/...`` and ``http://[::1][:port]/...``.
+
+    RFC 8252 §7.3: only the ``http`` scheme on a loopback IP literal gets the
+    variable-port exception. ``https`` on loopback and ``localhost`` do not.
+    """
+    try:
+        parsed = urlparse(uri)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    return parsed.scheme == "http" and hostname in _LOOPBACK_HOSTS
+
+
+def _without_port(uri: str) -> str:
+    """The URI with its port component removed, for loopback comparison."""
+    parsed = urlparse(uri)
+    hostname = parsed.hostname or ""
+    if ":" in hostname:  # IPv6 literal: restore the brackets
+        hostname = f"[{hostname}]"
+    netloc = hostname
+    if parsed.username is not None:
+        userinfo = parsed.username
+        if parsed.password is not None:
+            userinfo = f"{userinfo}:{parsed.password}"
+        netloc = f"{userinfo}@{netloc}"
+    return parsed._replace(netloc=netloc).geturl()
+
+
+def redirect_uri_matches(requested: str, registered: str) -> bool:
+    """Compare a requested redirect_uri against one registered value.
+
+    Simple string comparison (RFC 6749 §3.1.2.3), except that when the
+    REGISTERED value is a loopback URI the port of the requested one is
+    ignored (RFC 8252 §7.3). The exception is keyed on the registered side
+    on purpose: a client registered with ``http://localhost:3000/cb`` or
+    ``https://app.example.com/cb`` never gains port flexibility, and a
+    requested loopback URI cannot match a non-loopback registration.
+    """
+    if requested == registered:
+        return True
+    if not is_loopback_redirect_uri(registered):
+        return False
+    if not is_loopback_redirect_uri(requested):
+        return False
+    return _without_port(requested) == _without_port(registered)
+
+
+def redirect_uri_is_registered(requested: str, registered_uris: Iterable[str]) -> bool:
+    """True when ``requested`` matches any of ``registered_uris``."""
+    return any(redirect_uri_matches(requested, registered) for registered in registered_uris)

--- a/src/nanoidp/services/redirect_uri.py
+++ b/src/nanoidp/services/redirect_uri.py
@@ -143,12 +143,13 @@ def _strip_loopback_port(uri: str) -> str | None:
         return None
     if port is None:
         return uri
-    suffix = f":{port}"
-    netloc = parsed.netloc
-    if not netloc.endswith(suffix):
-        # e.g. ":0080" would parse as 80 but is not the literal suffix;
-        # refuse rather than guess.
-        return None
+    # Remove the port component as WRITTEN, not str(port): RFC 3986 3.2.3
+    # defines port as *DIGIT, so ":0080" is a valid port component that
+    # differs from ":80" only in the component RFC 8252 8.4 tells us to
+    # ignore (#81 review). parsed.port above already validated it; for an
+    # IPv6 literal the last ":" in the authority is the one after "]".
+    raw_port = parsed.netloc.rsplit(":", 1)[1]
+    suffix = f":{raw_port}"
     return uri[:authority_end - len(suffix)] + uri[authority_end:]
 
 

--- a/src/nanoidp/services/redirect_uri.py
+++ b/src/nanoidp/services/redirect_uri.py
@@ -58,6 +58,49 @@ def is_absolute_redirect_uri(uri: str) -> bool:
     return True
 
 
+_WEB_SCHEMES = frozenset({"http", "https"})
+
+PRIVATE_SCHEME_REASON = (
+    "Invalid redirect_uri: private-use scheme must be reverse-domain based, "
+    "e.g. com.example.app:/callback (RFC 8252 section 7.1)"
+)
+
+
+def has_acceptable_scheme(uri: str) -> bool:
+    """True when the scheme is ``http``/``https`` or a reverse-domain private-use
+    scheme (RFC 8252 §7.1).
+
+    §7.1 requires private-use schemes to be based on a domain name under the
+    app's control, in reverse order (``com.example.app``), names ``myapp`` as
+    an example that does NOT qualify, and says the authorization server
+    SHOULD enforce it and at a minimum SHOULD reject schemes without a
+    period. This applies exactly that minimum rule: nanoidp cannot know which
+    domains an app controls, so full reverse-domain ownership is not
+    verified, only the presence of a period in the scheme.
+    """
+    try:
+        scheme = urlparse(uri).scheme
+    except ValueError:
+        return False
+    return scheme in _WEB_SCHEMES or "." in scheme
+
+
+def redirect_uri_rejection_reason(uri: str) -> str | None:
+    """The single syntactic gate /authorize applies to a ``redirect_uri``.
+
+    Returns ``None`` when the URI is acceptable, otherwise the
+    ``error_description`` to answer with: the generic "Invalid redirect_uri"
+    for non-absolute URIs and fragments (RFC 6749 §3.1.2), or a message that
+    names the RFC 8252 §7.1 rule for a private-use scheme without a period,
+    so a client developer learns why ``myapp://`` is not enough.
+    """
+    if not is_absolute_redirect_uri(uri):
+        return "Invalid redirect_uri"
+    if not has_acceptable_scheme(uri):
+        return PRIVATE_SCHEME_REASON
+    return None
+
+
 def is_loopback_redirect_uri(uri: str) -> bool:
     """True for ``http://127.0.0.1[:port]/...`` and ``http://[::1][:port]/...``.
 

--- a/tests/test_native_app_redirect_uris.py
+++ b/tests/test_native_app_redirect_uris.py
@@ -18,10 +18,13 @@ import pytest
 
 from nanoidp.config import ConfigManager, OAuthClient, get_config
 from nanoidp.services.redirect_uri import (
+    PRIVATE_SCHEME_REASON,
+    has_acceptable_scheme,
     is_absolute_redirect_uri,
     is_loopback_redirect_uri,
     redirect_uri_is_registered,
     redirect_uri_matches,
+    redirect_uri_rejection_reason,
 )
 
 CUSTOM_SCHEME = "com.example.app:/oauth2redirect"
@@ -31,12 +34,57 @@ LOCALHOST = "http://localhost:3000/callback"
 WEB = "https://app.example.com/cb"
 
 
+class TestPrivateUseSchemeRule:
+    """RFC 8252 §7.1 minimum rule: a private-use scheme must contain a period."""
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            CUSTOM_SCHEME,
+            "com.example.app://callback",  # authority form is fine too
+            "a.b:/x",
+            LOOPBACK_V4,
+            LOCALHOST,
+            WEB,
+        ],
+    )
+    def test_acceptable_schemes(self, uri):
+        assert has_acceptable_scheme(uri)
+        assert redirect_uri_rejection_reason(uri) is None
+
+    @pytest.mark.parametrize("uri", ["myapp://callback", "myapp:/x", "app:/cb"])
+    def test_private_scheme_without_period_rejected(self, uri):
+        assert not has_acceptable_scheme(uri)
+        assert redirect_uri_rejection_reason(uri) == PRIVATE_SCHEME_REASON
+
+    def test_non_absolute_gets_generic_reason(self):
+        assert redirect_uri_rejection_reason("/relative") == "Invalid redirect_uri"
+        assert redirect_uri_rejection_reason("https://a.example/cb#f") == "Invalid redirect_uri"
+
+    def test_authorize_rejects_myapp_scheme_with_rfc_reason(self, client):
+        """demo-client has no redirect_uris, so only the syntactic gate applies."""
+        response = client.get(
+            "/authorize",
+            query_string={
+                "response_type": "code",
+                "client_id": "demo-client",
+                "redirect_uri": "myapp://callback",
+                "scope": "openid",
+            },
+        )
+        assert response.status_code == 400
+        assert "Location" not in response.headers
+        body = response.get_json()
+        assert body["error"] == "invalid_request"
+        assert "RFC 8252 section 7.1" in body["error_description"]
+
+
 class TestIsAbsoluteRedirectUri:
     @pytest.mark.parametrize(
         "uri",
         [
             CUSTOM_SCHEME,
-            "myapp://callback",
+            "myapp://callback",  # absolute; the scheme rule is a separate gate
             LOOPBACK_V4,
             LOOPBACK_V6,
             "http://127.0.0.1/callback",

--- a/tests/test_native_app_redirect_uris.py
+++ b/tests/test_native_app_redirect_uris.py
@@ -390,3 +390,46 @@ class TestRegistrationSurfacesAcceptNativeUris:
         # and the registration is honoured end-to-end
         assert _authorize(client, "ui-native", "http://127.0.0.1:7/callback").status_code == 200
         assert _authorize(client, "ui-native", LOCALHOST).status_code == 400
+
+
+class TestLoopbackPortExceptionTouchesOnlyThePort:
+    """#81 review: the port exception must relax the port and nothing else.
+
+    The previous implementation re-serialized the parsed URI, which
+    normalized scheme case, dropped an empty query and never validated the
+    port, so ``:evil`` was silently stripped. The comparison now slices only
+    the port substring out of the ORIGINAL string.
+    """
+
+    REGISTERED = "http://127.0.0.1:0/cb"
+
+    @pytest.mark.parametrize(
+        "requested",
+        [
+            "http://127.0.0.1:evil/cb",     # non-numeric port
+            "http://127.0.0.1:99999/cb",    # out-of-range port
+            "http://127.0.0.1:123/cb?",     # empty query is not "no query"
+            "HTTP://127.0.0.1:123/cb",      # scheme case preserved
+            "http://127.0.0.1:123/cb/",     # trailing slash
+            "http://127.0.0.1:123/CB",      # path case
+            "http://127.0.0.1:0080/cb",     # zero-padded port is not a port literal
+            "http://user@127.0.0.1:123/cb", # userinfo differs
+        ],
+    )
+    def test_rejected(self, requested):
+        assert not redirect_uri_matches(requested, self.REGISTERED)
+
+    @pytest.mark.parametrize(
+        "requested",
+        ["http://127.0.0.1:123/cb", "http://127.0.0.1:65535/cb", "http://127.0.0.1/cb"],
+    )
+    def test_accepted(self, requested):
+        assert redirect_uri_matches(requested, self.REGISTERED)
+
+    def test_ipv6_only_port_varies(self):
+        assert redirect_uri_matches("http://[::1]:4242/cb", "http://[::1]:0/cb")
+        assert not redirect_uri_matches("http://[::1]:4242/cb?", "http://[::1]:0/cb")
+        assert not redirect_uri_matches("http://[::1]:evil/cb", "http://[::1]:0/cb")
+
+    def test_registered_with_invalid_port_never_matches(self):
+        assert not redirect_uri_matches("http://127.0.0.1:123/cb", "http://127.0.0.1:evil/cb")

--- a/tests/test_native_app_redirect_uris.py
+++ b/tests/test_native_app_redirect_uris.py
@@ -412,7 +412,6 @@ class TestLoopbackPortExceptionTouchesOnlyThePort:
             "HTTP://127.0.0.1:123/cb",      # scheme case preserved
             "http://127.0.0.1:123/cb/",     # trailing slash
             "http://127.0.0.1:123/CB",      # path case
-            "http://127.0.0.1:0080/cb",     # zero-padded port is not a port literal
             "http://user@127.0.0.1:123/cb", # userinfo differs
         ],
     )
@@ -421,7 +420,15 @@ class TestLoopbackPortExceptionTouchesOnlyThePort:
 
     @pytest.mark.parametrize(
         "requested",
-        ["http://127.0.0.1:123/cb", "http://127.0.0.1:65535/cb", "http://127.0.0.1/cb"],
+        [
+            "http://127.0.0.1:123/cb",
+            "http://127.0.0.1:65535/cb",
+            "http://127.0.0.1/cb",
+            # RFC 3986 3.2.3: port = *DIGIT, so a zero-padded port is a valid
+            # port component and only the port differs (RFC 8252 8.4).
+            "http://127.0.0.1:0080/cb",
+            "http://127.0.0.1:00/cb",
+        ],
     )
     def test_accepted(self, requested):
         assert redirect_uri_matches(requested, self.REGISTERED)
@@ -430,6 +437,7 @@ class TestLoopbackPortExceptionTouchesOnlyThePort:
         assert redirect_uri_matches("http://[::1]:4242/cb", "http://[::1]:0/cb")
         assert not redirect_uri_matches("http://[::1]:4242/cb?", "http://[::1]:0/cb")
         assert not redirect_uri_matches("http://[::1]:evil/cb", "http://[::1]:0/cb")
+        assert redirect_uri_matches("http://[::1]:0042/cb", "http://[::1]:0/cb")
 
     def test_registered_with_invalid_port_never_matches(self):
         assert not redirect_uri_matches("http://127.0.0.1:123/cb", "http://127.0.0.1:evil/cb")

--- a/tests/test_native_app_redirect_uris.py
+++ b/tests/test_native_app_redirect_uris.py
@@ -1,0 +1,344 @@
+"""
+Native-app redirect URIs on /authorize (issue #81, RFC 8252).
+
+Two additive relaxations of the web-client assumptions from #67:
+
+- RFC 8252 §7.1: private-use scheme URIs (``com.example.app:/oauth2redirect``)
+  have a scheme and a path but no authority; they are absolute URIs and
+  must pass syntactic validation (RFC 6749 §3.1.2).
+- RFC 8252 §7.3: a registered loopback URI (``http://127.0.0.1:{port}/...``,
+  ``http://[::1]:{port}/...``) must match any port, because native apps bind
+  an ephemeral port. Everything else keeps exact string matching, and
+  ``localhost`` gets no port flexibility.
+"""
+
+import json
+
+import pytest
+
+from nanoidp.config import ConfigManager, OAuthClient, get_config
+from nanoidp.services.redirect_uri import (
+    is_absolute_redirect_uri,
+    is_loopback_redirect_uri,
+    redirect_uri_is_registered,
+    redirect_uri_matches,
+)
+
+CUSTOM_SCHEME = "com.example.app:/oauth2redirect"
+LOOPBACK_V4 = "http://127.0.0.1:0/callback"
+LOOPBACK_V6 = "http://[::1]:0/callback"
+LOCALHOST = "http://localhost:3000/callback"
+WEB = "https://app.example.com/cb"
+
+
+class TestIsAbsoluteRedirectUri:
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            CUSTOM_SCHEME,
+            "myapp://callback",
+            LOOPBACK_V4,
+            LOOPBACK_V6,
+            "http://127.0.0.1/callback",
+            LOCALHOST,
+            WEB,
+            "https://app.example.com/cb?state=keep",
+        ],
+    )
+    def test_absolute_uris_accepted(self, uri):
+        assert is_absolute_redirect_uri(uri)
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "/relative/path",  # no scheme (RFC 6749 §3.1.2: absolute URI)
+            "callback",
+            "",
+            "com.example.app:",  # scheme only, no path and no authority
+            "https://app.example.com/cb#frag",  # §3.1.2: no fragment
+            "https://app.example.com/cb#",
+            "com.example.app:/cb#x",
+        ],
+    )
+    def test_non_absolute_or_fragment_rejected(self, uri):
+        assert not is_absolute_redirect_uri(uri)
+
+
+class TestIsLoopbackRedirectUri:
+    @pytest.mark.parametrize(
+        "uri",
+        [LOOPBACK_V4, LOOPBACK_V6, "http://127.0.0.1/cb", "http://[::1]/cb"],
+    )
+    def test_loopback_literals(self, uri):
+        assert is_loopback_redirect_uri(uri)
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            LOCALHOST,  # §7.3 / §8.3: "localhost" is not the loopback literal
+            "https://127.0.0.1:3000/cb",  # only http gets the exception
+            "http://127.0.0.2/cb",
+            "http://10.0.0.1/cb",
+            CUSTOM_SCHEME,
+            WEB,
+        ],
+    )
+    def test_everything_else(self, uri):
+        assert not is_loopback_redirect_uri(uri)
+
+
+class TestRedirectUriMatches:
+    @pytest.mark.parametrize(
+        "requested,registered",
+        [
+            ("http://127.0.0.1:51234/callback", LOOPBACK_V4),
+            ("http://127.0.0.1/callback", LOOPBACK_V4),
+            ("http://127.0.0.1:51234/callback", "http://127.0.0.1/callback"),
+            ("http://[::1]:51234/callback", LOOPBACK_V6),
+            ("http://[::1]/callback", "http://[::1]:9/callback"),
+            ("http://127.0.0.1:5/cb?x=1", "http://127.0.0.1:9/cb?x=1"),
+            (CUSTOM_SCHEME, CUSTOM_SCHEME),
+            (WEB, WEB),
+            (LOCALHOST, LOCALHOST),
+        ],
+    )
+    def test_matches(self, requested, registered):
+        assert redirect_uri_matches(requested, registered)
+
+    @pytest.mark.parametrize(
+        "requested,registered",
+        [
+            ("http://localhost:3001/callback", LOCALHOST),  # localhost: exact port
+            ("http://127.0.0.1:5/callback", LOCALHOST),  # loopback vs localhost
+            ("http://localhost:5/callback", LOOPBACK_V4),
+            ("https://app.example.com:444/cb", WEB),  # non-loopback: exact port
+            ("http://127.0.0.1:5/other", LOOPBACK_V4),  # path stays exact
+            ("http://127.0.0.1:5/callback/", LOOPBACK_V4),
+            ("http://127.0.0.1:5/callback?x=1", LOOPBACK_V4),  # query stays exact
+            ("https://127.0.0.1:5/callback", LOOPBACK_V4),  # scheme stays exact
+            ("http://[::1]:5/callback", LOOPBACK_V4),  # v6 vs v4 literal
+            ("http://127.0.0.2:5/callback", LOOPBACK_V4),
+            ("com.example.app:/other", CUSTOM_SCHEME),
+            ("com.example.evil:/oauth2redirect", CUSTOM_SCHEME),
+        ],
+    )
+    def test_mismatches(self, requested, registered):
+        assert not redirect_uri_matches(requested, registered)
+
+    def test_is_registered_scans_every_entry(self):
+        registered = [WEB, LOOPBACK_V4, CUSTOM_SCHEME]
+        assert redirect_uri_is_registered("http://127.0.0.1:9999/callback", registered)
+        assert redirect_uri_is_registered(CUSTOM_SCHEME, registered)
+        assert not redirect_uri_is_registered("http://localhost:9999/callback", registered)
+        assert not redirect_uri_is_registered(WEB, [])
+
+
+@pytest.fixture
+def native_client(app):
+    """A client registered the way a native app would be (RFC 8252)."""
+    with app.app_context():
+        get_config().settings.clients.append(
+            OAuthClient(
+                client_id="native-client",
+                client_secret="native-secret",
+                redirect_uris=[CUSTOM_SCHEME, LOOPBACK_V4, LOOPBACK_V6, LOCALHOST],
+            )
+        )
+    return "native-client"
+
+
+def _authorize(client, client_id, redirect_uri):
+    return client.get(
+        "/authorize",
+        query_string={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "openid",
+        },
+    )
+
+
+class TestAuthorizeNativeApp:
+    """The accept/reject matrix on the live endpoint."""
+
+    @pytest.mark.parametrize(
+        "redirect_uri",
+        [
+            CUSTOM_SCHEME,
+            "http://127.0.0.1:51234/callback",
+            "http://127.0.0.1/callback",
+            "http://[::1]:51234/callback",
+            LOCALHOST,
+        ],
+    )
+    def test_accepted(self, client, native_client, redirect_uri):
+        response = _authorize(client, native_client, redirect_uri)
+        assert response.status_code == 200
+        assert b"username" in response.data  # login form rendered
+
+    @pytest.mark.parametrize(
+        "redirect_uri",
+        [
+            "http://localhost:3001/callback",  # localhost keeps exact port
+            "http://127.0.0.1:51234/other",  # loopback path stays exact
+            "https://127.0.0.1:51234/callback",  # https loopback: no exception
+            "com.example.evil:/oauth2redirect",  # different private scheme
+            "com.example.app:/oauth2redirect/extra",
+        ],
+    )
+    def test_rejected_without_redirect(self, client, native_client, redirect_uri):
+        response = _authorize(client, native_client, redirect_uri)
+        assert response.status_code == 400
+        assert "Location" not in response.headers  # §3.1.2.4
+        data = json.loads(response.data)
+        assert data["error"] == "invalid_request"
+        assert "not registered" in data["error_description"]
+
+    def test_non_loopback_registration_gets_no_port_flexibility(self, client, app):
+        with app.app_context():
+            get_config().settings.clients.append(
+                OAuthClient(
+                    client_id="web-only", client_secret="s", redirect_uris=[WEB]
+                )
+            )
+        assert _authorize(client, "web-only", WEB).status_code == 200
+        assert (
+            _authorize(client, "web-only", "https://app.example.com:444/cb").status_code
+            == 400
+        )
+
+    def test_unregistered_client_accepts_custom_scheme(self, client):
+        """demo-client has no redirect_uris: a private-use scheme URI is a
+        valid absolute URI and is accepted like any other."""
+        assert _authorize(client, "demo-client", CUSTOM_SCHEME).status_code == 200
+
+    @pytest.mark.parametrize("redirect_uri", ["/relative", "https://a.example/cb#frag"])
+    def test_non_absolute_still_invalid(self, client, redirect_uri):
+        response = _authorize(client, "demo-client", redirect_uri)
+        assert response.status_code == 400
+        assert json.loads(response.data)["error_description"] == "Invalid redirect_uri"
+
+    def test_loopback_flow_completes_and_redirects_to_ephemeral_port(
+        self, client, native_client
+    ):
+        """The login POST leg uses the same matcher and redirects to the
+        port the app actually asked for, not the registered placeholder."""
+        response = client.post(
+            "/authorize",
+            data={
+                "response_type": "code",
+                "client_id": native_client,
+                "redirect_uri": "http://127.0.0.1:51234/callback",
+                "scope": "openid",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith("http://127.0.0.1:51234/callback?")
+        assert "code=" in response.headers["Location"]
+
+    def test_custom_scheme_flow_redirects_to_app_scheme(self, client, native_client):
+        response = client.post(
+            "/authorize",
+            data={
+                "response_type": "code",
+                "client_id": native_client,
+                "redirect_uri": CUSTOM_SCHEME,
+                "scope": "openid",
+                "username": "admin",
+                "password": "admin",
+            },
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith(CUSTOM_SCHEME + "?")
+
+    def test_oauth21_profile_keeps_loopback_port_exception(self, client, app, native_client):
+        """OAuth 2.1 draft §4.1.1 carves out native-app loopback ports
+        (RFC 8252 §7.3); the profile must not tighten it away."""
+        # oauth21 also mandates PKCE, so send a challenge: the only variable
+        # under test here is the redirect_uri matcher.
+        pkce = {"code_challenge": "E" * 43, "code_challenge_method": "S256"}
+        with app.app_context():
+            get_config().settings.security_profile = "oauth21"
+        try:
+            response = client.get(
+                "/authorize",
+                query_string={
+                    "response_type": "code",
+                    "client_id": native_client,
+                    "redirect_uri": "http://127.0.0.1:51234/callback",
+                    "scope": "openid",
+                    **pkce,
+                },
+            )
+            assert response.status_code == 200
+            response = client.get(
+                "/authorize",
+                query_string={
+                    "response_type": "code",
+                    "client_id": native_client,
+                    "redirect_uri": "http://localhost:3001/callback",
+                    "scope": "openid",
+                    **pkce,
+                },
+            )
+            assert response.status_code == 400
+            assert "not registered" in json.loads(response.data)["error_description"]
+        finally:
+            with app.app_context():
+                get_config().settings.security_profile = "dev"
+
+
+class TestRegistrationSurfacesAcceptNativeUris:
+    """UI, /api and MCP registration paths store native-app URIs verbatim."""
+
+    def _config(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            "oauth:\n"
+            '  issuer: "http://localhost:8000"\n'
+            "  clients:\n"
+            '    - client_id: "test"\n'
+            '      client_secret: "test"\n'
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        return ConfigManager(str(config_dir))
+
+    async def test_mcp_create_client_with_native_uris(self, tmp_path):
+        from nanoidp.mcp_server import _execute_tool
+
+        config = self._config(tmp_path)
+        result = await _execute_tool(
+            "create_client",
+            {
+                "client_id": "native",
+                "client_secret": "s",
+                "redirect_uris": [CUSTOM_SCHEME, LOOPBACK_V4],
+            },
+            config,
+        )
+        assert result["success"] is True
+        assert config.get_client("native").redirect_uris == [CUSTOM_SCHEME, LOOPBACK_V4]
+
+    def test_ui_create_client_with_native_uris(self, client, app):
+        response = client.post(
+            "/clients/create",
+            data={
+                "client_id": "ui-native",
+                "client_secret": "s",
+                "redirect_uris": f"{CUSTOM_SCHEME}\n{LOOPBACK_V4}",
+            },
+        )
+        assert response.status_code in (302, 303)
+        with app.app_context():
+            stored = get_config().get_client("ui-native")
+        assert stored is not None
+        assert stored.redirect_uris == [CUSTOM_SCHEME, LOOPBACK_V4]
+        # and the registration is honoured end-to-end
+        assert _authorize(client, "ui-native", "http://127.0.0.1:7/callback").status_code == 200
+        assert _authorize(client, "ui-native", LOCALHOST).status_code == 400


### PR DESCRIPTION
Closes #81.

Native-app redirect URIs per RFC 8252, both changes additive and cited in code:

- **Syntax** (`is_absolute_redirect_uri`): scheme required, authority optional when a path is present, so `com.example.app:/oauth2redirect` (RFC 8252 section 7.1) is accepted; relative references and fragments rejected (RFC 6749 section 3.1.2). Fragments were previously let through by the `scheme and netloc` check; now rejected, noted in the CHANGELOG.
- **Matching** (`redirect_uri_matches`): exact string comparison everywhere, with the single RFC-mandated exception: when the REGISTERED URI is `http://127.0.0.1[:port]/...` or `http://[::1][:port]/...`, the requested port is ignored (RFC 8252 section 7.3); scheme, host, path and query stay exact. Keyed on the registered side so a web or `localhost` registration never gains port flexibility. `localhost` is deliberately not loopback here (sections 7.3 and 8.3). The OAuth 2.1 draft keeps the carve-out (section 4.1.1), so `oauth21` does not tighten it; a test pins that.
- One shared helper, `services/redirect_uri.py`, used by both legs of `/authorize`. The token endpoint's check compares against the URI used at `/authorize` (RFC 6749 section 4.1.3 "identical"), so exact compare stays correct there and is unchanged.
- Parity: `models.py` field description and the MCP `create_client`/`update_client` schema descriptions updated; `examples/test_agent.py` gets `test_native_app_redirect_uris` (registers a client via the UI form, 6-case matrix incl. negatives, completes the loopback flow, cleans up). Docs: "Native apps (RFC 8252)" paragraph in `configuration.md`.

## Verification

- `tests/test_native_app_redirect_uris.py`: 66 cases (helper matrices, `/authorize` accept/reject matrix with no-redirect assertions on rejects, oauth21 profile, UI/API/MCP registration storing native URIs verbatim). Full suite 1100 passed, ruff and mypy clean.
- Live (client registered with `com.example.app:/oauth2redirect`, `http://127.0.0.1:0/callback`, `http://localhost:3000/callback`, `https://app.example.com/cb`): custom scheme 200, `127.0.0.1:51234` 200, `[::1]:7` 400 (only v4 registered), `localhost:3001` 400, `app.example.com:444` 400, `127.0.0.1:51234/other` 400, `https://127.0.0.1:5` 400, `/relative` and `#frag` 400 "Invalid redirect_uri"; login POST leg 302s to `http://127.0.0.1:51234/callback?code=...` and to `com.example.app:/oauth2redirect?code=...`. `test_agent.py` 50/50 including the new test.
