### PR TITLE
test: isolate every test from the repo's config/ directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local files only (no remote URLs) to avoid beacons.
 
 ### Fixed
+- **The unit suite no longer rewrites the repo's `config/` files.** Tests
+  that build an app without an explicit config directory used to load the
+  committed preset through ConfigManager's `./config` fallback, and any save
+  that followed rewrote `config/settings.yaml` or `users.yaml` in the
+  checkout - twice committed by accident during review. `tests/conftest.py`
+  now points `NANOIDP_CONFIG_DIR` at a fresh copy of `config/` for every
+  test and resets the `yaml_writer` singleton alongside the others.
 - **`--profile` overrides settings.yaml for every value and survives reloads**
   (#172). An explicit `--profile dev` could not bring a file configured with
   `oauth21`/`stricter-dev` back to `dev` (the flag defaulted to `dev`, so the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ Pytest configuration and shared fixtures for NanoIDP tests.
 """
 
 import base64
+import shutil
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -11,6 +13,9 @@ import nanoidp.config as config_module
 import nanoidp.mcp_server as mcp_server_module
 import nanoidp.services.crypto as crypto_module
 import nanoidp.services.token as token_module
+import nanoidp.services.yaml_writer as yaml_writer_module
+
+_REPO_CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 from nanoidp.app import create_app
 from nanoidp.config import OAuthClient, User
 
@@ -56,6 +61,27 @@ def mcp_list_tools():
 
 
 @pytest.fixture(autouse=True)
+def isolated_repo_config(tmp_path_factory, monkeypatch):
+    """Every test that does not pass an explicit config_dir works on a
+    throwaway copy of the repo's config/ directory, never on the real one.
+
+    ConfigManager's discovery falls back to ./config, so a bare
+    create_app() in a test loads the committed preset; any UI/MCP save that
+    follows then rewrites config/settings.yaml or users.yaml in the
+    checkout. That rewrite has twice ended up committed by accident (#183
+    review) and makes the suite order-dependent. NANOIDP_CONFIG_DIR is the
+    first thing discovery honours, so pointing it at a fresh copy per test
+    closes the hole without touching the tests themselves. Tests that set
+    the variable or pass config_dir explicitly are unaffected.
+    """
+    config_dir = tmp_path_factory.mktemp("repo-config")
+    for name in ("settings.yaml", "users.yaml"):
+        shutil.copy(_REPO_CONFIG_DIR / name, config_dir / name)
+    monkeypatch.setenv("NANOIDP_CONFIG_DIR", str(config_dir))
+    yield config_dir
+
+
+@pytest.fixture(autouse=True)
 def reset_singletons():
     """Reset service singletons before and after each test.
 
@@ -66,17 +92,22 @@ def reset_singletons():
     _ensure_config()), which must be reset the same way or a test that drives
     it caches a ConfigManager into that global for the rest of the session.
     """
+    # get_yaml_writer()'s singleton captures config_dir from whichever
+    # ConfigManager is active when first built and keeps writing there; left
+    # unreset, a later test's saves land in an earlier test's directory.
     # Reset before test
     crypto_module._crypto_service = None
     config_module._config = None
     token_module._token_service = None
     mcp_server_module._config = None
+    yaml_writer_module._yaml_writer = None
     yield
     # Reset after test
     crypto_module._crypto_service = None
     config_module._config = None
     token_module._token_service = None
     mcp_server_module._config = None
+    yaml_writer_module._yaml_writer = None
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,10 @@ import nanoidp.mcp_server as mcp_server_module
 import nanoidp.services.crypto as crypto_module
 import nanoidp.services.token as token_module
 import nanoidp.services.yaml_writer as yaml_writer_module
-
-_REPO_CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 from nanoidp.app import create_app
 from nanoidp.config import OAuthClient, User
+
+_REPO_CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 
 
 async def call_mcp_tool(name: str, arguments: Optional[dict] = None):


### PR DESCRIPTION
Extracted from the #183 review: the suite could rewrite tracked files in `config/`, and that rewrite was committed by accident twice (#181's preset, and the #81 worktree before it was caught).

Root cause: ConfigManager's discovery falls back to `./config`, so a test that calls `create_app()` without a `config_dir` loads the committed preset, and any UI/MCP save that follows writes into the checkout. `get_yaml_writer()`'s singleton additionally captures the first config_dir it sees and keeps writing there.

Fix, in `tests/conftest.py` only:
- autouse fixture `isolated_repo_config`: copies `config/settings.yaml` and `users.yaml` into a fresh `tmp_path` per test and sets `NANOIDP_CONFIG_DIR` to it (the first thing discovery honours), so a bare `create_app()` works on a throwaway copy. Tests passing `config_dir` explicitly or setting the variable themselves are unaffected.
- `reset_singletons` also resets `yaml_writer._yaml_writer` (same idea as #176's conftest change; kept minimal here so #183 is unblocked).

Verification: on `main` the suite passes (1187) and `config/` is clean. On the #183 branch, whose new tests did dirty `config/settings.yaml`, the suite run twice in a row (what the 3.12 job does: plain run, then with coverage) leaves `config/` clean both times and the shipped-config guard test passes on the second run; without this change the second run failed exactly as CI did.