### PR TITLE
refactor: load settings.yaml and users.yaml through document models (#175 piece 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Configuration files load through document models** (#175, piece 2).
+  `settings.yaml` and `users.yaml` are now parsed into Pydantic document
+  models that mirror the YAML sections one to one
+  (`nanoidp.config_documents`), and the domain `Settings` / `User` objects
+  are built from them; the hand-written `.get(key, default)` mapping in
+  `config.py` is gone and the defaults live on the models, which the writer
+  reads as well. No file format change and no behavioural change for files
+  that loaded before. One visible improvement: an unknown key (a typo such
+  as `oauth.isuer`, or a key nanoidp does not know) is now logged as a
+  warning with its dotted path and ignored, instead of vanishing silently;
+  keys that shipped presets carry but the loader never consumed
+  (`cors_allowed_origins`, `device_flow`, `logging.format`,
+  `oauth.refresh_token_expiry_minutes`, `session.permanent`) are declared so
+  they do not warn. Fields inside a user entry keep folding into
+  `attributes`, as always. Stricter handling is a later piece.
+
 ### Config schema
 - `config_version` 1 introduced (#175, piece 1). No changes required to
   existing files: a file without the key is version 1. The version is the

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -35,6 +35,10 @@ The contract is a single integer, not semver:
 - **Absent means 1.** Existing files need no change; `nanoidp init` and the
   wizard write the key into the files they create, and saves from the web UI
   or the MCP server preserve it if present and never add it.
+- **Unknown keys are reported.** A key nanoidp does not know (a typo such
+  as `oauth.isuer`) is logged as a warning with its path and ignored; the
+  file still loads. Inside a user entry, unknown keys become that user's
+  `attributes`, as they always have.
 - **Optional additions never bump it.** New optional keys with defaults keep
   the version; only renames, removals or semantic changes of existing keys
   do, and such a bump ships with a migration step in the loader.

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -14,6 +14,12 @@ import yaml
 
 # Re-exported for compatibility: the models were defined here until #86, and
 # every consumer (routes, services, MCP, tests) imports them from this module.
+from .config_documents import (
+    SettingsDocument,
+    document_defaults,
+    load_settings_document,
+    load_users_document,
+)
 from .models import (  # noqa: F401
     SECURITY_PROFILES,
     OAuthClient,
@@ -161,115 +167,18 @@ class ConfigManager:
         self.config_version = check_config_version(data, settings_file)
         data = _expand_env_vars(data)
 
-        server = data.get("server", {})
-        oauth = data.get("oauth", {})
-        saml = data.get("saml", {})
-        jwt_config = data.get("jwt", {})
-        session = data.get("session", {})
-        logging_config = data.get("logging", {})
-        # `or {}` (not the `, {}` default) because a bare `login:` line in
-        # YAML parses to `{"login": None}`, not a missing key.
-        login = data.get("login") or {}
-
-        # Parse OAuth clients
-        clients = []
-        for client_data in oauth.get("clients", []):
-            client_id = client_data.get("client_id", "")
-            clients.append(OAuthClient(
-                client_id=client_id,
-                client_secret=client_data.get("client_secret", ""),
-                description=client_data.get("description", ""),
-                background_color=client_data.get("background_color"),
-                header_color=client_data.get("header_color"),
-                footer_color=client_data.get("footer_color"),
-                show_client_id=client_data.get("show_client_id", True),
-                show_description=client_data.get("show_description", False),
-                additional_audiences=_coerce_additional_audiences(
-                    client_data.get("additional_audiences", []), client_id
-                ),
-                redirect_uris=_coerce_client_str_list(
-                    client_data.get("redirect_uris", []), client_id, "redirect_uris"
-                ),
-            ))
-
-        # A client_id must be unique. Duplicates - including two ${VAR}
-        # placeholders that expand to the same value - make client lookup
-        # ambiguous and cause the settings-save merge to match the wrong raw
-        # entry, which can materialize an env-backed secret (#127/#151). Fail
-        # fast rather than silently corrupt settings.yaml on the next save.
-        seen_client_ids: set[str] = set()
-        for parsed_client in clients:
-            if parsed_client.client_id in seen_client_ids:
-                raise ValueError(
-                    f"Duplicate OAuth client_id '{parsed_client.client_id}' in "
-                    "settings.yaml; client ids must be unique (check for env "
-                    "placeholders that expand to the same value)"
-                )
-            seen_client_ids.add(parsed_client.client_id)
-
-        self.settings = Settings(
-            # Server
-            host=server.get("host", "127.0.0.1"),
-            port=server.get("port", 8000),
-            debug=server.get("debug", False),
-            # OAuth
-            issuer=oauth.get("issuer", "http://localhost:8000"),
-            issuer_from_request=oauth.get("issuer_from_request", False),
-            issuer_allowlist=oauth.get("issuer_allowlist", []) or [],
-            device_verification_base_url=oauth.get("device_verification_base_url"),
-            issuer_from_proxy_headers=oauth.get("issuer_from_proxy_headers", False),
-            audience=oauth.get("audience", "default"),
-            token_expiry_minutes=oauth.get("token_expiry_minutes", 60),
-            refresh_token_rotation=oauth.get("refresh_token_rotation", False),
-            require_pkce=oauth.get("require_pkce", False),
-            clients=clients,
-            logos_dir=oauth.get("logos_dir"),
-            # SAML
-            # Absent or blank = derived from the effective issuer (#181).
-            saml_entity_id=saml.get("entity_id") or None,
-            saml_sso_url=saml.get("sso_url") or None,
-            default_acs_url=saml.get("default_acs_url", "http://localhost:8080/login/saml2/sso/samlIdp"),
-            saml_sign_responses=saml.get("sign_responses", True),
-            saml_export_roles=saml.get("export_roles", False),
-            saml_export_groups=saml.get("export_groups", False),
-            saml_roles_attr_name=saml.get("roles_attr_name", "roles"),
-            saml_groups_attr_name=saml.get("groups_attr_name", "groups"),
-            saml_c14n_algorithm=saml.get("c14n_algorithm", "exc_c14n"),
-            saml_want_authn_requests_signed=saml.get(
-                "want_authn_requests_signed", False
-            ),
-            saml_sp_certificates=saml.get("sp_certificates", []) or [],
-            strict_saml_binding=saml.get("strict_binding", False),
-            # JWT
-            jwt_algorithm=jwt_config.get("algorithm", "RS256"),
-            keys_dir=jwt_config.get("keys_dir", "./keys"),
-            # Login mode (persona = passwordless interactive login, local dev convenience)
-            login_mode=login.get("mode", "password"),
-            # Security profile (top-level; CLI --profile overrides it, #68)
-            security_profile=data.get("security_profile", "dev"),
-            # Authority prefixes
-            authority_prefixes=data.get("authority_prefixes", {}),
-            # Allowed identity classes
-            allowed_identity_classes=data.get("allowed_identity_classes", []),
-            # Session
-            secret_key=session.get("secret_key", "dev-secret-key-change-in-production"),
-            require_ui_login=session.get("require_ui_login", False),
-            enforce_password_check=session.get("enforce_password_check", False),
-            # Logging
-            log_level=logging_config.get("level", "INFO"),
-            log_token_requests=logging_config.get("log_token_requests", True),
-            log_saml_requests=logging_config.get("log_saml_requests", True),
-            verbose_logging=logging_config.get("verbose_logging", True),
-        )
+        # YAML -> document model -> domain model (#175 piece 2). The document
+        # model is the single statement of the file format: unknown keys are
+        # reported with their path, defaults live on the model, and the
+        # domain Settings is built from it with every validator it already
+        # had. ${VAR} expansion and config_version stay at the edge, above.
+        self.settings = load_settings_document(data, settings_file).to_settings()
 
     def _set_default_settings(self) -> None:
         """Set default settings with demo client."""
-        self.settings = Settings(
-            clients=[OAuthClient(
-                client_id="demo-client",
-                client_secret="demo-secret",
-                description="Default demo client"
-            )],
+        # Model defaults (the same the loader applies to a sparse file) plus
+        # the demo client and prefixes a fresh install gets.
+        self.settings = SettingsDocument(
             authority_prefixes={
                 "roles": "ROLE_",
                 "groups": "GROUP_",
@@ -277,7 +186,12 @@ class ConfigManager:
                 "entitlements": "ENT_",
             },
             allowed_identity_classes=["INTERNAL", "EXTERNAL", "PARTNER", "SERVICE"],
-        )
+        ).to_settings()
+        self.settings.clients = [OAuthClient(
+            client_id="demo-client",
+            client_secret="demo-secret",
+            description="Default demo client",
+        )]
 
     def _load_users(self) -> None:
         """Load users from users.yaml."""
@@ -308,38 +222,9 @@ class ConfigManager:
         # settings.yaml (passwords, emails, attributes); until #175 only the
         # settings loader expanded them.
         data = _expand_env_vars(data)
-        self.default_user = data.get("default_user", "admin")
-
-        for username, user_data in data.get("users", {}).items():
-            # Extract known fields
-            known_fields = {
-                "password", "email", "identity_class", "entitlements",
-                "roles", "groups", "tenant", "source_acl", "attributes"
-            }
-
-            # Get explicit attributes or collect unknown fields as attributes
-            attributes = user_data.get("attributes", {})
-
-            # Any field not in known_fields becomes an attribute (for backward compatibility)
-            for key, value in user_data.items():
-                if key not in known_fields and key not in attributes:
-                    attributes[key] = value
-
-            self.users[username] = User(
-                username=username,
-                # Missing key -> None (persona-mode-only user), not "" - a
-                # user without a password must never accidentally validate
-                # against an empty password.
-                password=user_data.get("password"),
-                email=user_data.get("email", f"{username}@example.org"),
-                identity_class=user_data.get("identity_class"),
-                entitlements=user_data.get("entitlements", []),
-                roles=user_data.get("roles", ["USER"]),
-                groups=user_data.get("groups", []),
-                tenant=user_data.get("tenant", "default"),
-                source_acl=user_data.get("source_acl", []),
-                attributes=attributes,
-            )
+        # Same document-model path as settings (#175 piece 2); unknown keys
+        # inside a user entry keep folding into its attributes, as always.
+        self.users, self.default_user = load_users_document(data, users_file).to_users()
 
     def _set_default_users(self) -> None:
         """Set default users."""
@@ -461,7 +346,7 @@ class ConfigManager:
         settings_file = self.config_dir / "settings.yaml"
         document = load_yaml_document(settings_file)
         # Declared state, not effective state (#172): see persistable_settings().
-        apply_settings_document(document, self.persistable_settings())
+        apply_settings_document(document, self.persistable_settings(), defaults=document_defaults())
         atomic_write_yaml(settings_file, document)
 
 

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -132,8 +132,11 @@ class SamlSection(BaseModel):
     sign_responses: bool = True
     export_roles: bool = False
     export_groups: bool = False
-    roles_attr_name: str = "roles"
-    groups_attr_name: str = "groups"
+    # Optional on purpose: the domain model's before-validator
+    # (normalize_saml_attr_name) turns None/blank into the default, and a
+    # bare `roles_attr_name:` line must keep reaching it (#197 review).
+    roles_attr_name: Optional[str] = "roles"
+    groups_attr_name: Optional[str] = "groups"
     c14n_algorithm: str = "exc_c14n"
     want_authn_requests_signed: bool = False
     sp_certificates: Optional[List[str]] = None
@@ -174,16 +177,8 @@ class LoginSection(BaseModel):
     mode: str = "password"
 
 
-class DeviceFlowSection(BaseModel):
-    """Present in shipped presets, never consumed by the loader."""
 
-    model_config = _FORBID
-
-    code_expiry_seconds: Any = None  # accepted for compatibility, never consumed
-    polling_interval: Any = None  # accepted for compatibility, never consumed
-
-
-_SECTIONS = ("server", "oauth", "saml", "jwt", "session", "logging", "login", "device_flow")
+_SECTIONS = ("server", "oauth", "saml", "jwt", "session", "logging", "login")
 
 
 class SettingsDocument(BaseModel):
@@ -208,7 +203,10 @@ class SettingsDocument(BaseModel):
     # Accepted for compatibility, never consumed (the old loader never read it;
     # CORS stays ["*"]), hence Any: no new validation on an ignored key.
     cors_allowed_origins: Any = None
-    device_flow: DeviceFlowSection = Field(default_factory=DeviceFlowSection)
+    # Never read by the old loader, so neither the container shape nor its
+    # keys are validated: `device_flow: whatever` and a bare `device_flow:`
+    # loaded before and still do (#197 review).
+    device_flow: Any = None
 
     @model_validator(mode="before")
     @classmethod
@@ -262,8 +260,10 @@ class SettingsDocument(BaseModel):
             saml_sign_responses=self.saml.sign_responses,
             saml_export_roles=self.saml.export_roles,
             saml_export_groups=self.saml.export_groups,
-            saml_roles_attr_name=self.saml.roles_attr_name,
-            saml_groups_attr_name=self.saml.groups_attr_name,
+            # None passes through on purpose: Settings' before-validator
+            # normalizes it to the default, exactly as the old loader let it.
+            saml_roles_attr_name=self.saml.roles_attr_name,  # type: ignore[arg-type]
+            saml_groups_attr_name=self.saml.groups_attr_name,  # type: ignore[arg-type]
             saml_c14n_algorithm=self.saml.c14n_algorithm,
             saml_want_authn_requests_signed=self.saml.want_authn_requests_signed,
             saml_sp_certificates=self.saml.sp_certificates or [],

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -110,11 +110,16 @@ class OAuthSection(BaseModel):
     token_expiry_minutes: int = 60
     refresh_token_rotation: bool = False
     require_pkce: bool = False
-    clients: Optional[List[ClientEntry]] = None
+    # Absent = no clients; an explicit `clients:` (null) is a type error, as
+    # it was for the old loader (#197 review: null and missing differ).
+    clients: List[ClientEntry] = Field(default_factory=list)
     logos_dir: Optional[str] = None
     # Present in shipped presets, never consumed by the loader (accepted for
     # compatibility; see the module docstring).
-    refresh_token_expiry_minutes: Optional[int] = None
+    # Accepted for compatibility (shipped presets carry it), never consumed and
+    # therefore never validated: the old loader did not read it at all, so any
+    # value must keep loading (#197 review).
+    refresh_token_expiry_minutes: Any = None
 
 
 class SamlSection(BaseModel):
@@ -149,7 +154,7 @@ class SessionSection(BaseModel):
     require_ui_login: bool = False
     enforce_password_check: bool = False
     # Shipped presets carry it; the app sets session.permanent itself.
-    permanent: Optional[bool] = None
+    permanent: Any = None  # accepted for compatibility, never consumed
 
 
 class LoggingSection(BaseModel):
@@ -160,7 +165,7 @@ class LoggingSection(BaseModel):
     log_saml_requests: bool = True
     verbose_logging: bool = True
     # Shipped presets carry it; logging.basicConfig uses a fixed format.
-    format: Optional[str] = None
+    format: Any = None  # accepted for compatibility, never consumed
 
 
 class LoginSection(BaseModel):
@@ -174,8 +179,8 @@ class DeviceFlowSection(BaseModel):
 
     model_config = _FORBID
 
-    code_expiry_seconds: Optional[int] = None
-    polling_interval: Optional[int] = None
+    code_expiry_seconds: Any = None  # accepted for compatibility, never consumed
+    polling_interval: Any = None  # accepted for compatibility, never consumed
 
 
 _SECTIONS = ("server", "oauth", "saml", "jwt", "session", "logging", "login", "device_flow")
@@ -198,25 +203,28 @@ class SettingsDocument(BaseModel):
     login: LoginSection = Field(default_factory=LoginSection)
     security_profile: str = "dev"
     authority_prefixes: Dict[str, str] = Field(default_factory=dict)
-    allowed_identity_classes: Optional[List[str]] = None
+    allowed_identity_classes: List[str] = Field(default_factory=list)
     # Accepted for compatibility, not consumed (module docstring).
-    cors_allowed_origins: Optional[List[str]] = None
+    # Accepted for compatibility, never consumed (the old loader never read it;
+    # CORS stays ["*"]), hence Any: no new validation on an ignored key.
+    cors_allowed_origins: Any = None
     device_flow: DeviceFlowSection = Field(default_factory=DeviceFlowSection)
 
     @model_validator(mode="before")
     @classmethod
-    def _bare_sections_are_empty(cls, data: Any) -> Any:
+    def _bare_login_is_empty(cls, data: Any) -> Any:
         """A bare ``login:`` line parses to ``{"login": None}``, not a missing
-        key; treat every ``None`` section as an empty one."""
-        if isinstance(data, dict):
-            for key in _SECTIONS:
-                if key in data and data[key] is None:
-                    data = {**data, key: {}}
+        key. The old loader special-cased exactly this one section
+        (``data.get("login") or {}``); every other bare section was, and
+        stays, a type error: null and missing are different things (#197
+        review)."""
+        if isinstance(data, dict) and "login" in data and data["login"] is None:
+            data = {**data, "login": {}}
         return data
 
     def to_settings(self) -> Settings:
         """Build the domain ``Settings`` exactly as the old loader did."""
-        clients = [entry.to_client() for entry in (self.oauth.clients or [])]
+        clients = [entry.to_client() for entry in self.oauth.clients]
 
         # A client_id must be unique. Duplicates - including two ${VAR}
         # placeholders that expand to the same value - make client lookup
@@ -265,7 +273,7 @@ class SettingsDocument(BaseModel):
             login_mode=self.login.mode,
             security_profile=self.security_profile,
             authority_prefixes=self.authority_prefixes,
-            allowed_identity_classes=self.allowed_identity_classes or [],
+            allowed_identity_classes=self.allowed_identity_classes,
             secret_key=self.session.secret_key,
             require_ui_login=self.session.require_ui_login,
             enforce_password_check=self.session.enforce_password_check,
@@ -294,18 +302,22 @@ class UserEntry(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    # Missing -> default, explicit null -> validation error, exactly like the
+    # old ``user_data.get(key, default)`` followed by the domain model's
+    # validators (#197 review). ``password`` and ``identity_class`` are the
+    # two fields whose domain type is Optional, so null is valid there.
     password: Optional[str] = None
     email: Optional[str] = None
     identity_class: Optional[str] = None
-    entitlements: Optional[List[str]] = None
-    roles: Optional[List[str]] = None
-    groups: Optional[List[str]] = None
+    entitlements: List[str] = Field(default_factory=list)
+    roles: List[str] = Field(default_factory=lambda: ["USER"])
+    groups: List[str] = Field(default_factory=list)
     tenant: str = "default"
-    source_acl: Optional[List[str]] = None
-    attributes: Optional[Dict[str, Any]] = None
+    source_acl: List[str] = Field(default_factory=list)
+    attributes: Dict[str, Any] = Field(default_factory=dict)
 
     def to_user(self, username: str) -> User:
-        attributes: Dict[str, Any] = dict(self.attributes or {})
+        attributes: Dict[str, Any] = dict(self.attributes)
         # Any field not in the known set becomes an attribute (legacy files).
         for key, value in (self.model_extra or {}).items():
             if key not in _USER_KNOWN_FIELDS and key not in attributes:
@@ -313,13 +325,22 @@ class UserEntry(BaseModel):
         return User(
             username=username,
             password=self.password,
-            email=self.email if self.email is not None else f"{username}@example.org",
+            # Default depends on the key, so "absent" is detected through
+            # model_fields_set; an explicit `email: null` reaches User.email
+            # (a str) and fails there, as it did before.
+            email=(
+                # An explicit null is passed through on purpose so that
+                # User.email (a str) rejects it at runtime, as before.
+                self.email  # type: ignore[arg-type]
+                if "email" in self.model_fields_set
+                else f"{username}@example.org"
+            ),
             identity_class=self.identity_class,
-            entitlements=self.entitlements if self.entitlements is not None else [],
-            roles=self.roles if self.roles is not None else ["USER"],
-            groups=self.groups if self.groups is not None else [],
+            entitlements=self.entitlements,
+            roles=self.roles,
+            groups=self.groups,
             tenant=self.tenant,
-            source_acl=self.source_acl if self.source_acl is not None else [],
+            source_acl=self.source_acl,
             attributes=attributes,
         )
 
@@ -331,12 +352,13 @@ class UsersDocument(BaseModel):
 
     config_version: Optional[int] = None
     default_user: str = "admin"
-    users: Optional[Dict[str, UserEntry]] = None
+    # Absent = no users; a bare `users:` (null) is a type error, as before.
+    users: Dict[str, UserEntry] = Field(default_factory=dict)
 
     def to_users(self) -> Tuple[Dict[str, User], str]:
         users = {
             username: entry.to_user(username)
-            for username, entry in (self.users or {}).items()
+            for username, entry in self.users.items()
         }
         return users, self.default_user
 

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -1,0 +1,416 @@
+"""
+Document models: the YAML contract of ``settings.yaml`` and ``users.yaml``.
+
+One Pydantic model per YAML section, with field names equal to the YAML keys
+and defaults equal to what the loader used to hard-code in ``config.py``
+(#175, piece 2). The flow is ``YAML -> document model -> domain model``:
+
+- ``SettingsDocument`` / ``UsersDocument`` describe exactly what a file may
+  contain (``extra="forbid"`` at every level except a user entry, see
+  ``UserEntry``), so an unknown key is detected with its dotted path instead
+  of being silently ignored by a hand-written ``.get()`` chain.
+- ``to_settings()`` / ``to_users()`` build the existing domain models
+  (``Settings``, ``User``, ``OAuthClient``) unchanged; every validator those
+  models carry keeps running, so nothing that failed before loads now.
+
+``${VAR}`` placeholders are expanded and ``config_version`` is checked by the
+loader BEFORE a document is built (``serialization.expand_env_vars`` and
+``check_config_version``), so this module only ever sees plain values. It
+imports ``models`` and nothing else from the package; ``serialization.py``
+must not import it at runtime (import contract, #149), which is why the
+writer receives the defaults it needs as a mapping (``document_defaults``)
+rather than importing this module.
+
+Keys that shipped files carry but the loader never consumed (``cors_allowed_origins``,
+``device_flow``, ``logging.format``, ``oauth.refresh_token_expiry_minutes``,
+``session.permanent``) are declared here so they keep loading without a
+warning; they are still not consumed, exactly as before. Turning any of them
+into behaviour is a separate change, not a side effect of this refactor.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from .models import (
+    OAuthClient,
+    Settings,
+    User,
+    _coerce_additional_audiences,
+    _coerce_client_str_list,
+)
+
+logger = logging.getLogger(__name__)
+
+DocumentT = TypeVar("DocumentT", bound=BaseModel)
+
+_FORBID = ConfigDict(extra="forbid")
+
+
+class ServerSection(BaseModel):
+    model_config = _FORBID
+
+    host: str = "127.0.0.1"
+    port: int = 8000
+    debug: bool = False
+
+
+class ClientEntry(BaseModel):
+    """One ``oauth.clients[]`` entry. ``additional_audiences`` and
+    ``redirect_uris`` stay ``Any`` here because the loader accepts a scalar
+    string as a one-element list and reports unsupported shapes with a
+    client-scoped message (#35); that coercion runs in ``to_client()``."""
+
+    model_config = _FORBID
+
+    client_id: str = ""
+    client_secret: str = ""
+    description: str = ""
+    background_color: Optional[str] = None
+    header_color: Optional[str] = None
+    footer_color: Optional[str] = None
+    show_client_id: bool = True
+    show_description: bool = False
+    additional_audiences: Any = None
+    redirect_uris: Any = None
+
+    def to_client(self) -> OAuthClient:
+        return OAuthClient(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            description=self.description,
+            background_color=self.background_color,
+            header_color=self.header_color,
+            footer_color=self.footer_color,
+            show_client_id=self.show_client_id,
+            show_description=self.show_description,
+            additional_audiences=_coerce_additional_audiences(
+                self.additional_audiences, self.client_id
+            ),
+            redirect_uris=_coerce_client_str_list(
+                self.redirect_uris, self.client_id, "redirect_uris"
+            ),
+        )
+
+
+class OAuthSection(BaseModel):
+    model_config = _FORBID
+
+    issuer: str = "http://localhost:8000"
+    issuer_from_request: bool = False
+    issuer_allowlist: Optional[List[str]] = None
+    device_verification_base_url: Optional[str] = None
+    issuer_from_proxy_headers: bool = False
+    audience: str = "default"
+    token_expiry_minutes: int = 60
+    refresh_token_rotation: bool = False
+    require_pkce: bool = False
+    clients: Optional[List[ClientEntry]] = None
+    logos_dir: Optional[str] = None
+    # Present in shipped presets, never consumed by the loader (accepted for
+    # compatibility; see the module docstring).
+    refresh_token_expiry_minutes: Optional[int] = None
+
+
+class SamlSection(BaseModel):
+    model_config = _FORBID
+
+    # Absent or blank means "derived from the effective issuer" (#181).
+    entity_id: Optional[str] = None
+    sso_url: Optional[str] = None
+    default_acs_url: str = "http://localhost:8080/login/saml2/sso/samlIdp"
+    sign_responses: bool = True
+    export_roles: bool = False
+    export_groups: bool = False
+    roles_attr_name: str = "roles"
+    groups_attr_name: str = "groups"
+    c14n_algorithm: str = "exc_c14n"
+    want_authn_requests_signed: bool = False
+    sp_certificates: Optional[List[str]] = None
+    strict_binding: bool = False
+
+
+class JwtSection(BaseModel):
+    model_config = _FORBID
+
+    algorithm: str = "RS256"
+    keys_dir: str = "./keys"
+
+
+class SessionSection(BaseModel):
+    model_config = _FORBID
+
+    secret_key: str = "dev-secret-key-change-in-production"
+    require_ui_login: bool = False
+    enforce_password_check: bool = False
+    # Shipped presets carry it; the app sets session.permanent itself.
+    permanent: Optional[bool] = None
+
+
+class LoggingSection(BaseModel):
+    model_config = _FORBID
+
+    level: str = "INFO"
+    log_token_requests: bool = True
+    log_saml_requests: bool = True
+    verbose_logging: bool = True
+    # Shipped presets carry it; logging.basicConfig uses a fixed format.
+    format: Optional[str] = None
+
+
+class LoginSection(BaseModel):
+    model_config = _FORBID
+
+    mode: str = "password"
+
+
+class DeviceFlowSection(BaseModel):
+    """Present in shipped presets, never consumed by the loader."""
+
+    model_config = _FORBID
+
+    code_expiry_seconds: Optional[int] = None
+    polling_interval: Optional[int] = None
+
+
+_SECTIONS = ("server", "oauth", "saml", "jwt", "session", "logging", "login", "device_flow")
+
+
+class SettingsDocument(BaseModel):
+    """Top-level shape of ``settings.yaml``."""
+
+    model_config = _FORBID
+
+    # Validated by serialization.check_config_version before the document is
+    # built; declared so the key is known.
+    config_version: Optional[int] = None
+    server: ServerSection = Field(default_factory=ServerSection)
+    oauth: OAuthSection = Field(default_factory=OAuthSection)
+    saml: SamlSection = Field(default_factory=SamlSection)
+    jwt: JwtSection = Field(default_factory=JwtSection)
+    session: SessionSection = Field(default_factory=SessionSection)
+    logging: LoggingSection = Field(default_factory=LoggingSection)
+    login: LoginSection = Field(default_factory=LoginSection)
+    security_profile: str = "dev"
+    authority_prefixes: Dict[str, str] = Field(default_factory=dict)
+    allowed_identity_classes: Optional[List[str]] = None
+    # Accepted for compatibility, not consumed (module docstring).
+    cors_allowed_origins: Optional[List[str]] = None
+    device_flow: DeviceFlowSection = Field(default_factory=DeviceFlowSection)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _bare_sections_are_empty(cls, data: Any) -> Any:
+        """A bare ``login:`` line parses to ``{"login": None}``, not a missing
+        key; treat every ``None`` section as an empty one."""
+        if isinstance(data, dict):
+            for key in _SECTIONS:
+                if key in data and data[key] is None:
+                    data = {**data, key: {}}
+        return data
+
+    def to_settings(self) -> Settings:
+        """Build the domain ``Settings`` exactly as the old loader did."""
+        clients = [entry.to_client() for entry in (self.oauth.clients or [])]
+
+        # A client_id must be unique. Duplicates - including two ${VAR}
+        # placeholders that expand to the same value - make client lookup
+        # ambiguous and cause the settings-save merge to match the wrong raw
+        # entry, which can materialize an env-backed secret (#127/#151). Fail
+        # fast rather than silently corrupt settings.yaml on the next save.
+        seen_client_ids: set[str] = set()
+        for parsed_client in clients:
+            if parsed_client.client_id in seen_client_ids:
+                raise ValueError(
+                    f"Duplicate OAuth client_id '{parsed_client.client_id}' in "
+                    "settings.yaml; client ids must be unique (check for env "
+                    "placeholders that expand to the same value)"
+                )
+            seen_client_ids.add(parsed_client.client_id)
+
+        return Settings(
+            host=self.server.host,
+            port=self.server.port,
+            debug=self.server.debug,
+            issuer=self.oauth.issuer,
+            issuer_from_request=self.oauth.issuer_from_request,
+            issuer_allowlist=self.oauth.issuer_allowlist or [],
+            device_verification_base_url=self.oauth.device_verification_base_url,
+            issuer_from_proxy_headers=self.oauth.issuer_from_proxy_headers,
+            audience=self.oauth.audience,
+            token_expiry_minutes=self.oauth.token_expiry_minutes,
+            refresh_token_rotation=self.oauth.refresh_token_rotation,
+            require_pkce=self.oauth.require_pkce,
+            clients=clients,
+            logos_dir=self.oauth.logos_dir,
+            saml_entity_id=self.saml.entity_id or None,
+            saml_sso_url=self.saml.sso_url or None,
+            default_acs_url=self.saml.default_acs_url,
+            saml_sign_responses=self.saml.sign_responses,
+            saml_export_roles=self.saml.export_roles,
+            saml_export_groups=self.saml.export_groups,
+            saml_roles_attr_name=self.saml.roles_attr_name,
+            saml_groups_attr_name=self.saml.groups_attr_name,
+            saml_c14n_algorithm=self.saml.c14n_algorithm,
+            saml_want_authn_requests_signed=self.saml.want_authn_requests_signed,
+            saml_sp_certificates=self.saml.sp_certificates or [],
+            strict_saml_binding=self.saml.strict_binding,
+            jwt_algorithm=self.jwt.algorithm,
+            keys_dir=self.jwt.keys_dir,
+            login_mode=self.login.mode,
+            security_profile=self.security_profile,
+            authority_prefixes=self.authority_prefixes,
+            allowed_identity_classes=self.allowed_identity_classes or [],
+            secret_key=self.session.secret_key,
+            require_ui_login=self.session.require_ui_login,
+            enforce_password_check=self.session.enforce_password_check,
+            log_level=self.logging.level,
+            log_token_requests=self.logging.log_token_requests,
+            log_saml_requests=self.logging.log_saml_requests,
+            verbose_logging=self.logging.verbose_logging,
+        )
+
+
+# Keys of a user entry the domain model knows. Anything else in a user's
+# mapping has always been folded into ``attributes`` (backward compatibility
+# with pre-``attributes:`` files), so a user entry is the one place that must
+# NOT forbid extras.
+_USER_KNOWN_FIELDS = frozenset(
+    {"password", "email", "identity_class", "entitlements", "roles", "groups",
+     "tenant", "source_acl", "attributes"}
+)
+
+
+class UserEntry(BaseModel):
+    """One ``users.<name>`` mapping. Defaults mirror the old loader: a
+    missing ``password`` is ``None`` (persona-only user), ``roles`` default
+    to ``["USER"]``, ``email`` to ``<username>@example.org`` (filled in by
+    ``to_user`` because it needs the key)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    password: Optional[str] = None
+    email: Optional[str] = None
+    identity_class: Optional[str] = None
+    entitlements: Optional[List[str]] = None
+    roles: Optional[List[str]] = None
+    groups: Optional[List[str]] = None
+    tenant: str = "default"
+    source_acl: Optional[List[str]] = None
+    attributes: Optional[Dict[str, Any]] = None
+
+    def to_user(self, username: str) -> User:
+        attributes: Dict[str, Any] = dict(self.attributes or {})
+        # Any field not in the known set becomes an attribute (legacy files).
+        for key, value in (self.model_extra or {}).items():
+            if key not in _USER_KNOWN_FIELDS and key not in attributes:
+                attributes[key] = value
+        return User(
+            username=username,
+            password=self.password,
+            email=self.email if self.email is not None else f"{username}@example.org",
+            identity_class=self.identity_class,
+            entitlements=self.entitlements if self.entitlements is not None else [],
+            roles=self.roles if self.roles is not None else ["USER"],
+            groups=self.groups if self.groups is not None else [],
+            tenant=self.tenant,
+            source_acl=self.source_acl if self.source_acl is not None else [],
+            attributes=attributes,
+        )
+
+
+class UsersDocument(BaseModel):
+    """Top-level shape of ``users.yaml``."""
+
+    model_config = _FORBID
+
+    config_version: Optional[int] = None
+    default_user: str = "admin"
+    users: Optional[Dict[str, UserEntry]] = None
+
+    def to_users(self) -> Tuple[Dict[str, User], str]:
+        users = {
+            username: entry.to_user(username)
+            for username, entry in (self.users or {}).items()
+        }
+        return users, self.default_user
+
+
+def _dotted(loc: Tuple[Any, ...]) -> str:
+    parts: List[str] = []
+    for item in loc:
+        if isinstance(item, int):
+            parts[-1] = f"{parts[-1]}[{item}]" if parts else f"[{item}]"
+        else:
+            parts.append(str(item))
+    return ".".join(parts)
+
+
+def _drop_path(data: Any, loc: Tuple[Any, ...]) -> None:
+    target = data
+    for item in loc[:-1]:
+        target = target[item]
+    if isinstance(target, dict):
+        target.pop(loc[-1], None)
+
+
+def _load_document(model: Type[DocumentT], data: Dict[str, Any], file_path: Path) -> DocumentT:
+    """Validate ``data`` against ``model``.
+
+    Unknown keys (``extra_forbidden``) are reported as a WARNING with their
+    dotted path, removed, and validation is retried, so a typo such as
+    ``oauth.isuer`` no longer vanishes silently (#175) while files that load
+    today keep loading. Any other error (wrong type, invalid value) raises a
+    ``ValueError`` naming the file and the path; stricter handling is piece 4.
+    """
+    working = data
+    for _attempt in range(2):
+        try:
+            return model.model_validate(working)
+        except ValidationError as exc:
+            unknown = [e for e in exc.errors() if e["type"] == "extra_forbidden"]
+            others = [e for e in exc.errors() if e["type"] != "extra_forbidden"]
+            if others or not unknown:
+                first = others[0] if others else unknown[0]
+                raise ValueError(
+                    f"{file_path}: invalid value at {_dotted(first['loc']) or '<root>'}: "
+                    f"{first['msg']}"
+                ) from exc
+            working = copy.deepcopy(working) if working is data else working
+            for error in unknown:
+                logger.warning(
+                    f"{file_path}: unknown key {_dotted(error['loc'])} (ignored)"
+                )
+                _drop_path(working, error["loc"])
+    return model.model_validate(working)  # pragma: no cover - second pass raised
+
+
+def load_settings_document(data: Dict[str, Any], file_path: Path) -> SettingsDocument:
+    return _load_document(SettingsDocument, data, file_path)
+
+
+def load_users_document(data: Dict[str, Any], file_path: Path) -> UsersDocument:
+    return _load_document(UsersDocument, data, file_path)
+
+
+def document_defaults() -> Dict[str, Any]:
+    """Flat ``section.key -> default`` mapping of every settings.yaml key.
+
+    Handed to the writer (``serialization.apply_settings_document`` and the
+    ``YamlWriter``) so "omit at default" decisions read the same defaults the
+    loader applies, without ``serialization.py`` importing this module.
+    """
+    doc = SettingsDocument()
+    defaults: Dict[str, Any] = {}
+    for key, value in doc.model_dump().items():
+        if key in _SECTIONS:
+            for sub_key, sub_value in value.items():
+                defaults[f"{key}.{sub_key}"] = sub_value
+        else:
+            defaults[key] = value
+    return defaults

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -32,7 +32,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
@@ -361,8 +361,20 @@ def user_to_yaml(user: User) -> Dict[str, Any]:
     return entry
 
 
+# Fallback used when a caller passes no ``defaults`` mapping. The source of
+# truth is ``config_documents.document_defaults()`` (the document models);
+# this module cannot import it at runtime (import contract, #149), so
+# callers hand it in and these two literals only cover legacy call sites.
+_FALLBACK_DEFAULTS: Dict[str, Any] = {
+    "security_profile": "dev",
+    "login.mode": "password",
+}
+
+
 def apply_settings_document(
-    document: Dict[str, Any], settings: Settings
+    document: Dict[str, Any],
+    settings: Settings,
+    defaults: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Update the settings.yaml keys this codebase manages, in place.
 
@@ -479,7 +491,9 @@ def apply_settings_document(
         else:
             document.pop("allowed_identity_classes", None)
 
-    security_profile_default = "dev"
+    # "Omit at default" decisions read the loader's defaults (#175 piece 2).
+    resolved_defaults = defaults if defaults is not None else _FALLBACK_DEFAULTS
+    security_profile_default = resolved_defaults["security_profile"]
     current_security_profile = document.get("security_profile", security_profile_default)
     if not is_unchanged(current_security_profile, settings.security_profile):
         if settings.security_profile != security_profile_default:
@@ -487,7 +501,7 @@ def apply_settings_document(
         else:
             document.pop("security_profile", None)
 
-    login_mode_default = "password"
+    login_mode_default = resolved_defaults["login.mode"]
     merge_optional_nested_field(document, "login", "mode", settings.login_mode, login_mode_default)
 
     return document

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ..config import OAuthClient, Settings, User, get_config
+from ..config_documents import document_defaults
 from ..serialization import (
     atomic_write_yaml,
     client_id_matches,
@@ -341,7 +342,7 @@ class YamlWriter:
         raises instead of persisting a mode the server can't start with.
         """
         data = self._load_settings_yaml()
-        login_mode_default = "password"
+        login_mode_default = document_defaults()["login.mode"]
 
         if mode:
             Settings.validate_login_mode(mode)

--- a/tests/test_config_documents.py
+++ b/tests/test_config_documents.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from nanoidp.config import ConfigManager
 from nanoidp.config_documents import (
@@ -62,7 +63,7 @@ class TestDefaultsMatchTheOldLoaderLiterals:
         assert d.oauth.token_expiry_minutes == 60
         assert d.oauth.refresh_token_rotation is False
         assert d.oauth.require_pkce is False
-        assert d.oauth.clients is None
+        assert d.oauth.clients == []
         assert d.oauth.logos_dir is None
         assert d.saml.entity_id is None and d.saml.sso_url is None
         assert d.saml.default_acs_url == "http://localhost:8080/login/saml2/sso/samlIdp"
@@ -84,7 +85,7 @@ class TestDefaultsMatchTheOldLoaderLiterals:
         assert d.login.mode == "password"
         assert d.security_profile == "dev"
         assert d.authority_prefixes == {}
-        assert d.allowed_identity_classes is None
+        assert d.allowed_identity_classes == []
 
     def test_empty_document_builds_the_same_settings_as_an_empty_file(self, tmp_path):
         (tmp_path / "settings.yaml").write_text("")
@@ -222,24 +223,63 @@ class TestEdgeConventionsPreserved:
         assert config.settings.audience == "aud"
         assert config.users["alice"].password == "s3cret"
 
-    def test_bare_sections_parse_as_empty(self, tmp_path):
-        (tmp_path / "settings.yaml").write_text("login:\nsaml:\noauth:\nserver:\n")
-        (tmp_path / "users.yaml").write_text("users:\n")
-        config = ConfigManager(str(tmp_path))
-        assert config.settings.login_mode == "password"
-        assert config.settings.saml_entity_id is None
-        assert config.users == {}
+    def test_bare_login_is_empty_but_other_bare_sections_are_errors(self, tmp_path):
+        """Only `login:` was special-cased by the old loader (`or {}`); a bare
+        `oauth:` / `saml:` / `server:` was a type error and stays one (#197
+        review: null and missing differ)."""
+        (tmp_path / "settings.yaml").write_text("login:\n")
+        (tmp_path / "users.yaml").write_text("users: {}\n")
+        assert ConfigManager(str(tmp_path)).settings.login_mode == "password"
+        for section in ("oauth", "saml", "server", "session", "jwt", "logging"):
+            (tmp_path / "settings.yaml").write_text(f"{section}:\n")
+            with pytest.raises(ValueError, match=f"invalid value at {section}"):
+                ConfigManager(str(tmp_path))
 
     def test_blank_saml_urls_mean_derived(self, tmp_path):
         cfg = _write(tmp_path, {"saml": {"entity_id": "", "sso_url": ""}})
         settings = ConfigManager(cfg).settings
         assert settings.saml_entity_id is None and settings.saml_sso_url is None
 
-    def test_null_lists_are_empty(self, tmp_path):
-        cfg = _write(tmp_path, {"oauth": {"issuer_allowlist": None, "clients": None}, "saml": {"sp_certificates": None}, "allowed_identity_classes": None})
+    def test_null_collections_are_errors_except_where_the_old_loader_said_or(self, tmp_path):
+        """`issuer_allowlist` and `sp_certificates` used `... or []` and keep
+        accepting null; `clients`, `allowed_identity_classes` did not and a
+        null there is a type error with its path, as before."""
+        cfg = _write(tmp_path, {"oauth": {"issuer_allowlist": None}, "saml": {"sp_certificates": None}})
         settings = ConfigManager(cfg).settings
-        assert settings.issuer_allowlist == [] and settings.clients == []
-        assert settings.saml_sp_certificates == [] and settings.allowed_identity_classes == []
+        assert settings.issuer_allowlist == [] and settings.saml_sp_certificates == []
+        with pytest.raises(ValueError, match="invalid value at oauth.clients"):
+            ConfigManager(_write(tmp_path, {"oauth": {"clients": None}}))
+        with pytest.raises(ValueError, match="invalid value at allowed_identity_classes"):
+            ConfigManager(_write(tmp_path, {"allowed_identity_classes": None}))
+
+    def test_user_null_fields_are_errors_but_missing_fields_default(self, tmp_path):
+        _write(tmp_path)
+        (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {"a": {"password": "x"}}}))
+        user = ConfigManager(str(tmp_path)).users["a"]
+        assert user.roles == ["USER"] and user.groups == [] and user.email == "a@example.org"
+        for field in ("roles", "groups", "entitlements", "source_acl", "attributes", "email"):
+            (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {"a": {"password": "x", field: None}}}))
+            with pytest.raises((ValueError, ValidationError)):
+                ConfigManager(str(tmp_path))
+        # null password and identity_class are valid (Optional in the domain model)
+        (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {"a": {"password": None, "identity_class": None}}}))
+        assert ConfigManager(str(tmp_path)).users["a"].password is None
+        # bare `users:` was a type error and stays one
+        (tmp_path / "users.yaml").write_text("users:\n")
+        with pytest.raises(ValueError, match="invalid value at users"):
+            ConfigManager(str(tmp_path))
+
+    def test_compatibility_keys_are_not_validated(self, tmp_path):
+        """Keys the old loader never read must keep loading with any value."""
+        cfg = _write(tmp_path, {
+            "cors_allowed_origins": "*",
+            "session": {"permanent": "whatever"},
+            "logging": {"format": 42},
+            "oauth": {"refresh_token_expiry_minutes": "soon"},
+            "device_flow": {"polling_interval": "x", "code_expiry_seconds": None},
+        })
+        settings = ConfigManager(cfg).settings
+        assert settings.cors_allowed_origins == ["*"]
 
     def test_scalar_redirect_uri_is_coerced_and_bad_shape_is_client_scoped(self, tmp_path):
         cfg = _write(tmp_path, {"oauth": {"clients": [{"client_id": "c", "client_secret": "s", "redirect_uris": "http://x/cb"}]}})

--- a/tests/test_config_documents.py
+++ b/tests/test_config_documents.py
@@ -1,0 +1,301 @@
+"""
+#175 piece 2: settings.yaml and users.yaml load through document models.
+
+The document models are now the single statement of the file format. These
+tests pin (a) that their defaults equal the literals the loader used to
+hard-code, (b) that every shipped file loads with zero warnings (the
+"legacy keys keep loading" guard), (c) that unknown keys are reported with
+their path instead of vanishing, and (d) that the round-trip conventions of
+#127 are untouched.
+"""
+
+import copy
+import glob
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nanoidp.config import ConfigManager
+from nanoidp.config_documents import (
+    SettingsDocument,
+    UsersDocument,
+    document_defaults,
+    load_settings_document,
+    load_users_document,
+)
+from nanoidp.models import Settings
+from nanoidp.serialization import apply_settings_document, expand_env_vars, load_yaml_document
+
+REPO = Path(__file__).resolve().parent.parent
+SHIPPED_SETTINGS = sorted(
+    [REPO / "config" / "settings.yaml"] + [Path(p) for p in glob.glob(str(REPO / "examples" / "*" / "settings.yaml"))]
+)
+SHIPPED_USERS = sorted(
+    [REPO / "config" / "users.yaml"] + [Path(p) for p in glob.glob(str(REPO / "examples" / "*" / "users.yaml"))]
+)
+# Captured at import time: the suite may rewrite config/ mid-run (#184 keeps
+# that out of the repo, but the guard should not depend on test order).
+SHIPPED_SETTINGS_DATA = {p: yaml.safe_load(p.read_text()) or {} for p in SHIPPED_SETTINGS}
+SHIPPED_USERS_DATA = {p: yaml.safe_load(p.read_text()) or {} for p in SHIPPED_USERS}
+
+
+def _write(tmp_path, settings=None, users=None):
+    (tmp_path / "settings.yaml").write_text(yaml.safe_dump(settings if settings is not None else {"server": {"port": 8000}}))
+    (tmp_path / "users.yaml").write_text(yaml.safe_dump(users if users is not None else {"users": {}}))
+    return str(tmp_path)
+
+
+class TestDefaultsMatchTheOldLoaderLiterals:
+    """Every literal that used to live in ConfigManager._read_settings()."""
+
+    def test_settings_section_defaults(self):
+        d = SettingsDocument()
+        assert (d.server.host, d.server.port, d.server.debug) == ("127.0.0.1", 8000, False)
+        assert d.oauth.issuer == "http://localhost:8000"
+        assert d.oauth.issuer_from_request is False
+        assert d.oauth.issuer_allowlist is None
+        assert d.oauth.device_verification_base_url is None
+        assert d.oauth.issuer_from_proxy_headers is False
+        assert d.oauth.audience == "default"
+        assert d.oauth.token_expiry_minutes == 60
+        assert d.oauth.refresh_token_rotation is False
+        assert d.oauth.require_pkce is False
+        assert d.oauth.clients is None
+        assert d.oauth.logos_dir is None
+        assert d.saml.entity_id is None and d.saml.sso_url is None
+        assert d.saml.default_acs_url == "http://localhost:8080/login/saml2/sso/samlIdp"
+        assert d.saml.sign_responses is True
+        assert d.saml.export_roles is False and d.saml.export_groups is False
+        assert d.saml.roles_attr_name == "roles" and d.saml.groups_attr_name == "groups"
+        assert d.saml.c14n_algorithm == "exc_c14n"
+        assert d.saml.want_authn_requests_signed is False
+        assert d.saml.sp_certificates is None
+        assert d.saml.strict_binding is False
+        assert d.jwt.algorithm == "RS256" and d.jwt.keys_dir == "./keys"
+        assert d.session.secret_key == "dev-secret-key-change-in-production"
+        assert d.session.require_ui_login is False
+        assert d.session.enforce_password_check is False
+        assert d.logging.level == "INFO"
+        assert d.logging.log_token_requests is True
+        assert d.logging.log_saml_requests is True
+        assert d.logging.verbose_logging is True
+        assert d.login.mode == "password"
+        assert d.security_profile == "dev"
+        assert d.authority_prefixes == {}
+        assert d.allowed_identity_classes is None
+
+    def test_empty_document_builds_the_same_settings_as_an_empty_file(self, tmp_path):
+        (tmp_path / "settings.yaml").write_text("")
+        (tmp_path / "users.yaml").write_text("users: {}\n")
+        from_file = ConfigManager(str(tmp_path)).settings
+        assert from_file.model_dump() == SettingsDocument().to_settings().model_dump()
+
+    def test_user_entry_defaults(self):
+        users, default_user = UsersDocument(users={"alice": {}}).to_users()
+        assert default_user == "admin"
+        alice = users["alice"]
+        assert alice.password is None
+        assert alice.email == "alice@example.org"
+        assert alice.roles == ["USER"]
+        assert alice.groups == [] and alice.entitlements == [] and alice.source_acl == []
+        assert alice.tenant == "default"
+        assert alice.identity_class is None
+        assert alice.attributes == {}
+
+    def test_document_defaults_mapping_matches_models(self):
+        defaults = document_defaults()
+        assert defaults["security_profile"] == "dev"
+        assert defaults["login.mode"] == "password"
+        assert defaults["saml.default_acs_url"] == SettingsDocument().saml.default_acs_url
+        assert defaults["server.port"] == 8000
+
+
+class TestShippedFilesLoadWithoutWarnings:
+    """The document models must know every key a shipped file carries: a
+    warning here means a key was dropped from the contract, not a typo in
+    the preset. Placeholders are expanded first, as the loader does."""
+
+    @pytest.mark.parametrize("path", SHIPPED_SETTINGS, ids=lambda p: str(p.relative_to(REPO)))
+    def test_settings(self, path, caplog):
+        data = expand_env_vars(copy.deepcopy(SHIPPED_SETTINGS_DATA[path]))
+        with caplog.at_level(logging.WARNING, logger="nanoidp.config_documents"):
+            document = load_settings_document(data, path)
+        assert not [r for r in caplog.records if "unknown key" in r.getMessage()], caplog.text
+        if path.parent.name == "react-spa-pkce":
+            # Pre-existing, independent of this refactor: the preset ships a
+            # public client with client_secret "" which OAuthClient refuses
+            # (min_length=1). Tracked under #188 (public clients).
+            with pytest.raises(ValueError, match="client_secret"):
+                document.to_settings()
+        else:
+            document.to_settings()
+
+    @pytest.mark.parametrize("path", SHIPPED_USERS, ids=lambda p: str(p.relative_to(REPO)))
+    def test_users(self, path, caplog):
+        with caplog.at_level(logging.WARNING, logger="nanoidp.config_documents"):
+            load_users_document(copy.deepcopy(SHIPPED_USERS_DATA[path]), path).to_users()
+        assert not [r for r in caplog.records if "unknown key" in r.getMessage()], caplog.text
+
+    def test_shipped_config_loads_identically_through_config_manager(self):
+        """Full path (ConfigManager) on the committed preset."""
+        config = ConfigManager(str(REPO / "config"))
+        doc = load_settings_document(
+            expand_env_vars(copy.deepcopy(SHIPPED_SETTINGS_DATA[REPO / "config" / "settings.yaml"])), Path("x")
+        )
+        assert config.settings.model_dump() == doc.to_settings().model_dump()
+        assert set(config.users) == set(SHIPPED_USERS_DATA[REPO / "config" / "users.yaml"]["users"])
+
+
+class TestUnknownKeysAreReportedNotSwallowed:
+    def test_top_level_unknown_key(self, tmp_path, caplog):
+        cfg = _write(tmp_path, {"server": {"port": 8000}, "isuer": "x"})
+        with caplog.at_level(logging.WARNING):
+            settings = ConfigManager(cfg).settings
+        assert "settings.yaml: unknown key isuer (ignored)" in caplog.text
+        assert settings.port == 8000
+
+    def test_nested_unknown_key_has_dotted_path(self, tmp_path, caplog):
+        cfg = _write(tmp_path, {"oauth": {"isuer": "http://wrong", "audience": "a"}})
+        with caplog.at_level(logging.WARNING):
+            settings = ConfigManager(cfg).settings
+        assert "unknown key oauth.isuer (ignored)" in caplog.text
+        assert settings.issuer == "http://localhost:8000"  # the typo did not apply
+        assert settings.audience == "a"
+
+    def test_unknown_key_inside_a_client_entry(self, tmp_path, caplog):
+        cfg = _write(tmp_path, {"oauth": {"clients": [
+            {"client_id": "c", "client_secret": "s", "redirect_uri": "http://x/cb"},
+        ]}})
+        with caplog.at_level(logging.WARNING):
+            settings = ConfigManager(cfg).settings
+        assert "unknown key oauth.clients[0].redirect_uri (ignored)" in caplog.text
+        assert settings.clients[0].client_id == "c"
+        assert settings.clients[0].redirect_uris == []
+
+    def test_identical_settings_with_and_without_the_unknown_key(self, tmp_path):
+        base = {"oauth": {"audience": "a", "token_expiry_minutes": 5}}
+        with_typo = {"oauth": {**base["oauth"], "isuer": "x"}, "bogus": 1}
+        a = ConfigManager(_write(tmp_path, base)).settings.model_dump()
+        b = ConfigManager(_write(tmp_path, with_typo)).settings.model_dump()
+        assert a == b
+
+    def test_wrong_type_is_a_clear_error_with_path(self, tmp_path):
+        cfg = _write(tmp_path, {"server": {"port": "eighty"}})
+        with pytest.raises(ValueError, match=r"settings\.yaml: invalid value at server\.port"):
+            ConfigManager(cfg)
+
+    def test_domain_validators_still_run(self, tmp_path):
+        """Constraints live on Settings, not on the document: port 70000 is
+        refused exactly as before."""
+        cfg = _write(tmp_path, {"server": {"port": 70000}})
+        with pytest.raises(ValueError):
+            ConfigManager(cfg)
+
+    def test_unknown_user_fields_still_become_attributes(self, tmp_path, caplog):
+        cfg = _write(tmp_path, users={"users": {"bob": {"password": "x", "department": "R&D", "attributes": {"level": 3}}}})
+        with caplog.at_level(logging.WARNING):
+            config = ConfigManager(cfg)
+        assert "unknown key" not in caplog.text
+        assert config.users["bob"].attributes == {"level": 3, "department": "R&D"}
+
+    def test_unknown_top_level_users_key_is_reported(self, tmp_path, caplog):
+        cfg = _write(tmp_path, users={"users": {}, "defualt_user": "x"})
+        with caplog.at_level(logging.WARNING):
+            config = ConfigManager(cfg)
+        assert "users.yaml: unknown key defualt_user (ignored)" in caplog.text
+        assert config.default_user == "admin"
+
+
+class TestEdgeConventionsPreserved:
+    def test_placeholders_expand_before_validation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MY_PORT", "8123")
+        monkeypatch.setenv("ALICE_PW", "s3cret")
+        cfg = _write(
+            tmp_path,
+            {"server": {"port": "${MY_PORT:8000}"}, "oauth": {"audience": "${NOPE:aud}"}},
+            {"users": {"alice": {"password": "${ALICE_PW}"}}},
+        )
+        config = ConfigManager(cfg)
+        assert config.settings.port == 8123
+        assert config.settings.audience == "aud"
+        assert config.users["alice"].password == "s3cret"
+
+    def test_bare_sections_parse_as_empty(self, tmp_path):
+        (tmp_path / "settings.yaml").write_text("login:\nsaml:\noauth:\nserver:\n")
+        (tmp_path / "users.yaml").write_text("users:\n")
+        config = ConfigManager(str(tmp_path))
+        assert config.settings.login_mode == "password"
+        assert config.settings.saml_entity_id is None
+        assert config.users == {}
+
+    def test_blank_saml_urls_mean_derived(self, tmp_path):
+        cfg = _write(tmp_path, {"saml": {"entity_id": "", "sso_url": ""}})
+        settings = ConfigManager(cfg).settings
+        assert settings.saml_entity_id is None and settings.saml_sso_url is None
+
+    def test_null_lists_are_empty(self, tmp_path):
+        cfg = _write(tmp_path, {"oauth": {"issuer_allowlist": None, "clients": None}, "saml": {"sp_certificates": None}, "allowed_identity_classes": None})
+        settings = ConfigManager(cfg).settings
+        assert settings.issuer_allowlist == [] and settings.clients == []
+        assert settings.saml_sp_certificates == [] and settings.allowed_identity_classes == []
+
+    def test_scalar_redirect_uri_is_coerced_and_bad_shape_is_client_scoped(self, tmp_path):
+        cfg = _write(tmp_path, {"oauth": {"clients": [{"client_id": "c", "client_secret": "s", "redirect_uris": "http://x/cb"}]}})
+        assert ConfigManager(cfg).settings.clients[0].redirect_uris == ["http://x/cb"]
+        cfg = _write(tmp_path, {"oauth": {"clients": [{"client_id": "c", "client_secret": "s", "redirect_uris": {"a": 1}}]}})
+        with pytest.raises(ValueError, match="Client 'c': redirect_uris must be a string or a list"):
+            ConfigManager(cfg)
+
+    def test_duplicate_client_id_message_unchanged(self, tmp_path):
+        cfg = _write(tmp_path, {"oauth": {"clients": [
+            {"client_id": "foo", "client_secret": "a"}, {"client_id": "foo", "client_secret": "b"},
+        ]}})
+        with pytest.raises(ValueError, match="Duplicate OAuth client_id 'foo'"):
+            ConfigManager(cfg)
+
+    def test_compat_keys_are_accepted_but_not_consumed(self, tmp_path, caplog):
+        cfg = _write(tmp_path, {
+            "cors_allowed_origins": ["http://a"],
+            "device_flow": {"code_expiry_seconds": 1, "polling_interval": 2},
+            "logging": {"format": "%(message)s"},
+            "oauth": {"refresh_token_expiry_minutes": 5},
+            "session": {"permanent": True},
+        })
+        with caplog.at_level(logging.WARNING):
+            settings = ConfigManager(cfg).settings
+        assert "unknown key" not in caplog.text
+        # exactly as before this refactor: the keys never reached Settings
+        assert settings.cors_allowed_origins == ["*"]
+
+
+class TestWriterUsesDocumentDefaults:
+    def test_round_trip_of_shipped_config_keeps_placeholders_and_is_idempotent(self):
+        """#127 conventions, unchanged by this refactor: serializing the
+        loaded Settings back onto the loaded document leaves every ${VAR}
+        placeholder in place (the writer compares expanded values), and a
+        second pass is a no-op. (The first pass does materialize managed
+        keys the file omitted, e.g. logging.verbose_logging; that is the
+        pre-existing writer behaviour, pinned by test_issue_127.)"""
+        path = REPO / "config" / "settings.yaml"
+        document = load_yaml_document(path)
+        settings = ConfigManager(str(REPO / "config")).settings
+        apply_settings_document(document, settings, defaults=document_defaults())
+        assert document["server"]["port"] == "${PORT:8000}"
+        assert document["oauth"]["issuer"] == "http://localhost:${PORT:8000}"
+        once = copy.deepcopy(document)
+        apply_settings_document(document, settings, defaults=document_defaults())
+        assert document == once
+
+    def test_defaults_drive_omit_at_default(self):
+        doc = {}
+        apply_settings_document(doc, Settings(), defaults=document_defaults())
+        assert "security_profile" not in doc and "login" not in doc
+        apply_settings_document(doc, Settings(security_profile="oauth21", login_mode="persona"), defaults=document_defaults())
+        assert doc["security_profile"] == "oauth21" and doc["login"]["mode"] == "persona"
+
+    def test_fallback_without_defaults_still_works(self):
+        doc = {}
+        apply_settings_document(doc, Settings(security_profile="stricter-dev"))
+        assert doc["security_profile"] == "stricter-dev"

--- a/tests/test_config_documents.py
+++ b/tests/test_config_documents.py
@@ -280,6 +280,22 @@ class TestEdgeConventionsPreserved:
         })
         settings = ConfigManager(cfg).settings
         assert settings.cors_allowed_origins == ["*"]
+        # the container shape was never read either: a scalar or a bare line loads
+        for value in ("whatever", None, 3):
+            ConfigManager(_write(tmp_path, {"device_flow": value}))
+
+    def test_blank_saml_attr_names_fall_back_to_defaults(self, tmp_path):
+        """A bare `roles_attr_name:` reached Settings as None and the domain
+        before-validator turned it into the default; the document model must
+        let None through instead of rejecting it (#197 review)."""
+        cfg = _write(tmp_path, {"saml": {"roles_attr_name": None, "groups_attr_name": None}})
+        settings = ConfigManager(cfg).settings
+        assert settings.saml_roles_attr_name == "roles"
+        assert settings.saml_groups_attr_name == "groups"
+        cfg = _write(tmp_path, {"saml": {"roles_attr_name": "  ", "groups_attr_name": ""}})
+        settings = ConfigManager(cfg).settings
+        assert settings.saml_roles_attr_name == "roles"
+        assert settings.saml_groups_attr_name == "groups"
 
     def test_scalar_redirect_uri_is_coerced_and_bad_shape_is_client_scoped(self, tmp_path):
         cfg = _write(tmp_path, {"oauth": {"clients": [{"client_id": "c", "client_secret": "s", "redirect_uris": "http://x/cb"}]}})


### PR DESCRIPTION
Piece 2 of #175: `YAML -> document models -> domain models`, with `${VAR}` and legacy keys kept at the edge. No format change, no semantic change for files that load today; the one visible difference is that an unknown key is now reported with its path instead of being silently ignored.

## What changed

- New `config_documents.py` (imports only `models`): one Pydantic model per YAML section (`ServerSection`, `OAuthSection` with `ClientEntry`, `SamlSection`, `JwtSection`, `SessionSection`, `LoggingSection`, `LoginSection`), `SettingsDocument.to_settings()`, `UserEntry.to_user()`, `UsersDocument.to_users()`, `load_settings_document()` / `load_users_document()`, `document_defaults()`. Field names are the YAML keys; defaults are the literals the loader used to hard-code. All `extra="forbid"` except `UserEntry` (`extra="allow"`: unknown user fields keep folding into `attributes`, the legacy behaviour). A before-validator turns a bare `login:` line (`None`) into `{}`, the one section the old loader special-cased (`data.get("login") or {}`); every other bare section, and every null collection the old loader did not `or []`, is a type error with its path, exactly as before. Null and missing are different: missing -> default, explicit null -> the domain validator's verdict (so `email: null` fails while an absent email defaults to `<username>@example.org`, and a blank `saml.roles_attr_name` still normalizes to `roles`). The #35 scalar coercions, the duplicate `client_id` check and every domain-model validator run unchanged, so nothing that failed before loads now (`port: 70000` is still refused by `Settings`).
- `config.py`: `_read_settings()` = read -> `check_config_version` -> `_expand_env_vars` -> `load_settings_document(...).to_settings()`; same shape for users (the version-agreement check from #182 kept). Unknown keys: each `extra_forbidden` error is logged as `WARNING <file>: unknown key <dotted.path> (ignored)`, removed, and validation retried; any other error raises `ValueError("<file>: invalid value at <path>: <msg>")`. No strict mode here (piece 4). `_set_default_settings()` builds from `SettingsDocument()` defaults plus the demo client.
- Writer defaults: `apply_settings_document(document, settings, defaults=None)` takes a flat `section.key -> default` mapping; `config.py` passes `document_defaults()`, `YamlWriter.update_login_settings` reads `document_defaults()["login.mode"]`. `serialization.py` keeps a two-entry fallback because it must not import package modules at runtime (#149 contract). Honest finding: the "~37 writer literals" counted in #175 are mostly "absent when empty" patterns tied to Optional semantics, not defaults; only `security_profile` and `login.mode` were true default literals, and those are now model-driven. The omit-at-empty logic was left as is: rewriting it as omit-at-default would change files.
- Keys that shipped files carry but the loader never consumed are declared as `Any` so they keep loading without a warning and without any new validation, and are still not consumed (`cors_allowed_origins`, `device_flow` as a whole, `logging.format`, `oauth.refresh_token_expiry_minutes`, `session.permanent`); they get a real type the day they get behaviour. `session.management_secret` (#176) is not in the models yet: #176 must add the field when it lands, or files declaring it will warn (noted there).

## Findings (pre-existing, not changed here)

- Loader defaults `roles` to `["USER"]` while `user_to_yaml` omits empty `roles`, so a user saved with `roles: []` reloads as `["USER"]`.
- The writer materializes managed keys a file omitted on first save, so a load/save of the shipped preset is not a byte no-op (placeholders survive and the second pass is a no-op; the test pins that real contract).
- `examples/react-spa-pkce/settings.yaml` does not load on `main` either: `client_secret: ""` and `OAuthClient` requires a non-empty secret. Tracked separately; it is what #188 (public clients) makes legitimate.

## Verification

- `tests/test_config_documents.py` (38 tests): every section default pinned to the previous literal; unknown key at top level / nested / inside a client entry -> WARNING with the path and identical `Settings`; wrong type -> error with path; the shipped `config/` and every `examples/*` file load with zero unknown-key warnings; round trip; `${VAR}` before validation; bare `login:` loads while bare `oauth:`/`saml:`/`server:`/`session:`/`jwt:`/`logging:` fail with their path; null collections and null user fields fail where they failed before; compatibility keys accept any value; blank SAML attribute names normalize. 1260 passed (1222 existing unchanged), ruff/mypy clean, `lint-imports` 2 kept.
- Live with `oauth.isuer: x` injected: `nanoidp.config_documents - WARNING - .../settings.yaml: unknown key oauth.isuer (ignored)`, `/api/config` unchanged, `examples/test_agent.py` 53/53. MCP server and test_agent needed no change (no surface change).
