### PR TITLE
fix: derive SAML entity_id/sso_url from the effective issuer when unset (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   file" use case only worked for settings. A UI/MCP save of one user still
   rewrites only that user's entry; the MCP `save_config` tool rewrites the
   whole map and materializes expanded placeholders, as documented.
+- **SAML `entity_id`/`sso_url` follow the effective issuer** (#181). With
+  `oauth.issuer_from_request` on (or behind a proxy), OIDC discovery reflected
+  the request host while `/saml/metadata`, the `<Issuer>` in responses and
+  assertions and the SSO location kept the fixed `http://localhost:8000/...`
+  strings. Both settings are now optional: absent (or blank in the UI/MCP)
+  means derived as `<effective issuer>/saml` and `<effective issuer>/saml/sso`
+  through one helper shared by every SAML surface, an explicit value still
+  wins, and a derived value is never written back to `settings.yaml`. SAML 2.0
+  Metadata 2.3.2 requires `entityID` to be the value used as `<Issuer>` (Core
+  2.2.5). `/api/config` and the MCP `get_settings` tool report the effective
+  values plus `entity_id_derived`/`sso_url_derived`; `update_settings` gains
+  `saml_entity_id`/`saml_sso_url` (empty string clears); the e2e agent checks
+  metadata against discovery and no longer posts derived values back as
+  explicit ones.
 - **Example presets now bind to `127.0.0.1`** (#164). All four pre-2.6.0
   presets (`cli-device-flow`, `microservices-client-credentials`,
   `react-spa-pkce`, `spring-boot-saml`) still shipped an explicit

--- a/book/src/guides/reverse-proxy.md
+++ b/book/src/guides/reverse-proxy.md
@@ -214,3 +214,17 @@ environment:
   the trust model behind `issuer_from_request`
 - [Endpoints reference](../reference/endpoints.md) - `GET /api/config`,
   `POST /api/config/reload`
+
+## SAML metadata follows the issuer
+
+`saml.entity_id` and `saml.sso_url` are optional. When they are absent from
+`settings.yaml`, nanoidp derives them from the effective issuer as
+`<issuer>/saml` and `<issuer>/saml/sso`, so `/saml/metadata`, the `<Issuer>`
+in responses and assertions, and OIDC discovery all name the same origin under
+every option above (fixed issuer, request-derived issuer, proxy headers,
+allowlist). Nothing SAML-specific needs to be configured for a proxy.
+
+Set them explicitly only when the SP expects a fixed, different value; an
+explicit value always wins and does not follow the request. `GET /api/config`
+reports the effective values together with `entity_id_derived` /
+`sso_url_derived` so you can tell which case applies.

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -166,8 +166,12 @@ oauth:
   # logos_dir: "./static/logos"    # optional; defaults to src/nanoidp/static/logos
 
 saml:
-  entity_id: "http://localhost:8000/saml"
-  sso_url: "http://localhost:8000/saml/sso"
+  # Both optional: when absent they are derived from the effective issuer as
+  # <issuer>/saml and <issuer>/saml/sso, so they follow issuer_from_request and
+  # the reverse-proxy settings exactly like OIDC discovery does (#181). Set
+  # them only when the SP needs a different, fixed value.
+  # entity_id: "http://localhost:8000/saml"
+  # sso_url: "http://localhost:8000/saml/sso"
   default_acs_url: "http://localhost:8080/login/saml2/sso/nanoidp"
   sign_responses: true  # Set to false for testing unsigned SAML flows
   want_authn_requests_signed: false  # verify AuthnRequest signatures (see SAML options)

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -43,8 +43,11 @@ oauth:
   issuer_from_proxy_headers: false
   # logos_dir: ./static/logos  # optional override; defaults to src/nanoidp/static/logos
 saml:
-  entity_id: http://localhost:${PORT:8000}/saml
-  sso_url: http://localhost:${PORT:8000}/saml/sso
+  # entity_id / sso_url: absent = derived from the effective issuer as
+  # <issuer>/saml and <issuer>/saml/sso (follows issuer_from_request); set
+  # them only to pin a fixed value
+  # entity_id: http://localhost:${PORT:8000}/saml
+  # sso_url: http://localhost:${PORT:8000}/saml/sso
   default_acs_url: http://localhost:8080/login/saml2/sso/nanoidp
   sign_responses: true
   c14n_algorithm: exc_c14n
@@ -54,6 +57,8 @@ saml:
   export_groups: false
   roles_attr_name: roles
   groups_attr_name: groups
+  entity_id: http://localhost:8000/saml
+  sso_url: http://localhost:8000/saml/sso
 jwt:
   algorithm: RS256
   keys_dir: ./keys

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -57,8 +57,6 @@ saml:
   export_groups: false
   roles_attr_name: roles
   groups_attr_name: groups
-  entity_id: http://localhost:8000/saml
-  sso_url: http://localhost:8000/saml/sso
 jwt:
   algorithm: RS256
   keys_dir: ./keys

--- a/examples/spring-boot-saml/settings.yaml
+++ b/examples/spring-boot-saml/settings.yaml
@@ -16,8 +16,11 @@ oauth:
       description: "Spring Boot SAML application"
 
 saml:
-  entity_id: "http://localhost:8000/saml"
-  sso_url: "http://localhost:8000/saml/sso"
+  # entity_id / sso_url: absent = derived from the effective issuer as
+  # <issuer>/saml and <issuer>/saml/sso (follows issuer_from_request); set
+  # them only to pin a fixed value
+  # entity_id: "http://localhost:8000/saml"
+  # sso_url: "http://localhost:8000/saml/sso"
   # Change this to match your Spring Boot app's ACS URL
   default_acs_url: "http://localhost:8080/login/saml2/sso/nanoidp"
   # Export roles/groups as SAML attributes (off by default in NanoIDP)

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -1758,6 +1758,54 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("SAML Metadata", TestCategory.SAML, False, str(e))
 
+    def test_saml_metadata_follows_issuer(self) -> TestResult:
+        """SAML metadata entityID / SSO location follow the effective issuer (#181).
+
+        Reads /api/config: when entity_id / sso_url are derived, metadata must
+        advertise <discovery issuer>/saml and <discovery issuer>/saml/sso for
+        the same Host the agent uses (so it tracks issuer_from_request like
+        OIDC does); when explicit, metadata must carry the explicit values
+        verbatim. Either way metadata, /api/config and discovery agree.
+        """
+        try:
+            cfg = self.session.get(f"{self.base_url}/api/config", timeout=5).json()
+            saml_cfg = cfg.get("saml", {})
+            for key in ("entity_id", "entity_id_derived", "sso_url", "sso_url_derived"):
+                if key not in saml_cfg:
+                    return self._add_result(
+                        "SAML Metadata Follows Issuer", TestCategory.SAML, False,
+                        f"/api/config saml lacks {key}", saml_cfg,
+                    )
+            discovery = self.session.get(
+                f"{self.base_url}/.well-known/openid-configuration", timeout=5
+            ).json()
+            issuer = discovery.get("issuer", "").rstrip("/")
+            metadata = self.session.get(f"{self.base_url}/saml/metadata", timeout=5)
+            root = ET.fromstring(metadata.text)
+            entity_id = root.get("entityID")
+            locations = {
+                el.get("Location")
+                for el in root.iter("{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService")
+            }
+            expected_entity = f"{issuer}/saml" if saml_cfg["entity_id_derived"] else saml_cfg["entity_id"]
+            expected_sso = f"{issuer}/saml/sso" if saml_cfg["sso_url_derived"] else saml_cfg["sso_url"]
+            ok = (
+                entity_id == expected_entity
+                and locations == {expected_sso}
+                and saml_cfg["entity_id"] == expected_entity
+                and saml_cfg["sso_url"] == expected_sso
+            )
+            return self._add_result(
+                "SAML Metadata Follows Issuer",
+                TestCategory.SAML,
+                ok,
+                f"entityID={entity_id} (derived={saml_cfg['entity_id_derived']}), "
+                f"sso={sorted(locations)}, issuer={issuer}",
+                {"entity_id": entity_id, "locations": sorted(locations), "expected": [expected_entity, expected_sso]},
+            )
+        except Exception as e:
+            return self._add_result("SAML Metadata Follows Issuer", TestCategory.SAML, False, str(e))
+
     def test_saml_sso_post_binding(self) -> TestResult:
         """SAML SSO endpoint with HTTP-POST binding (uncompressed request).
 
@@ -2208,8 +2256,10 @@ class NanoIDPTestAgent:
                     "issuer": config.get("oauth", {}).get("issuer", "http://localhost:8000"),
                     "audience": config.get("oauth", {}).get("audience", "default"),
                     "token_expiry_minutes": config.get("oauth", {}).get("token_expiry_minutes", 60),
-                    "saml_entity_id": saml_config.get("entity_id", "http://localhost:8000/saml"),
-                    "saml_sso_url": saml_config.get("sso_url", "http://localhost:8000/saml/sso"),
+                    # Derived values (#181) go back as blank, or the round-trip
+                    # would freeze them into explicit settings.
+                    "saml_entity_id": "" if saml_config.get("entity_id_derived") else saml_config.get("entity_id", ""),
+                    "saml_sso_url": "" if saml_config.get("sso_url_derived") else saml_config.get("sso_url", ""),
                     "default_acs_url": saml_config.get("default_acs_url", ""),
                     "saml_sign_responses": "true" if sign_responses else "",
                     "strict_saml_binding": "true" if saml_config.get("strict_binding", False) else "",
@@ -2261,8 +2311,10 @@ class NanoIDPTestAgent:
                     "issuer": config.get("oauth", {}).get("issuer", "http://localhost:8000"),
                     "audience": config.get("oauth", {}).get("audience", "default"),
                     "token_expiry_minutes": config.get("oauth", {}).get("token_expiry_minutes", 60),
-                    "saml_entity_id": saml_config.get("entity_id", "http://localhost:8000/saml"),
-                    "saml_sso_url": saml_config.get("sso_url", "http://localhost:8000/saml/sso"),
+                    # Derived values (#181) go back as blank, or the round-trip
+                    # would freeze them into explicit settings.
+                    "saml_entity_id": "" if saml_config.get("entity_id_derived") else saml_config.get("entity_id", ""),
+                    "saml_sso_url": "" if saml_config.get("sso_url_derived") else saml_config.get("sso_url", ""),
                     "default_acs_url": saml_config.get("default_acs_url", ""),
                     "saml_sign_responses": "true" if sign_responses else "",
                     "strict_saml_binding": "true" if saml_config.get("strict_binding", False) else "",
@@ -3708,6 +3760,7 @@ class NanoIDPTestAgent:
             ]),
             (TestCategory.SAML, "SAML 2.0", [
                 self.test_saml_metadata,
+                self.test_saml_metadata_follows_issuer,
                 self.test_saml_metadata_bindings,
                 self.test_saml_sso_post_binding,
                 self.test_saml_sso_redirect_binding,

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -74,8 +74,11 @@ oauth:
       description: "Default demo client"
 
 saml:
-  entity_id: "http://localhost:8000/saml"
-  sso_url: "http://localhost:8000/saml/sso"
+  # entity_id / sso_url: absent = derived from the effective issuer as
+  # <issuer>/saml and <issuer>/saml/sso (follows issuer_from_request); set
+  # them only to pin a fixed value
+  # entity_id: "http://localhost:8000/saml"
+  # sso_url: "http://localhost:8000/saml/sso"
   default_acs_url: "http://localhost:8080/login/saml2/sso/nanoidp"
   # Roles/groups are not standard SAML attributes; enable and name them here.
   export_roles: false

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -225,8 +225,9 @@ class ConfigManager:
             clients=clients,
             logos_dir=oauth.get("logos_dir"),
             # SAML
-            saml_entity_id=saml.get("entity_id", "http://localhost:8000/saml"),
-            saml_sso_url=saml.get("sso_url", "http://localhost:8000/saml/sso"),
+            # Absent or blank = derived from the effective issuer (#181).
+            saml_entity_id=saml.get("entity_id") or None,
+            saml_sso_url=saml.get("sso_url") or None,
             default_acs_url=saml.get("default_acs_url", "http://localhost:8080/login/saml2/sso/samlIdp"),
             saml_sign_responses=saml.get("sign_responses", True),
             saml_export_roles=saml.get("export_roles", False),

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -736,6 +736,17 @@ _TOOLS: list[Tool] = [
                     "type": "integer",
                     "description": "Token expiration in minutes",
                 },
+                "saml_entity_id": {
+                    "type": "string",
+                    "description": "SAML IdP entityID. Empty string clears it so "
+                    "it is derived again from the effective issuer as "
+                    "<issuer>/saml (#181)",
+                },
+                "saml_sso_url": {
+                    "type": "string",
+                    "description": "SAML SingleSignOnService location. Empty string "
+                    "clears it so it is derived again as <issuer>/saml/sso (#181)",
+                },
                 "saml_sign_responses": {
                     "type": "boolean",
                     "description": "Enable/disable SAML response signing",
@@ -1256,8 +1267,13 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             "require_pkce": settings.require_pkce,
             "jwt_algorithm": settings.jwt_algorithm,
             "saml": {
-                "entity_id": settings.saml_entity_id,
-                "sso_url": settings.saml_sso_url,
+                # MCP has no HTTP request, so derived values (#181) resolve
+                # against the fixed settings.issuer, the same exception the
+                # MCP discovery tools already make for issuer_from_request.
+                "entity_id": settings.resolve_saml_entity_id(settings.issuer),
+                "entity_id_derived": settings.saml_entity_id is None,
+                "sso_url": settings.resolve_saml_sso_url(settings.issuer),
+                "sso_url_derived": settings.saml_sso_url is None,
                 "sign_responses": settings.saml_sign_responses,
                 "c14n_algorithm": settings.saml_c14n_algorithm,
                 "strict_binding": settings.strict_saml_binding,
@@ -1314,6 +1330,13 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         if "token_expiry_minutes" in arguments:
             settings.token_expiry_minutes = arguments["token_expiry_minutes"]
             updated.append("token_expiry_minutes")
+        if "saml_entity_id" in arguments:
+            # "" = back to derived (#181), mirroring the UI form's blank field
+            settings.saml_entity_id = arguments["saml_entity_id"] or None
+            updated.append("saml_entity_id")
+        if "saml_sso_url" in arguments:
+            settings.saml_sso_url = arguments["saml_sso_url"] or None
+            updated.append("saml_sso_url")
         if "saml_sign_responses" in arguments:
             settings.saml_sign_responses = arguments["saml_sign_responses"]
             updated.append("saml_sign_responses")

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -231,8 +231,21 @@ class Settings(BaseModel):
     )
 
     # SAML
-    saml_entity_id: str = Field(default="http://localhost:8000/saml", description="SAML entity ID")
-    saml_sso_url: str = Field(default="http://localhost:8000/saml/sso", description="SAML SSO URL")
+    # None means "derived from the effective issuer" (#181): <issuer>/saml and
+    # <issuer>/saml/sso, where the issuer follows issuer_from_request, the
+    # proxy headers and the allowlist exactly as OIDC discovery does. An
+    # explicit value wins. SAML 2.0 Metadata 2.3.2 requires entityID to be the
+    # value the IdP uses as <Issuer> (Core 2.2.5), so every SAML surface reads
+    # these through resolve_saml_entity_id()/resolve_saml_sso_url(), never the
+    # raw fields.
+    saml_entity_id: Optional[str] = Field(
+        default=None,
+        description="SAML entity ID; unset = derived from the effective issuer as <issuer>/saml",
+    )
+    saml_sso_url: Optional[str] = Field(
+        default=None,
+        description="SAML SSO URL; unset = derived from the effective issuer as <issuer>/saml/sso",
+    )
     default_acs_url: str = Field(default="http://localhost:8080/login/saml2/sso/samlIdp", description="Default ACS URL")
     saml_sign_responses: bool = Field(default=True, description="Sign SAML responses (set to false for testing unsigned flows)")
     saml_export_roles: bool = Field(
@@ -354,6 +367,14 @@ class Settings(BaseModel):
     @classmethod
     def _validate_saml_attr_name(cls, v: Any, info: ValidationInfo) -> str:
         return normalize_saml_attr_name(str(info.field_name), v)
+
+    def resolve_saml_entity_id(self, issuer: str) -> str:
+        """The entityID to advertise for ``issuer``: explicit value, else derived (#181)."""
+        return self.saml_entity_id or f"{issuer.rstrip('/')}/saml"
+
+    def resolve_saml_sso_url(self, issuer: str) -> str:
+        """The SSO location to advertise for ``issuer``: explicit value, else derived (#181)."""
+        return self.saml_sso_url or f"{issuer.rstrip('/')}/saml/sso"
 
     @field_validator("security_profile")
     @classmethod

--- a/src/nanoidp/routes/_issuer.py
+++ b/src/nanoidp/routes/_issuer.py
@@ -35,3 +35,20 @@ def effective_issuer(settings: Settings) -> str:
     if settings.issuer_allowlist and candidate not in settings.issuer_allowlist:
         return settings.issuer
     return candidate
+
+
+def effective_saml_entity_id(settings: Settings) -> str:
+    """SAML entityID for the current request (#181).
+
+    Explicit ``saml.entity_id`` wins; otherwise ``<effective issuer>/saml``,
+    so the metadata a SAML SP fetches through a proxy or a second hostname
+    names the same origin OIDC discovery does. SAML 2.0 Metadata 2.3.2:
+    ``entityID`` is the unique identifier the entity uses as ``<Issuer>``
+    (Core 2.2.5), which is why responses and assertions call this too.
+    """
+    return settings.resolve_saml_entity_id(effective_issuer(settings))
+
+
+def effective_saml_sso_url(settings: Settings) -> str:
+    """SAML SingleSignOnService location for the current request (#181)."""
+    return settings.resolve_saml_sso_url(effective_issuer(settings))

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -9,7 +9,7 @@ from flask.typing import ResponseReturnValue
 
 from ..config import get_config
 from ..services import get_audit_log, get_token_service
-from ._issuer import effective_issuer
+from ._issuer import effective_issuer, effective_saml_entity_id, effective_saml_sso_url
 
 logger = logging.getLogger(__name__)
 
@@ -148,8 +148,15 @@ def get_configuration() -> ResponseReturnValue:
             "clients_count": len(settings.clients),
         },
         "saml": {
-            "entity_id": settings.saml_entity_id,
-            "sso_url": settings.saml_sso_url,
+            # Effective values for THIS request (#181): explicit YAML value,
+            # or derived from the effective issuer. The *_derived flags let a
+            # client (the e2e agent rebuilding the settings form, an MCP
+            # agent) tell the two apart, so it never posts a derived value
+            # back as an explicit one and freezes it.
+            "entity_id": effective_saml_entity_id(settings),
+            "entity_id_derived": settings.saml_entity_id is None,
+            "sso_url": effective_saml_sso_url(settings),
+            "sso_url_derived": settings.saml_sso_url is None,
             # The e2e agent rebuilds the /settings form from this document, so
             # every form-editable SAML field must appear here - omitting one
             # makes the round-trip post it blank and the "blank = clear"

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -23,6 +23,7 @@ from ..services.saml_verification import (
     verify_redirect_signature,
 )
 from ._audit import audit_event
+from ._issuer import effective_saml_entity_id, effective_saml_sso_url
 
 # Create secure XML parser (XXE protection without deprecated defusedxml.lxml)
 _secure_parser = etree.XMLParser(
@@ -329,7 +330,7 @@ def metadata() -> ResponseReturnValue:
 
     ent = etree.Element(
         "{urn:oasis:names:tc:SAML:2.0:metadata}EntityDescriptor",
-        entityID=settings.saml_entity_id,
+        entityID=effective_saml_entity_id(settings),
         nsmap=NS,
     )
     idpsso = etree.SubElement(
@@ -354,13 +355,13 @@ def metadata() -> ResponseReturnValue:
         idpsso,
         "{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService",
         Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-        Location=settings.saml_sso_url,
+        Location=effective_saml_sso_url(settings),
     )
     etree.SubElement(
         idpsso,
         "{urn:oasis:names:tc:SAML:2.0:metadata}SingleSignOnService",
         Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-        Location=settings.saml_sso_url,
+        Location=effective_saml_sso_url(settings),
     )
 
     xml = etree.tostring(ent, xml_declaration=True, encoding="UTF-8", pretty_print=True)
@@ -573,7 +574,7 @@ def sso() -> ResponseReturnValue:
     # Generate SAML Response
     xml = _build_saml_response(
         acs_url=acs_url,
-        issuer=config.settings.saml_entity_id,
+        issuer=effective_saml_entity_id(config.settings),
         audience=config.settings.audience,
         name_id=name_id,
         attributes={k: v for k, v in saml_attrs.items() if v is not None},
@@ -833,7 +834,7 @@ def attribute_query() -> ResponseReturnValue:
             }
 
         # Build SAML Response
-        issuer_url = f"{config.settings.saml_entity_id}"
+        issuer_url = effective_saml_entity_id(config.settings)
         response_xml = _build_attribute_query_response(
             user_id=user_id,
             attributes=attributes,

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -26,6 +26,7 @@ from ..config import OAuthClient, User, get_config
 from ..services import get_audit_log, get_token_service, get_yaml_writer
 from ._audit import audit_event
 from ._auth import ui_login_required
+from ._issuer import effective_saml_entity_id, effective_saml_sso_url
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ def index() -> ResponseReturnValue:
     return render_template(
         "index.html",
         users_count=len(config.users),
+        saml_entity_id=effective_saml_entity_id(config.settings),
         stats=audit.get_stats(),
         settings=config.settings,
         current_user=session.get("user"),
@@ -560,6 +562,9 @@ def settings() -> ResponseReturnValue:
         return render_template(
             "settings.html",
             settings=config.settings,
+            # Shown as placeholders when the fields are derived (#181)
+            effective_saml_entity_id=effective_saml_entity_id(config.settings),
+            effective_saml_sso_url=effective_saml_sso_url(config.settings),
             current_user=session.get("user"),
         )
 

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -430,10 +430,14 @@ def apply_settings_document(
             oauth.pop("clients", None)
 
     saml = document.setdefault("saml", {})
-    if not is_unchanged(saml.get("entity_id"), settings.saml_entity_id):
-        saml["entity_id"] = settings.saml_entity_id
-    if not is_unchanged(saml.get("sso_url"), settings.saml_sso_url):
-        saml["sso_url"] = settings.saml_sso_url
+    # entity_id / sso_url: None means "derived from the effective issuer"
+    # (#181) and is represented by the key being absent - a derived value is
+    # never materialized into the file, so it keeps following the issuer.
+    for key, value in (("entity_id", settings.saml_entity_id), ("sso_url", settings.saml_sso_url)):
+        if value is None:
+            saml.pop(key, None)
+        elif not is_unchanged(saml.get(key), value):
+            saml[key] = value
     if not is_unchanged(saml.get("default_acs_url"), settings.default_acs_url):
         saml["default_acs_url"] = settings.default_acs_url
     if not is_unchanged(saml.get("sign_responses"), settings.saml_sign_responses):

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -248,10 +248,15 @@ class YamlWriter:
         data = self._load_settings_yaml()
         saml = data.setdefault("saml", {})
 
-        if entity_id is not None and not is_unchanged(saml.get("entity_id"), entity_id):
-            saml["entity_id"] = entity_id
-        if sso_url is not None and not is_unchanged(saml.get("sso_url"), sso_url):
-            saml["sso_url"] = sso_url
+        # Blank clears the key: absent = derived from the effective issuer
+        # (#181), the same "present-but-blank = clear" contract as #131.
+        for key, value in (("entity_id", entity_id), ("sso_url", sso_url)):
+            if value is None:
+                continue
+            if not value:
+                saml.pop(key, None)
+            elif not is_unchanged(saml.get(key), value):
+                saml[key] = value
         if default_acs_url is not None and not is_unchanged(
             saml.get("default_acs_url"), default_acs_url
         ):

--- a/src/nanoidp/templates/index.html
+++ b/src/nanoidp/templates/index.html
@@ -111,7 +111,7 @@
                     </tr>
                     <tr>
                         <td class="text-muted">SAML Entity ID</td>
-                        <td><code>{{ settings.saml_entity_id }}</code></td>
+                        <td><code>{{ saml_entity_id }}</code></td>
                     </tr>
                     <tr>
                         <td class="text-muted">OAuth Clients</td>

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -127,15 +127,19 @@
                     <div class="mb-3">
                         <label for="saml_entity_id" class="form-label">Entity ID</label>
                         <input type="text" class="form-control" id="saml_entity_id" name="saml_entity_id"
-                               value="{{ settings.saml_entity_id }}">
-                        <div class="form-text">SAML IdP Entity ID</div>
+                               value="{{ settings.saml_entity_id or '' }}"
+                               placeholder="{{ effective_saml_entity_id }}">
+                        <div class="form-text">SAML IdP Entity ID. Leave blank to derive it from the issuer
+                            (currently <code>{{ effective_saml_entity_id }}</code>).</div>
                     </div>
 
                     <div class="mb-3">
                         <label for="saml_sso_url" class="form-label">SSO URL</label>
                         <input type="url" class="form-control" id="saml_sso_url" name="saml_sso_url"
-                               value="{{ settings.saml_sso_url }}">
-                        <div class="form-text">SAML Single Sign-On endpoint</div>
+                               value="{{ settings.saml_sso_url or '' }}"
+                               placeholder="{{ effective_saml_sso_url }}">
+                        <div class="form-text">SAML Single Sign-On endpoint. Leave blank to derive it from the
+                            issuer (currently <code>{{ effective_saml_sso_url }}</code>).</div>
                     </div>
 
                     <div class="mb-3">

--- a/src/nanoidp/wizard.py
+++ b/src/nanoidp/wizard.py
@@ -240,8 +240,11 @@ oauth:
       description: "{client_desc}"
 
 saml:
-  entity_id: "{issuer}/saml"
-  sso_url: "{issuer}/saml/sso"
+  # entity_id / sso_url: absent = derived from the effective issuer as
+  # <issuer>/saml and <issuer>/saml/sso (follows issuer_from_request); set
+  # them only to pin a fixed value
+  # entity_id: "{issuer}/saml"
+  # sso_url: "{issuer}/saml/sso"
   default_acs_url: "http://localhost:8080/login/saml2/sso/nanoidp"
   # Roles/groups are not standard SAML attributes; enable and name them here.
   export_roles: false

--- a/tests/test_saml_effective_issuer.py
+++ b/tests/test_saml_effective_issuer.py
@@ -11,7 +11,9 @@ Core 2.2.5).
 """
 
 import base64
+import inspect
 import re
+from pathlib import Path
 
 import pytest
 import yaml
@@ -324,3 +326,37 @@ class TestMcp:
         props = tool.input_schema["properties"]
         assert "saml_entity_id" in props and "saml_sso_url" in props
 
+
+
+_REPO = Path(__file__).resolve().parent.parent
+# Captured at collection time, before any test runs: the suite's own saves
+# rewrite config/settings.yaml (conftest yaml_writer singleton gap), so
+# reading the file inside a test would see whatever an earlier test wrote,
+# not the committed artifact this guards.
+_SHIPPED_SETTINGS = {
+    name: yaml.safe_load((_REPO / name / "settings.yaml").read_text())
+    for name in ("config", "examples/spring-boot-saml")
+}
+
+
+class TestShippedConfigDerivesSamlUrls:
+    """#181 review: the shipped files must not pin entity_id/sso_url, or the
+    derivation never kicks in for anyone who starts from them. Guards the
+    committed artifacts, not just the code."""
+
+    @pytest.mark.parametrize("config_dir", sorted(_SHIPPED_SETTINGS))
+    def test_shipped_settings_have_no_explicit_saml_urls(self, config_dir):
+        saml = _SHIPPED_SETTINGS[config_dir].get("saml") or {}
+        assert "entity_id" not in saml, config_dir
+        assert "sso_url" not in saml, config_dir
+
+    def test_init_and_wizard_templates_keep_keys_commented(self):
+        import re
+
+        from nanoidp import __main__ as main_mod
+        from nanoidp import wizard
+
+        for mod in (main_mod, wizard):
+            src = inspect.getsource(mod)
+            assert not re.search(r"^\s*entity_id:", src, re.M), mod.__name__
+            assert not re.search(r"^\s*sso_url:", src, re.M), mod.__name__

--- a/tests/test_saml_effective_issuer.py
+++ b/tests/test_saml_effective_issuer.py
@@ -1,0 +1,326 @@
+"""
+#181: saml.entity_id / saml.sso_url follow the effective issuer when unset.
+
+Absent from settings.yaml means "derived": <effective issuer>/saml and
+<effective issuer>/saml/sso, where the effective issuer honours
+issuer_from_request exactly like OIDC discovery. An explicit value wins. One
+helper (routes/_issuer.py) feeds metadata, the <Issuer> of responses and
+assertions, /api/config, the UI and the MCP settings tools, so they cannot
+disagree (SAML 2.0 Metadata 2.3.2: entityID is the value used as <Issuer>,
+Core 2.2.5).
+"""
+
+import base64
+import re
+
+import pytest
+import yaml
+from lxml import etree
+
+from nanoidp.app import create_app
+from nanoidp.config import ConfigManager, get_config, init_config
+from nanoidp.mcp_server import _execute_tool
+from nanoidp.models import Settings
+from nanoidp.serialization import apply_settings_document
+from nanoidp.services.yaml_writer import YamlWriter
+
+MD = "{urn:oasis:names:tc:SAML:2.0:metadata}"
+SAMLP = "{urn:oasis:names:tc:SAML:2.0:protocol}"
+SAML = "{urn:oasis:names:tc:SAML:2.0:assertion}"
+
+
+def _config_dir(tmp_path, saml=None, issuer="http://localhost:8000", issuer_from_request=False):
+    settings = {
+        "server": {"host": "127.0.0.1", "port": 8000},
+        "oauth": {
+            "issuer": issuer,
+            "issuer_from_request": issuer_from_request,
+            "clients": [{"client_id": "demo-client", "client_secret": "demo-secret"}],
+        },
+        "saml": {"sign_responses": False, **(saml or {})},
+    }
+    (tmp_path / "settings.yaml").write_text(yaml.safe_dump(settings))
+    (tmp_path / "users.yaml").write_text(
+        yaml.safe_dump({"users": {"admin": {"password": "admin"}}, "default_user": "admin"})
+    )
+    return str(tmp_path)
+
+
+@pytest.fixture
+def make_app(tmp_path, monkeypatch):
+    # The YamlWriter singleton is created against the first config dir it
+    # sees and never reset between tests; point it at this test's dir.
+    import nanoidp.services.yaml_writer as yw
+
+    monkeypatch.setattr(yw, "_yaml_writer", None)
+
+    def _make(**kwargs):
+        app = create_app(config_dir=_config_dir(tmp_path, **kwargs))
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret-key"
+        return app
+
+    return _make
+
+
+def _authn_request(acs_url="http://sp.example.com/acs", request_id="_req1"):
+    xml = (
+        f'<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" '
+        f'ID="{request_id}" Version="2.0" IssueInstant="2026-01-01T00:00:00Z" '
+        f'AssertionConsumerServiceURL="{acs_url}"/>'
+    )
+    return base64.b64encode(xml.encode()).decode()
+
+
+def _metadata(client, host=None):
+    headers = {"Host": host} if host else {}
+    resp = client.get("/saml/metadata", headers=headers)
+    assert resp.status_code == 200
+    root = etree.fromstring(resp.data)
+    locations = {el.get("Location") for el in root.iter(f"{MD}SingleSignOnService")}
+    return root.get("entityID"), locations
+
+
+def _sso_response(client, host=None):
+    # The test client's cookie jar is domain-bound, so the login session must
+    # be created under the same base_url the request is sent with.
+    base_url = f"http://{host}/" if host else "http://localhost/"
+    with client.session_transaction(base_url=base_url) as sess:
+        sess["user"] = "admin"
+    resp = client.post("/saml/sso", data={"SAMLRequest": _authn_request()}, base_url=base_url)
+    assert resp.status_code == 200
+    match = re.search(r'name="SAMLResponse"\s+value="([^"]+)"', resp.data.decode())
+    assert match
+    return etree.fromstring(base64.b64decode(match.group(1)))
+
+
+class TestModelDerivation:
+    def test_defaults_are_unset(self):
+        s = Settings()
+        assert s.saml_entity_id is None
+        assert s.saml_sso_url is None
+
+    def test_derived_from_issuer(self):
+        s = Settings(issuer="https://idp.example.test/")
+        assert s.resolve_saml_entity_id(s.issuer) == "https://idp.example.test/saml"
+        assert s.resolve_saml_sso_url(s.issuer) == "https://idp.example.test/saml/sso"
+
+    def test_explicit_wins(self):
+        s = Settings(saml_entity_id="urn:idp:fixed", saml_sso_url="https://fixed/sso")
+        assert s.resolve_saml_entity_id("http://other") == "urn:idp:fixed"
+        assert s.resolve_saml_sso_url("http://other") == "https://fixed/sso"
+
+    def test_default_derivation_matches_previous_defaults(self):
+        """Absent keys must behave exactly as the old hard-coded defaults did."""
+        s = Settings()
+        assert s.resolve_saml_entity_id(s.issuer) == "http://localhost:8000/saml"
+        assert s.resolve_saml_sso_url(s.issuer) == "http://localhost:8000/saml/sso"
+
+
+class TestLoader:
+    def test_absent_loads_as_none(self, tmp_path):
+        config = ConfigManager(_config_dir(tmp_path))
+        assert config.settings.saml_entity_id is None
+        assert config.settings.saml_sso_url is None
+
+    def test_blank_loads_as_none(self, tmp_path):
+        config = ConfigManager(_config_dir(tmp_path, saml={"entity_id": "", "sso_url": ""}))
+        assert config.settings.saml_entity_id is None
+        assert config.settings.saml_sso_url is None
+
+    def test_explicit_loads_verbatim(self, tmp_path):
+        config = ConfigManager(
+            _config_dir(tmp_path, saml={"entity_id": "urn:idp:x", "sso_url": "https://x/sso"})
+        )
+        assert config.settings.saml_entity_id == "urn:idp:x"
+        assert config.settings.saml_sso_url == "https://x/sso"
+
+    def test_env_placeholder_still_expands(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SAML_ENTITY_ID", "urn:from:env")
+        config = ConfigManager(_config_dir(tmp_path, saml={"entity_id": "${SAML_ENTITY_ID}"}))
+        assert config.settings.saml_entity_id == "urn:from:env"
+
+
+class TestMetadataAndIssuerConsistency:
+    def test_static_issuer_derivation(self, make_app):
+        client = make_app(issuer="http://idp.local:8000").test_client()
+        entity_id, locations = _metadata(client)
+        assert entity_id == "http://idp.local:8000/saml"
+        assert locations == {"http://idp.local:8000/saml/sso"}
+
+    def test_static_issuer_ignores_host_header(self, make_app):
+        client = make_app(issuer="http://idp.local:8000").test_client()
+        entity_id, _ = _metadata(client, host="evil.example:9")
+        assert entity_id == "http://idp.local:8000/saml"
+
+    def test_issuer_from_request_reflects_host(self, make_app):
+        client = make_app(issuer_from_request=True).test_client()
+        entity_id, locations = _metadata(client, host="nanoidp:9900")
+        assert entity_id == "http://nanoidp:9900/saml"
+        assert locations == {"http://nanoidp:9900/saml/sso"}
+        # and OIDC discovery on the same Host agrees
+        disc = client.get("/.well-known/openid-configuration", headers={"Host": "nanoidp:9900"})
+        assert disc.get_json()["issuer"] == "http://nanoidp:9900"
+
+    def test_explicit_values_do_not_follow_request(self, make_app):
+        client = make_app(
+            issuer_from_request=True,
+            saml={"entity_id": "urn:idp:fixed", "sso_url": "https://fixed.example/sso"},
+        ).test_client()
+        entity_id, locations = _metadata(client, host="nanoidp:9900")
+        assert entity_id == "urn:idp:fixed"
+        assert locations == {"https://fixed.example/sso"}
+
+    def test_response_and_assertion_issuer_match_metadata(self, make_app):
+        client = make_app(issuer_from_request=True).test_client()
+        entity_id, _ = _metadata(client, host="nanoidp:9900")
+        root = _sso_response(client, host="nanoidp:9900")
+        response_issuer = root.find(f"{SAML}Issuer").text
+        assertion_issuer = root.find(f"{SAML}Assertion/{SAML}Issuer").text
+        assert response_issuer == assertion_issuer == entity_id == "http://nanoidp:9900/saml"
+
+    def test_response_issuer_uses_explicit_entity_id(self, make_app):
+        client = make_app(saml={"entity_id": "urn:idp:fixed"}).test_client()
+        root = _sso_response(client)
+        assert root.find(f"{SAML}Issuer").text == "urn:idp:fixed"
+
+    def test_api_config_reports_effective_and_derived(self, make_app):
+        client = make_app(issuer_from_request=True).test_client()
+        saml = client.get("/api/config", headers={"Host": "nanoidp:9900"}).get_json()["saml"]
+        assert saml["entity_id"] == "http://nanoidp:9900/saml"
+        assert saml["entity_id_derived"] is True
+        assert saml["sso_url"] == "http://nanoidp:9900/saml/sso"
+        assert saml["sso_url_derived"] is True
+
+    def test_api_config_reports_explicit(self, make_app):
+        client = make_app(saml={"entity_id": "urn:idp:fixed"}).test_client()
+        saml = client.get("/api/config").get_json()["saml"]
+        assert saml["entity_id"] == "urn:idp:fixed"
+        assert saml["entity_id_derived"] is False
+        assert saml["sso_url_derived"] is True
+
+
+class TestWriter:
+    def test_derived_values_are_never_persisted(self, tmp_path):
+        config = init_config(_config_dir(tmp_path))
+        config.save()
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert "entity_id" not in saml
+        assert "sso_url" not in saml
+
+    def test_explicit_values_are_preserved(self, tmp_path):
+        config = init_config(_config_dir(tmp_path, saml={"entity_id": "urn:idp:x"}))
+        config.save()
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert saml["entity_id"] == "urn:idp:x"
+        assert "sso_url" not in saml
+
+    def test_clearing_removes_key(self, tmp_path):
+        config = init_config(_config_dir(tmp_path, saml={"entity_id": "urn:idp:x"}))
+        config.settings.saml_entity_id = None
+        config.save()
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert "entity_id" not in saml
+
+    def test_apply_settings_document_pops_absent(self):
+        document = {"saml": {"entity_id": "urn:old", "sso_url": "https://old/sso"}}
+        apply_settings_document(document, Settings())
+        assert "entity_id" not in document["saml"]
+        assert "sso_url" not in document["saml"]
+
+    def test_yaml_writer_blank_clears_and_value_sets(self, tmp_path):
+        init_config(_config_dir(tmp_path, saml={"entity_id": "urn:idp:x"}))
+        writer = YamlWriter(str(tmp_path))
+        writer.update_saml_settings(entity_id="", sso_url="https://new/sso")
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert "entity_id" not in saml
+        assert saml["sso_url"] == "https://new/sso"
+        assert get_config().settings.saml_entity_id is None
+        assert get_config().settings.saml_sso_url == "https://new/sso"
+
+    def test_yaml_writer_none_leaves_untouched(self, tmp_path):
+        init_config(_config_dir(tmp_path, saml={"entity_id": "urn:idp:x"}))
+        YamlWriter(str(tmp_path)).update_saml_settings(sign_responses=True)
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert saml["entity_id"] == "urn:idp:x"
+
+
+class TestUiForm:
+    def test_settings_page_shows_effective_as_placeholder(self, make_app):
+        client = make_app(issuer="http://idp.local:8000").test_client()
+        html = client.get("/settings").data.decode()
+        assert 'placeholder="http://idp.local:8000/saml"' in html
+        assert 'name="saml_entity_id"' in html
+        # derived -> the input itself is empty, the placeholder carries the value
+        assert re.search(r'name="saml_entity_id"\s+value=""', html)
+
+    def test_settings_page_shows_explicit_as_value(self, make_app):
+        client = make_app(saml={"entity_id": "urn:idp:x"}).test_client()
+        html = client.get("/settings").data.decode()
+        assert re.search(r'name="saml_entity_id"\s+value="urn:idp:x"', html)
+
+    def test_blank_post_keeps_derived(self, make_app, tmp_path):
+        client = make_app().test_client()
+        client.post("/settings", data={"saml_entity_id": "", "saml_sso_url": ""})
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert "entity_id" not in saml and "sso_url" not in saml
+        assert get_config().settings.saml_entity_id is None
+
+    def test_blank_post_clears_explicit(self, make_app, tmp_path):
+        client = make_app(saml={"entity_id": "urn:idp:x"}).test_client()
+        client.post("/settings", data={"saml_entity_id": ""})
+        assert "entity_id" not in yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert get_config().settings.saml_entity_id is None
+
+    def test_absent_field_leaves_explicit(self, make_app, tmp_path):
+        client = make_app(saml={"entity_id": "urn:idp:x"}).test_client()
+        client.post("/settings", data={"audience": "other"})
+        assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]["entity_id"] == "urn:idp:x"
+
+    def test_post_sets_explicit(self, make_app, tmp_path):
+        client = make_app().test_client()
+        client.post("/settings", data={"saml_entity_id": "urn:idp:new"})
+        assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]["entity_id"] == "urn:idp:new"
+        assert get_config().settings.saml_entity_id == "urn:idp:new"
+
+    def test_dashboard_shows_effective_entity_id(self, make_app):
+        client = make_app(issuer="http://idp.local:8000").test_client()
+        assert "http://idp.local:8000/saml" in client.get("/").data.decode()
+
+
+class TestMcp:
+    @pytest.mark.asyncio
+    async def test_get_settings_reports_effective_against_fixed_issuer(self, tmp_path):
+        config = ConfigManager(_config_dir(tmp_path, issuer="http://idp.local:8000", issuer_from_request=True))
+        result = await _execute_tool("get_settings", {}, config)
+        assert result["saml"]["entity_id"] == "http://idp.local:8000/saml"
+        assert result["saml"]["entity_id_derived"] is True
+        assert result["saml"]["sso_url"] == "http://idp.local:8000/saml/sso"
+        assert result["saml"]["sso_url_derived"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_settings_sets_and_clears(self, tmp_path):
+        config = ConfigManager(_config_dir(tmp_path))
+        result = await _execute_tool(
+            "update_settings", {"saml_entity_id": "urn:idp:mcp", "saml_sso_url": "https://mcp/sso"}, config
+        )
+        assert result["success"] is True
+        assert set(result["updated_fields"]) >= {"saml_entity_id", "saml_sso_url"}
+        assert config.settings.saml_entity_id == "urn:idp:mcp"
+        got = await _execute_tool("get_settings", {}, config)
+        assert got["saml"]["entity_id"] == "urn:idp:mcp"
+        assert got["saml"]["entity_id_derived"] is False
+
+        await _execute_tool("update_settings", {"saml_entity_id": "", "saml_sso_url": ""}, config)
+        assert config.settings.saml_entity_id is None
+        assert config.settings.saml_sso_url is None
+        got = await _execute_tool("get_settings", {}, config)
+        assert got["saml"]["entity_id_derived"] is True
+
+    def test_update_settings_schema_declares_fields(self):
+        from nanoidp.mcp_server import _TOOLS
+
+        tool = next(t for t in _TOOLS if t.name == "update_settings")
+        props = tool.input_schema["properties"]
+        assert "saml_entity_id" in props and "saml_sso_url" in props
+


### PR DESCRIPTION
Closes #181.

- `Settings.saml_entity_id` / `saml_sso_url` become `Optional[str] = None`; `None` means "derived from the effective issuer" as `<issuer>/saml` and `<issuer>/saml/sso`. An explicit value wins exactly as before. With the default issuer the derived values equal the old hard-coded defaults, so untouched configs behave identically (test pins it); `${VAR}` placeholders still expand.
- One helper pair in `routes/_issuer.py` (`effective_saml_entity_id` / `effective_saml_sso_url`) built on `effective_issuer()`, so request reflection, proxy headers and the allowlist come for free. Used by `/saml/metadata` (`entityID` and both `SingleSignOnService` locations), the `<Issuer>` of SSO responses and assertions, the AttributeQuery response, `/api/config`, the settings page and the dashboard. SAML 2.0 Metadata 2.3.2 / Core 2.2.5 cited in code.
- Writer: a derived value is never materialized (`apply_settings_document` pops the key when `None`); `YamlWriter.update_saml_settings("")` clears, `None` leaves untouched (matches the #131 present-but-blank = clear contract). The UI form shows the effective value as a placeholder and posts `""` to keep it derived.
- Parity: MCP `get_settings` reports effective values plus `entity_id_derived` / `sso_url_derived` (resolved against the fixed `oauth.issuer`, same documented exception as the MCP discovery tools); `update_settings` gains both fields (empty string clears). `examples/test_agent.py`: new `SAML Metadata Follows Issuer` check (metadata == discovery issuer + `/saml[/sso]` when derived, == explicit values when not, `/api/config` agrees), and the two settings-form round-trips now post `""` for derived values instead of freezing them into explicit ones on every run.
- Shipped `config/settings.yaml`, the `nanoidp init` template, the wizard template and `examples/spring-boot-saml/settings.yaml` now carry both keys commented out with the "absent = derived" rule, so new setups get the derivation.
- Docs: `configuration.md` saml section, new "SAML metadata follows the issuer" section in the reverse-proxy guide, CHANGELOG.

## Verification

- 32 new tests (`tests/test_saml_effective_issuer.py`: derivation static/reflected/explicit, response and assertion `<Issuer>` == metadata `entityID` under a reflected Host with the XML parsed, writer never persists derived / preserves explicit / clears, UI placeholder and blank-POST semantics, MCP get/set/clear). Full suite 1066 passed, ruff and mypy clean.
- Live (`issuer_from_request: true`, no SAML keys): `Host: idp.test:9900` gives `entityID="http://idp.test:9900/saml"`, SSO location `http://idp.test:9900/saml/sso`, discovery issuer `http://idp.test:9900`, `/api/config` `entity_id_derived: true`; default Host gives `http://localhost:8795/saml`; an explicit `entity_id: "urn:fixed:idp"` wins regardless of Host with `entity_id_derived: false`. `test_agent.py` 51/51 and the YAML still has no SAML URL keys afterwards.
