### PR TITLE
feat: hooks and plugins v1, extension points for external config stores (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured under `plugins.<name>:`. Per-hook error policy: `on_before_load`
   may block under `hooks.strict`, `on_config_saved` is propagated to the
   caller under `strict` after the write (the local save is always
-  committed), `on_audit_event` never propagates. Bootstrap surface for hooks
+  committed and the running configuration reloaded from it, so only the
+  mirror is behind), `on_audit_event` never propagates. Commands are never
+  reported by `/api/config` or MCP (they may embed expanded secrets) and a
+  propagated error names the hook and its source only; the bootstrap
+  surface is the baseline for `strict`/`timeout_seconds`, `settings.yaml`
+  overrides only what it declares. Bootstrap surface for hooks
   that must run before `settings.yaml` exists: `NANOIDP_BOOTSTRAP_HOOK` /
   `--bootstrap-hook`, `NANOIDP_BOOTSTRAP_PLUGIN` with
   `NANOIDP_PLUGIN_<NAME>_<KEY>` settings, and `bootstrap.yaml` in the config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (checked before `${VAR}` expansion).
 
 ### Added
+- **Hooks and plugins v1** (#185): extension points for external
+  configuration stores, not backends. Three synchronous hooks with
+  `HOOK_API_VERSION = 1`: `on_before_load(config_dir)` before the files are
+  read (startup and every reload), `on_config_saved(path, kind)` after an
+  atomic write of `settings.yaml` or `users.yaml`, `on_audit_event(event)`
+  after an audit entry. Implement them as shell commands under `hooks:` in
+  `settings.yaml` (placeholders `{config_dir}`, `{path}`, `{kind}`,
+  `{event_type}`, audit event JSON on stdin) or as Python plugins packaged
+  separately and discovered through the `nanoidp.plugins` entry-point group,
+  configured under `plugins.<name>:`. Per-hook error policy: `on_before_load`
+  may block under `hooks.strict`, `on_config_saved` is propagated to the
+  caller under `strict` after the write (the local save is always
+  committed), `on_audit_event` never propagates. Bootstrap surface for hooks
+  that must run before `settings.yaml` exists: `NANOIDP_BOOTSTRAP_HOOK` /
+  `--bootstrap-hook`, `NANOIDP_BOOTSTRAP_PLUGIN` with
+  `NANOIDP_PLUGIN_<NAME>_<KEY>` settings, and `bootstrap.yaml` in the config
+  directory (`hooks:` and `plugins:` only). `nanoidp plugins`, `GET
+  /api/config` and the MCP `get_settings` tool report what is loaded, from
+  which surface, with failure counters; `hooks:`/`plugins:` are YAML-only.
+  Reference plugin `examples/plugins/nanoidp-echo`; guide "Extending nanoidp:
+  hooks and plugins".
 - **Import contracts enforced in CI** (#149): `import-linter` now pins the
   package layering (`routes -> services -> config`) and the invariant that
   `serialization.py` has no runtime imports from the package (it is what

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,6 +11,7 @@
 
 - [Requesting tokens](guides/token-requests.md)
 - [Running behind a reverse proxy](guides/reverse-proxy.md)
+- [Extending nanoidp: hooks and plugins](guides/extending.md)
 - [MCP with Claude Code](guides/MCP_WORKFLOW.md)
 - [Security guide](guides/SECURITY.md)
 

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -15,9 +15,9 @@ Three hooks, called synchronously:
 
 | Hook | When | Arguments | Typical use |
 |---|---|---|---|
-| `on_before_load` | before `settings.yaml` and `users.yaml` are read: startup and every reload | `config_dir` | render the files from a store into the directory |
-| `on_config_saved` | after an atomic write of either file (web UI, MCP, `save`) | `path`, `kind` (`settings` or `users`) | push to a store, `git commit`, notify |
-| `on_audit_event` | after an audit entry is recorded | the event as a mapping | ship audit elsewhere |
+| `on_before_load` | before `settings.yaml` and `users.yaml` are read: startup and every reload | plugin: `config_dir`; shell: `{config_dir}` | render the files from a store into the directory |
+| `on_config_saved` | after an atomic write of either file (web UI, MCP, `save`) | plugin: `path`, `kind` (`settings` or `users`); shell: `{config_dir}`, `{path}`, `{kind}` | push to a store, `git commit`, notify |
+| `on_audit_event` | after an audit entry is recorded | plugin: the event as a mapping; shell: `{config_dir}`, `{event_type}` plus the event as JSON on stdin | ship audit elsewhere |
 
 Two ways to implement it, sharing one dispatcher (shell hook first, then
 plugins in declaration order):
@@ -30,13 +30,21 @@ hooks:
   on_config_saved: "vault kv put secret/idp/{kind} @{path}"
   on_audit_event: "jq -c . >> /var/log/nanoidp-audit.jsonl"   # event JSON on stdin
   strict: false          # see the error policy below
-  timeout_seconds: 10
+  timeout_seconds: 10    # shell hooks only
 ```
 
-Placeholders: `{config_dir}`, `{path}`, `{kind}`, `{event_type}`. They are
-replaced textually, so other braces (`${VAR}`, `jq` filters) are left alone.
-The command runs through the shell with nanoidp's environment; for
+Placeholders are listed per hook in the table above. They are replaced
+textually, so other braces (`${VAR}`, `jq` filters) are left alone. The
+command runs through the shell with nanoidp's environment; for
 `on_audit_event` the event is also written to the command's stdin as JSON.
+
+A command is stored after `${VAR}` expansion, so it may embed a token. It
+is therefore never reported outside the process: `GET /api/config` and the
+MCP `get_settings` tool show a hook's name, source and failure counter but
+not its command, and the error a caller sees under `strict` names the hook
+and its source only. The command and the hook's stderr go to the server
+log at WARNING, and `nanoidp plugins`, which runs in your own terminal,
+is the one place that prints commands.
 
 **Python plugins**, packaged separately and discovered through the
 `nanoidp.plugins` entry-point group:
@@ -49,15 +57,20 @@ plugins:
 
 `plugins:` is the only section of `settings.yaml` whose inner keys nanoidp
 does not validate: the shape is `name -> mapping`, the keys are the plugin's.
+A plugin's identity is its entry-point name, which is also that key; the
+object itself carries only `hook_api_version` and the hooks it implements.
 
 ## Error policy, per hook
 
-The policy is the same for shell hooks and plugins; a timeout is a failure.
+The policy is the same for shell hooks and plugins. `timeout_seconds`
+applies to shell hooks only, and a timeout is a failure; a Python plugin
+must manage its own network timeouts and queueing, nanoidp does not
+interrupt it.
 
 | Hook | default | `hooks.strict: true` |
 |---|---|---|
 | `on_before_load` | log, continue with whatever is in the directory | the load (startup or reload) fails with the hook's error |
-| `on_config_saved` | log | the error is propagated to the caller **after** the write: the file on disk is what was written |
+| `on_config_saved` | log | the error is propagated to the caller **after** the write. Disk and runtime stay aligned: the file on disk is what was written and the running configuration is reloaded from it before the error is raised, so only the mirror is behind. The web UI says "Settings saved locally; mirror hook failed" |
 | `on_audit_event` | log | log; never propagates |
 
 `on_before_load` is the only hook that can block an operation, because it
@@ -86,6 +99,15 @@ outside the normal config covers it:
 | `NANOIDP_BOOTSTRAP_HOOK="<command>"` or `nanoidp --bootstrap-hook "<command>"` | an `on_before_load` shell command | once, before the first load |
 | `NANOIDP_BOOTSTRAP_PLUGIN=<name>` with `NANOIDP_PLUGIN_<NAME>_<KEY>=<value>` | a plugin and its settings (name upper-cased, `-` as `_`) | loaded once, then takes part in every hook |
 | `bootstrap.yaml` in the configuration directory | `hooks:` and `plugins:` only, same schema as `settings.yaml`; any other key is refused | its `on_before_load` once, its other hooks and plugins always |
+
+Precedence of the policy values (`strict`, `timeout_seconds`): the
+bootstrap surface is the baseline; `settings.yaml` overrides a value only
+when it declares it explicitly, and a `settings.yaml` that disappears (a
+render that failed, a sync that left the directory half written) takes its
+hooks, plugins and policy with it on the next reload, leaving the bootstrap
+ones in force. A renderer that replaces or syncs the whole configuration
+directory must preserve `bootstrap.yaml`, or that deployment should use the
+env/CLI bootstrap instead.
 
 After the first load, `settings.yaml` may declare the same hook for reloads
 and saves. `nanoidp plugins` shows which surface each entry came from
@@ -139,8 +161,8 @@ and records it to a file. It is the whole template:
 from pathlib import Path
 
 class VaultPlugin:
-    name = "myvault"
-    hook_api_version = 1          # nanoidp refuses any other value
+    hook_api_version = 1          # nanoidp refuses any other value; the
+                                  # plugin's name is its entry-point name
 
     def configure(self, settings: dict) -> None:   # receives plugins.myvault, optional
         self.path = settings["path"]
@@ -171,9 +193,9 @@ block a save, queue it on the plugin's side.
 
 `nanoidp plugins [--config DIR]`, `GET /api/config` (`hooks` block) and the
 MCP `get_settings` tool show the hook API version, `strict`, the timeout,
-every shell hook with its source and failure counter, and every plugin with
-its `hook_api_version`, the hooks it implements, its source and its failure
-counters per hook. `hooks:` and `plugins:` are YAML-only: the web UI's
+every shell hook with its source and failure counter (never its command,
+see above), and every plugin with its `hook_api_version`, the hooks it
+implements, its source and its failure counters per hook. `hooks:` and `plugins:` are YAML-only: the web UI's
 settings page and the MCP `update_settings` tool report them but cannot
 change them, because a command editable through the surface it observes
 would be a remote-execution primitive.

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -1,0 +1,195 @@
+# Extending nanoidp: hooks and plugins
+
+nanoidp reads and writes two YAML files and nothing else. When those files
+need to come from, or go to, somewhere else (an S3 bucket per stage, a Vault
+path, a git repository, an audit sink), that integration lives outside the
+core, behind a small, versioned extension point: **extension points, not
+backends**. A hook observes what happens to the files and can provide them
+before they are read; it never replaces persistence, never sees an HTTP
+request and never touches token issuance, so a broken hook cannot change
+what nanoidp advertises or issues.
+
+## The contract (hook API version 1)
+
+Three hooks, called synchronously:
+
+| Hook | When | Arguments | Typical use |
+|---|---|---|---|
+| `on_before_load` | before `settings.yaml` and `users.yaml` are read: startup and every reload | `config_dir` | render the files from a store into the directory |
+| `on_config_saved` | after an atomic write of either file (web UI, MCP, `save`) | `path`, `kind` (`settings` or `users`) | push to a store, `git commit`, notify |
+| `on_audit_event` | after an audit entry is recorded | the event as a mapping | ship audit elsewhere |
+
+Two ways to implement it, sharing one dispatcher (shell hook first, then
+plugins in declaration order):
+
+**Shell hooks**, declared in `settings.yaml`, zero API:
+
+```yaml
+hooks:
+  on_before_load: "aws s3 sync s3://idp-config-${STAGE} {config_dir}"
+  on_config_saved: "vault kv put secret/idp/{kind} @{path}"
+  on_audit_event: "jq -c . >> /var/log/nanoidp-audit.jsonl"   # event JSON on stdin
+  strict: false          # see the error policy below
+  timeout_seconds: 10
+```
+
+Placeholders: `{config_dir}`, `{path}`, `{kind}`, `{event_type}`. They are
+replaced textually, so other braces (`${VAR}`, `jq` filters) are left alone.
+The command runs through the shell with nanoidp's environment; for
+`on_audit_event` the event is also written to the command's stdin as JSON.
+
+**Python plugins**, packaged separately and discovered through the
+`nanoidp.plugins` entry-point group:
+
+```yaml
+plugins:
+  echo:
+    record: /tmp/nanoidp-hooks.jsonl   # keys under a plugin's name belong to the plugin
+```
+
+`plugins:` is the only section of `settings.yaml` whose inner keys nanoidp
+does not validate: the shape is `name -> mapping`, the keys are the plugin's.
+
+## Error policy, per hook
+
+The policy is the same for shell hooks and plugins; a timeout is a failure.
+
+| Hook | default | `hooks.strict: true` |
+|---|---|---|
+| `on_before_load` | log, continue with whatever is in the directory | the load (startup or reload) fails with the hook's error |
+| `on_config_saved` | log | the error is propagated to the caller **after** the write: the file on disk is what was written |
+| `on_audit_event` | log | log; never propagates |
+
+`on_before_load` is the only hook that can block an operation, because it
+runs before any mutation. `on_config_saved` runs after the atomic write, so
+the local save is always committed; under `strict` the web UI, `/api` and
+MCP callers surface the failure so the operator learns the mirror did not
+happen, and a multi-step save stops at the first failed write:
+`ConfigManager.save()` writes `users.yaml` then `settings.yaml`, and the
+web UI's settings page writes its sections one atomic write at a time, so
+under `strict` a failing hook leaves the steps after it unsaved (the flash
+message says which write failed). Make the hook idempotent: the next save
+re-mirrors. `on_audit_event` never fails the request that
+produced the event: a token already issued must not turn into a 500 because
+an audit sink is down. Failures are counted per hook and shown by
+`nanoidp plugins` and `GET /api/config`.
+
+## Bootstrap: hooks that run before `settings.yaml` exists
+
+`on_before_load` runs before `settings.yaml` is read, but `hooks:` is
+declared in `settings.yaml`: the main use case, rendering the files from a
+store, cannot be configured by the file it fetches. A minimal surface
+outside the normal config covers it:
+
+| Surface | What it declares | Runs |
+|---|---|---|
+| `NANOIDP_BOOTSTRAP_HOOK="<command>"` or `nanoidp --bootstrap-hook "<command>"` | an `on_before_load` shell command | once, before the first load |
+| `NANOIDP_BOOTSTRAP_PLUGIN=<name>` with `NANOIDP_PLUGIN_<NAME>_<KEY>=<value>` | a plugin and its settings (name upper-cased, `-` as `_`) | loaded once, then takes part in every hook |
+| `bootstrap.yaml` in the configuration directory | `hooks:` and `plugins:` only, same schema as `settings.yaml`; any other key is refused | its `on_before_load` once, its other hooks and plugins always |
+
+After the first load, `settings.yaml` may declare the same hook for reloads
+and saves. `nanoidp plugins` shows which surface each entry came from
+(`bootstrap-env`, `bootstrap.yaml`, `settings.yaml`). Note that `strict` read
+from `settings.yaml` cannot apply to the very first load (the file is not
+known yet): to make a failed bootstrap render fatal, set `strict: true` in
+`bootstrap.yaml`.
+
+## Worked example: version every change in git
+
+```yaml
+hooks:
+  on_config_saved: "git -C {config_dir} add {path} && git -C {config_dir} commit -q -m 'nanoidp: {kind} saved' || true"
+```
+
+Every save from the web UI or the MCP server becomes a commit; `git log -p`
+is the change history, `git revert` the rollback, branches the stages. The
+trailing `|| true` keeps a "nothing to commit" from counting as a failure.
+
+## Worked example: render from a store before the load
+
+With a shell hook, the store stays entirely outside nanoidp:
+
+```bash
+NANOIDP_BOOTSTRAP_HOOK='aws s3 sync "s3://idp-config-$STAGE" {config_dir}' \
+NANOIDP_CONFIG_DIR=/var/lib/nanoidp/config \
+nanoidp
+```
+
+and, to mirror changes back:
+
+```yaml
+hooks:
+  on_config_saved: 'aws s3 cp {path} "s3://idp-config-$STAGE/"'
+```
+
+The same result without any hook: an init container (or Vault Agent, or a
+`docker compose` dependency) renders the files into the directory before
+nanoidp starts, and `POST /api/config/reload` (or the MCP `reload_config`
+tool) picks up a later change. Hooks are for when the render must follow
+nanoidp's own lifecycle (every reload) or when the mirror must follow every
+save.
+
+## Writing a plugin
+
+The reference plugin, `examples/plugins/nanoidp-echo`, logs every hook call
+and records it to a file. It is the whole template:
+
+```python
+# src/nanoidp_myvault/__init__.py
+from pathlib import Path
+
+class VaultPlugin:
+    name = "myvault"
+    hook_api_version = 1          # nanoidp refuses any other value
+
+    def configure(self, settings: dict) -> None:   # receives plugins.myvault, optional
+        self.path = settings["path"]
+
+    def on_before_load(self, config_dir: Path) -> None:
+        ...  # read secret/<path>/settings and users, write them into config_dir
+
+    def on_config_saved(self, path: Path, kind: str) -> None:
+        ...  # write the file back
+
+    # on_audit_event(self, event: dict) is optional, like the other two
+```
+
+```toml
+# pyproject.toml
+[project.entry-points."nanoidp.plugins"]
+myvault = "nanoidp_myvault:VaultPlugin"
+```
+
+Install it next to nanoidp (`pip install nanoidp-myvault`, or `pip install -e
+examples/plugins/nanoidp-echo` to try the reference one), declare it under
+`plugins:` or through `NANOIDP_BOOTSTRAP_PLUGIN`, and check `nanoidp
+plugins`. Any method may raise: nanoidp counts the failure and applies the
+policy of that hook. Keep plugins synchronous; if a store call must not
+block a save, queue it on the plugin's side.
+
+## What is reported
+
+`nanoidp plugins [--config DIR]`, `GET /api/config` (`hooks` block) and the
+MCP `get_settings` tool show the hook API version, `strict`, the timeout,
+every shell hook with its source and failure counter, and every plugin with
+its `hook_api_version`, the hooks it implements, its source and its failure
+counters per hook. `hooks:` and `plugins:` are YAML-only: the web UI's
+settings page and the MCP `update_settings` tool report them but cannot
+change them, because a command editable through the surface it observes
+would be a remote-execution primitive.
+
+## Security
+
+A Python plugin runs with the process's privileges; installing one is a
+trust decision like any dependency. Shell hooks run whatever the YAML says,
+with nanoidp's environment: the file is operator-owned by definition, the
+same trust boundary as `secret_key` or `management_secret`. Neither surface
+is reachable from the web UI or MCP.
+
+## What hooks are not
+
+There are no hooks on the protocol path (`on_token_issued`, `on_login` and
+the like): that would be a change to what nanoidp is, decided in
+[VISION](../project/vision.md), not added by a plugin. And a plugin cannot
+replace the YAML files as the source of truth: nanoidp never reads from or
+writes to an external store itself.

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -15,7 +15,7 @@ Three hooks, called synchronously:
 
 | Hook | When | Arguments | Typical use |
 |---|---|---|---|
-| `on_before_load` | before `settings.yaml` and `users.yaml` are read: startup and every reload | plugin: `config_dir`; shell: `{config_dir}` | render the files from a store into the directory |
+| `on_before_load` | before `settings.yaml` and `users.yaml` are read: startup and every explicit reload (`POST /api/config/reload`, MCP `reload_config`), never the refresh that follows a local write | plugin: `config_dir`; shell: `{config_dir}` | render the files from a store into the directory |
 | `on_config_saved` | after an atomic write of either file (web UI, MCP, `save`) | plugin: `path`, `kind` (`settings` or `users`); shell: `{config_dir}`, `{path}`, `{kind}` | push to a store, `git commit`, notify |
 | `on_audit_event` | after an audit entry is recorded | plugin: the event as a mapping; shell: `{config_dir}`, `{event_type}` plus the event as JSON on stdin | ship audit elsewhere |
 
@@ -70,7 +70,7 @@ interrupt it.
 | Hook | default | `hooks.strict: true` |
 |---|---|---|
 | `on_before_load` | log, continue with whatever is in the directory | the load (startup or reload) fails with the hook's error |
-| `on_config_saved` | log | the error is propagated to the caller **after** the write. Disk and runtime stay aligned: the file on disk is what was written and the running configuration is reloaded from it before the error is raised, so only the mirror is behind. The web UI says "Settings saved locally; mirror hook failed" |
+| `on_config_saved` | log | the error is propagated to the caller **after** the write. Disk and runtime stay aligned: the file on disk is what was written and the running configuration is reloaded from it before the error is raised, so only the mirror is behind. The web UI says "Settings saved locally; mirror hook failed". That refresh reads the local files only and does not run `on_before_load`: the disk is the newest state right after a write, and pulling a mirror that has not caught up yet would silently roll the write back |
 | `on_audit_event` | log | log; never propagates |
 
 `on_before_load` is the only hook that can block an operation, because it

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -303,6 +303,28 @@ logging:
 Set `verbose_logging: false` if you're concerned about PII in log files,
 though for a dev tool this is typically not an issue.
 
+## Hooks and plugins (`hooks:`, `plugins:`)
+
+Two optional top-level sections, absent by default, declare the extension
+points described in [Extending nanoidp: hooks and plugins](../guides/extending.md):
+`hooks:` holds shell commands for `on_before_load`, `on_config_saved` and
+`on_audit_event` plus `strict` and `timeout_seconds`; `plugins:` maps a
+plugin name to its own settings (the only section whose inner keys nanoidp
+does not validate). Both are YAML-only: reported by `GET /api/config` and
+the MCP `get_settings` tool, never changed through the web UI or MCP. Hooks
+that must run before `settings.yaml` exists go in `bootstrap.yaml` (same two
+keys) or in `NANOIDP_BOOTSTRAP_HOOK` / `NANOIDP_BOOTSTRAP_PLUGIN`.
+
+```yaml
+hooks:
+  on_config_saved: "git -C {config_dir} add {path} && git -C {config_dir} commit -q -m 'nanoidp: {kind}' || true"
+  strict: false
+  timeout_seconds: 10
+plugins:
+  echo:
+    record: /tmp/nanoidp-hooks.jsonl
+```
+
 ## Placeholders and the config directory as the interface
 
 Both files accept `${VAR}` and `${VAR:default}` placeholders in any scalar

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -308,10 +308,14 @@ though for a dev tool this is typically not an issue.
 Two optional top-level sections, absent by default, declare the extension
 points described in [Extending nanoidp: hooks and plugins](../guides/extending.md):
 `hooks:` holds shell commands for `on_before_load`, `on_config_saved` and
-`on_audit_event` plus `strict` and `timeout_seconds`; `plugins:` maps a
-plugin name to its own settings (the only section whose inner keys nanoidp
-does not validate). Both are YAML-only: reported by `GET /api/config` and
-the MCP `get_settings` tool, never changed through the web UI or MCP. Hooks
+`on_audit_event` plus `strict` and `timeout_seconds` (shell hooks only);
+`plugins:` maps a plugin's entry-point name to its own settings (the only
+section whose inner keys nanoidp does not validate). Both are YAML-only:
+`GET /api/config` and the MCP `get_settings` tool report hook names,
+sources and failure counters, never the commands (which may embed expanded
+`${VAR}` secrets), and neither surface can change them. Policy values
+declared here override `bootstrap.yaml`'s; undeclared ones keep the
+bootstrap value. Hooks
 that must run before `settings.yaml` exists go in `bootstrap.yaml` (same two
 keys) or in `NANOIDP_BOOTSTRAP_HOOK` / `NANOIDP_BOOTSTRAP_PLUGIN`.
 

--- a/docs/MCP_WORKFLOW.md
+++ b/docs/MCP_WORKFLOW.md
@@ -88,6 +88,11 @@ Copy and paste these prompts directly into Claude Code.
 
 ### Configuration
 
+`get_settings` also reports the `hooks` block (loaded shell hooks and
+plugins, #185). `hooks:` and `plugins:` are YAML-only: an agent can read
+them, not change them, like `secret_key` and `require_ui_login`.
+
+
 **Check current settings:**
 > "Show me the current nanoidp settings including issuer and token expiry"
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -248,6 +248,28 @@ jwt:
 
 ---
 
+## Hooks and Plugins
+
+`hooks:` (shell commands run before a configuration load, after a
+configuration save and after an audit event) and `plugins:` (Python
+packages loaded from the `nanoidp.plugins` entry-point group) extend
+nanoidp from outside the core; see the
+[Extending nanoidp](https://cdelmonte-zg.github.io/nanoidp/guides/extending.html)
+guide. Two facts matter here:
+
+- A Python plugin runs with the process's privileges. Installing one is a
+  trust decision like any other dependency.
+- A shell hook runs whatever the YAML says, through the shell, with
+  nanoidp's environment. `settings.yaml` and `bootstrap.yaml` are
+  operator-owned by definition, the same trust boundary as `secret_key`
+  and `management_secret`, which is why hooks and plugins are YAML-only:
+  the web UI and the MCP `update_settings` tool report them and cannot
+  change them. A configuration surface that could set a command would be a
+  remote-execution primitive.
+
+Hooks never run on the protocol path and cannot fail a request: an
+`on_audit_event` failure is counted and logged, never propagated.
+
 ## MCP Server Security
 
 The MCP (Model Context Protocol) server provides integration with Claude Code and other MCP-compatible tools.

--- a/examples/plugins/nanoidp-echo/pyproject.toml
+++ b/examples/plugins/nanoidp-echo/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nanoidp-echo"
+version = "0.1.0"
+description = "Reference nanoidp plugin: logs every hook call and records it to a file"
+requires-python = ">=3.10"
+dependencies = []
+
+# The whole plugin contract is this one line: nanoidp loads the object named
+# here when settings.yaml (or bootstrap.yaml / NANOIDP_BOOTSTRAP_PLUGIN) lists
+# a plugin called "echo".
+[project.entry-points."nanoidp.plugins"]
+echo = "nanoidp_echo:EchoPlugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nanoidp_echo"]

--- a/examples/plugins/nanoidp-echo/src/nanoidp_echo/__init__.py
+++ b/examples/plugins/nanoidp-echo/src/nanoidp_echo/__init__.py
@@ -1,0 +1,77 @@
+"""
+nanoidp-echo: the reference plugin for nanoidp's hook API v1 (#185).
+
+It does nothing useful on purpose: every hook call is logged and, when the
+plugin is configured with a ``record`` path, appended to that file as one
+JSON line. Copy this package, rename it, and replace the three methods with
+what your store needs; keep ``name`` and ``hook_api_version``.
+
+Install next to nanoidp::
+
+    pip install -e examples/plugins/nanoidp-echo
+
+then declare it in ``settings.yaml``::
+
+    plugins:
+      echo:
+        record: /tmp/nanoidp-hooks.jsonl
+
+or, for hooks that must run before settings.yaml exists::
+
+    NANOIDP_BOOTSTRAP_PLUGIN=echo NANOIDP_PLUGIN_ECHO_RECORD=/tmp/nanoidp-hooks.jsonl nanoidp
+
+The contract a plugin implements (all hooks optional, all synchronous):
+
+- ``on_before_load(config_dir: Path) -> None``
+- ``on_config_saved(path: Path, kind: str) -> None``  (``kind`` is ``settings`` or ``users``)
+- ``on_audit_event(event: dict) -> None``
+- ``configure(settings: dict) -> None``  (optional; receives ``plugins.<name>``)
+
+Raising from a hook counts as a failure; nanoidp applies its per-hook error
+policy (see the "Extending nanoidp" guide). ``on_audit_event`` failures never
+reach the request that produced the event.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("nanoidp_echo")
+
+
+class EchoPlugin:
+    name = "echo"
+    hook_api_version = 1
+
+    def __init__(self) -> None:
+        self.record: Optional[Path] = None
+        self.calls: list[Dict[str, Any]] = []
+
+    def configure(self, settings: Dict[str, Any]) -> None:
+        record = settings.get("record")
+        self.record = Path(record) if record else None
+
+    def _note(self, hook: str, **payload: Any) -> None:
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "hook": hook,
+            **payload,
+        }
+        self.calls.append(entry)
+        logger.info("echo plugin: %s %s", hook, payload)
+        if self.record is not None:
+            with open(self.record, "a") as f:
+                f.write(json.dumps(entry, default=str) + "\n")
+
+    def on_before_load(self, config_dir: Path) -> None:
+        self._note("on_before_load", config_dir=str(config_dir))
+
+    def on_config_saved(self, path: Path, kind: str) -> None:
+        self._note("on_config_saved", path=str(path), kind=kind)
+
+    def on_audit_event(self, event: Dict[str, Any]) -> None:
+        self._note("on_audit_event", event_type=event.get("event_type"), status=event.get("status"))

--- a/examples/plugins/nanoidp-echo/src/nanoidp_echo/__init__.py
+++ b/examples/plugins/nanoidp-echo/src/nanoidp_echo/__init__.py
@@ -4,7 +4,8 @@ nanoidp-echo: the reference plugin for nanoidp's hook API v1 (#185).
 It does nothing useful on purpose: every hook call is logged and, when the
 plugin is configured with a ``record`` path, appended to that file as one
 JSON line. Copy this package, rename it, and replace the three methods with
-what your store needs; keep ``name`` and ``hook_api_version``.
+what your store needs; keep ``hook_api_version``. A plugin's identity is
+its entry-point name (the ``plugins.<name>`` key), nothing on the object.
 
 Install next to nanoidp::
 
@@ -44,7 +45,6 @@ logger = logging.getLogger("nanoidp_echo")
 
 
 class EchoPlugin:
-    name = "echo"
     hook_api_version = 1
 
     def __init__(self) -> None:

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -49,6 +49,7 @@ Uso:
 import base64
 import hashlib
 import json
+import os
 import secrets
 import sys
 import time
@@ -3380,6 +3381,87 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("API Profile Survives Reload", TestCategory.API, False, str(e))
 
+    def test_api_hooks_block(self) -> TestResult:
+        """REST API - /api/config reports hooks and plugins (#185).
+
+        The block is always present (hook API version, strict, timeout,
+        loaded shell hooks and plugins with their source and failure
+        counters). When the server was started with an on_config_saved hook
+        (the e2e workflow passes one through settings.yaml or
+        NANOIDP_BOOTSTRAP_HOOK), a settings round-trip must run it without a
+        failure; with NANOIDP_E2E_HOOK_LOG set to the file that hook appends
+        to, the line count must grow too. Skips the hook part cleanly when no
+        hook is configured, like the persona/management checks.
+        """
+        try:
+            before = self.session.get(f"{self.base_url}/api/config", timeout=5).json()
+            block = before.get("hooks")
+            if not isinstance(block, dict) or block.get("hook_api_version") != 1:
+                return self._add_result(
+                    "API Hooks Block",
+                    TestCategory.API,
+                    False,
+                    f"/api/config lacks a hooks block with hook_api_version 1: {block!r}",
+                    before,
+                )
+            saved_hooks = [h for h in block.get("shell_hooks", []) if h.get("hook") == "on_config_saved"]
+            if not saved_hooks:
+                return self._add_result(
+                    "API Hooks Block",
+                    TestCategory.API,
+                    True,
+                    "Skipped hook round-trip: no on_config_saved hook configured "
+                    f"(block present, {len(block.get('plugins', []))} plugins)",
+                    {"skipped": True, "hooks": block},
+                )
+            log_path = os.environ.get("NANOIDP_E2E_HOOK_LOG")
+            lines_before = self._count_lines(log_path)
+            saml_config = before.get("saml", {})
+            # A no-op settings round-trip: same values posted back, derived
+            # SAML values as blank (#181), which is still an atomic write.
+            self.session.post(
+                f"{self.base_url}/settings",
+                data={
+                    "issuer": before.get("oauth", {}).get("issuer", "http://localhost:8000"),
+                    "audience": before.get("oauth", {}).get("audience", "default"),
+                    "token_expiry_minutes": before.get("oauth", {}).get("token_expiry_minutes", 60),
+                    "saml_entity_id": "" if saml_config.get("entity_id_derived") else saml_config.get("entity_id", ""),
+                    "saml_sso_url": "" if saml_config.get("sso_url_derived") else saml_config.get("sso_url", ""),
+                    "default_acs_url": saml_config.get("default_acs_url", ""),
+                    "saml_sign_responses": "true" if saml_config.get("sign_responses", True) else "",
+                    "strict_saml_binding": "true" if saml_config.get("strict_binding", False) else "",
+                    "saml_c14n_algorithm": saml_config.get("c14n_algorithm", "exc_c14n"),
+                    "allowed_identity_classes": "\n".join(before.get("allowed_identity_classes", [])),
+                },
+                allow_redirects=True,
+                timeout=10,
+            )
+            after = self.session.get(f"{self.base_url}/api/config", timeout=5).json().get("hooks", {})
+            failures_before = sum(h.get("failures", 0) for h in saved_hooks)
+            failures_after = sum(
+                h.get("failures", 0) for h in after.get("shell_hooks", []) if h.get("hook") == "on_config_saved"
+            )
+            lines_after = self._count_lines(log_path)
+            ran_clean = failures_after == failures_before
+            logged = lines_after > lines_before if log_path else True
+            return self._add_result(
+                "API Hooks Block",
+                TestCategory.API,
+                ran_clean and logged,
+                f"on_config_saved ran on a settings save: failures {failures_before}->{failures_after}"
+                + (f", log lines {lines_before}->{lines_after}" if log_path else ""),
+                {"before": block, "after": after},
+            )
+        except Exception as e:
+            return self._add_result("API Hooks Block", TestCategory.API, False, str(e))
+
+    @staticmethod
+    def _count_lines(path: Optional[str]) -> int:
+        if not path or not os.path.exists(path):
+            return 0
+        with open(path) as f:
+            return sum(1 for _ in f)
+
     def test_api_audit_log(self) -> TestResult:
         """REST API - Audit log."""
         try:
@@ -3791,6 +3873,7 @@ class NanoIDPTestAgent:
                 self.test_api_config_version,
                 self.test_api_config_reload,
                 self.test_api_config_profile_survives_reload,
+                self.test_api_hooks_block,
                 self.test_api_audit_log,
                 self.test_api_audit_stats,
             ]),

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -171,7 +171,25 @@ def main() -> None:
         help="Path to create configuration directory (default: ./config)",
     )
 
+    # plugins subcommand (#185)
+    plugins_parser = subparsers.add_parser(
+        "plugins",
+        help="List loaded hooks and plugins (hook API version, implemented hooks, failures, source)",
+    )
+    plugins_parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to configuration directory",
+    )
+
     # Main server arguments (when no subcommand)
+    parser.add_argument(
+        "--bootstrap-hook",
+        default=None,
+        help="Shell command run once before the first configuration load, e.g. to "
+        "render settings.yaml/users.yaml from an external store into the config "
+        "directory (placeholder {config_dir}). Same as NANOIDP_BOOTSTRAP_HOOK.",
+    )
     parser.add_argument(
         "--host",
         default=None,
@@ -214,6 +232,15 @@ def main() -> None:
         """)
         init_config(args.config_dir)
         return
+
+    # Handle plugins command
+    if args.command == "plugins":
+        from nanoidp.config import ConfigManager
+        print(ConfigManager(args.config).hooks.format_report())
+        return
+
+    if args.bootstrap_hook:
+        os.environ["NANOIDP_BOOTSTRAP_HOOK"] = args.bootstrap_hook
 
     # Handle wizard command
     if args.command == "wizard":

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -354,9 +354,27 @@ class ConfigManager:
         return None
 
     def reload(self) -> None:
-        """Reload configuration from files."""
+        """Reload configuration from files: the EXTERNAL reload.
+
+        Runs on_before_load first (render from a store, ...), then reads the
+        files. This is what startup, POST /api/config/reload and the MCP
+        reload_config tool do.
+        """
         self._load_config()
         logger.info("Configuration reloaded")
+
+    def reload_local(self) -> None:
+        """Refresh the in-memory configuration from the LOCAL files only.
+
+        No on_before_load: this is the post-write refresh. After a local
+        write the files on disk are the newest state by definition, and
+        letting on_before_load pull from a mirror that has not caught up yet
+        (or whose push just failed) would silently roll the write back
+        (#185 review). Only an explicit reload() consults the mirror.
+        """
+        self._load_settings()
+        self._load_users()
+        logger.info("Configuration refreshed from local files")
 
     def save(self) -> None:
         """Save current configuration to YAML files."""

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -168,6 +168,9 @@ class ConfigManager:
 
         if not settings_file.exists():
             logger.warning(f"Settings file not found: {settings_file}, using defaults")
+            # A vanished settings.yaml takes its hooks, plugins and policy
+            # with it (#185 review); bootstrap entries stay.
+            self.hooks.drop_source(SOURCE_SETTINGS)
             self._set_default_settings()
             return
 
@@ -192,13 +195,17 @@ class ConfigManager:
         """Replace the settings.yaml-sourced hooks/plugins with the file's
         current declaration (#185); bootstrap entries are untouched."""
         self.hooks.drop_source(SOURCE_SETTINGS)
-        self.hooks.configure_from_sections(hooks.model_dump(), plugins, SOURCE_SETTINGS)
+        # The HooksSection itself, not model_dump(): only the policy values
+        # the file declares explicitly override the bootstrap baseline.
+        self.hooks.configure_from_sections(hooks, plugins, SOURCE_SETTINGS)
 
     def notify_saved(self, path: Path, kind: str) -> None:
         """The single on_config_saved call site for every write path (#185):
         ConfigManager's own saves and YamlWriter's. Called AFTER the atomic
         write; under hooks.strict the hook's failure is raised to the caller
-        while the file on disk stays what was written."""
+        while the file on disk stays what was written. ConfigManager's own
+        saves serialize in-memory state, so disk and runtime already agree
+        when the error propagates; YamlWriter reloads before re-raising."""
         self.hooks.run_config_saved(path, kind)
 
     def _set_default_settings(self) -> None:

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -15,11 +15,13 @@ import yaml
 # Re-exported for compatibility: the models were defined here until #86, and
 # every consumer (routes, services, MCP, tests) imports them from this module.
 from .config_documents import (
+    HooksSection,
     SettingsDocument,
     document_defaults,
     load_settings_document,
     load_users_document,
 )
+from .hooks import SOURCE_SETTINGS, HookRegistry, bootstrap_registry
 from .models import (  # noqa: F401
     SECURITY_PROFILES,
     OAuthClient,
@@ -64,6 +66,11 @@ class ConfigManager:
         # Effective config schema version of the loaded files (#175): the
         # declared value, or 1 when a file carries no config_version key.
         self.config_version: int = IMPLICIT_CONFIG_VERSION
+        # Hooks and plugins (#185): the bootstrap surface (bootstrap.yaml in
+        # the config dir, NANOIDP_BOOTSTRAP_HOOK / _PLUGIN) is read before
+        # the first load because settings.yaml may be what a hook renders;
+        # settings.yaml's own hooks: / plugins: are merged in after each load.
+        self.hooks: HookRegistry = bootstrap_registry(self.config_dir)
         self._load_config()
 
     def _find_config_dir(self) -> str:
@@ -88,6 +95,11 @@ class ConfigManager:
 
     def _load_config(self) -> None:
         """Load all configuration files."""
+        # on_before_load: bootstrap hooks run once (first load only), the
+        # settings.yaml-declared ones on every load. The registry enforces
+        # the once-only rule; under hooks.strict a failure raises HookError
+        # here, before anything is read.
+        self.hooks.run_before_load(self.config_dir)
         self._load_settings()
         self._load_users()
         logger.info(f"Loaded configuration from {self.config_dir}")
@@ -172,7 +184,22 @@ class ConfigManager:
         # reported with their path, defaults live on the model, and the
         # domain Settings is built from it with every validator it already
         # had. ${VAR} expansion and config_version stay at the edge, above.
-        self.settings = load_settings_document(data, settings_file).to_settings()
+        document = load_settings_document(data, settings_file)
+        self.settings = document.to_settings()
+        self._configure_hooks_from(document.hooks, document.plugins)
+
+    def _configure_hooks_from(self, hooks: HooksSection, plugins: Dict[str, Dict[str, Any]]) -> None:
+        """Replace the settings.yaml-sourced hooks/plugins with the file's
+        current declaration (#185); bootstrap entries are untouched."""
+        self.hooks.drop_source(SOURCE_SETTINGS)
+        self.hooks.configure_from_sections(hooks.model_dump(), plugins, SOURCE_SETTINGS)
+
+    def notify_saved(self, path: Path, kind: str) -> None:
+        """The single on_config_saved call site for every write path (#185):
+        ConfigManager's own saves and YamlWriter's. Called AFTER the atomic
+        write; under hooks.strict the hook's failure is raised to the caller
+        while the file on disk stays what was written."""
+        self.hooks.run_config_saved(path, kind)
 
     def _set_default_settings(self) -> None:
         """Set default settings with demo client."""
@@ -336,6 +363,7 @@ class ConfigManager:
         document = load_yaml_document(users_file)
         apply_users_document(document, self.users, self.default_user)
         atomic_write_yaml(users_file, document)
+        self.notify_saved(users_file, "users")
 
     def _save_settings(self) -> None:
         """Save settings to settings.yaml (shared builder, #83).
@@ -348,6 +376,7 @@ class ConfigManager:
         # Declared state, not effective state (#172): see persistable_settings().
         apply_settings_document(document, self.persistable_settings(), defaults=document_defaults())
         atomic_write_yaml(settings_file, document)
+        self.notify_saved(settings_file, "settings")
 
 
 # Global config instance

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -35,7 +35,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from .models import (
     OAuthClient,
@@ -177,6 +177,48 @@ class LoginSection(BaseModel):
     mode: str = "password"
 
 
+class HooksSection(BaseModel):
+    """``hooks:`` (#185): shell commands run at the three extension points.
+
+    Absent = no hooks. ``strict`` and ``timeout_seconds`` apply to plugins
+    too. YAML-only (and ``bootstrap.yaml``/env): never settable from the UI
+    or MCP, since a command editable through the surface it observes would
+    be a remote-execution primitive.
+    """
+
+    model_config = _FORBID
+
+    on_before_load: Optional[str] = None
+    on_config_saved: Optional[str] = None
+    on_audit_event: Optional[str] = None
+    strict: bool = False
+    timeout_seconds: float = 10.0
+
+
+def _validate_plugins_mapping(value: Any) -> Dict[str, Dict[str, Any]]:
+    """``plugins:`` is a mapping of plugin name -> its own settings mapping.
+
+    The only section with plugin-owned keys: the core validates the shape
+    (name -> mapping, a bare ``name:`` meaning no settings) and nothing
+    inside, because the keys belong to the plugin (#185).
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("plugins must be a mapping of plugin name -> settings mapping")
+    result: Dict[str, Dict[str, Any]] = {}
+    for name, settings in value.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("plugin names must be non-empty strings")
+        if settings is None:
+            result[name] = {}
+        elif isinstance(settings, dict):
+            result[name] = dict(settings)
+        else:
+            raise ValueError(f"plugins.{name} must be a mapping (or empty)")
+    return result
+
+
 
 _SECTIONS = ("server", "oauth", "saml", "jwt", "session", "logging", "login")
 
@@ -207,6 +249,14 @@ class SettingsDocument(BaseModel):
     # keys are validated: `device_flow: whatever` and a bare `device_flow:`
     # loaded before and still do (#197 review).
     device_flow: Any = None
+    # Extension points (#185). Absent = off.
+    hooks: HooksSection = Field(default_factory=HooksSection)
+    plugins: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+    @field_validator("plugins", mode="before")
+    @classmethod
+    def _plugins_shape(cls, value: Any) -> Dict[str, Dict[str, Any]]:
+        return _validate_plugins_mapping(value)
 
     @model_validator(mode="before")
     @classmethod
@@ -281,7 +331,39 @@ class SettingsDocument(BaseModel):
             log_token_requests=self.logging.log_token_requests,
             log_saml_requests=self.logging.log_saml_requests,
             verbose_logging=self.logging.verbose_logging,
+            hooks_on_before_load=self.hooks.on_before_load,
+            hooks_on_config_saved=self.hooks.on_config_saved,
+            hooks_on_audit_event=self.hooks.on_audit_event,
+            hooks_strict=self.hooks.strict,
+            hooks_timeout_seconds=self.hooks.timeout_seconds,
+            plugins=self.plugins,
         )
+
+
+class BootstrapDocument(BaseModel):
+    """``bootstrap.yaml`` (#185): the hook surface that exists before
+    ``settings.yaml`` can be read. Only ``hooks:`` and ``plugins:`` are
+    allowed, validated by the same section models; anything else is refused
+    so the file cannot quietly grow into a second settings file."""
+
+    model_config = _FORBID
+
+    hooks: HooksSection = Field(default_factory=HooksSection)
+    plugins: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+    @field_validator("plugins", mode="before")
+    @classmethod
+    def _plugins_shape(cls, value: Any) -> Dict[str, Dict[str, Any]]:
+        return _validate_plugins_mapping(value)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _bare_sections_are_empty(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            for key in ("hooks", "plugins"):
+                if key in data and data[key] is None:
+                    data = {**data, key: {}}
+        return data
 
 
 # Keys of a user entry the domain model knows. Anything else in a user's

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -180,8 +180,10 @@ class LoginSection(BaseModel):
 class HooksSection(BaseModel):
     """``hooks:`` (#185): shell commands run at the three extension points.
 
-    Absent = no hooks. ``strict`` and ``timeout_seconds`` apply to plugins
-    too. YAML-only (and ``bootstrap.yaml``/env): never settable from the UI
+    Absent = no hooks. ``strict`` applies to plugins too; ``timeout_seconds``
+    is for shell hooks only (a plugin manages its own timeouts). Policy
+    values declared here override ``bootstrap.yaml``'s; undeclared ones do
+    not (``model_fields_set`` decides). YAML-only (and ``bootstrap.yaml``/env): never settable from the UI
     or MCP, since a command editable through the surface it observes would
     be a remote-execution primitive.
     """
@@ -192,7 +194,7 @@ class HooksSection(BaseModel):
     on_config_saved: Optional[str] = None
     on_audit_event: Optional[str] = None
     strict: bool = False
-    timeout_seconds: float = 10.0
+    timeout_seconds: float = Field(default=10.0, gt=0)
 
 
 def _validate_plugins_mapping(value: Any) -> Dict[str, Dict[str, Any]]:

--- a/src/nanoidp/hooks.py
+++ b/src/nanoidp/hooks.py
@@ -25,20 +25,35 @@ JSON on stdin), and Python plugins discovered through the ``nanoidp.plugins``
 entry-point group. Order per hook: shell hook first, then plugins in
 declaration order.
 
-Error policy, per hook (identical for shell and Python):
+Error policy, per hook (identical for shell and Python, except that
+``timeout_seconds`` only applies to shell hooks: a plugin manages its own
+timeouts):
 
 - ``on_before_load`` is the only hook that may block an operation, because it
   runs before any mutation. Default: log and continue with whatever is in
   the directory; ``hooks.strict: true``: the load fails with the hook's error.
 - ``on_config_saved`` runs after the atomic write, so the local save is
   always committed. Default: log. ``strict``: the error is propagated to the
-  caller after the write (the file on disk is what was written).
+  caller after the write; the caller reloads first so disk and runtime both
+  carry the new value and only the mirror failed.
 - ``on_audit_event`` never propagates, strict or not: an audit plugin failure
   must not fail a ``/token`` whose token is already issued. Failures are
   counted and surfaced by ``nanoidp plugins`` and ``GET /api/config``.
 
-Timeouts are failures. No threads or async in the core; a plugin that wants
-asynchrony does it on its side.
+Timeouts are failures (shell hooks). No threads or async in the core; a
+plugin that wants asynchrony or a timeout does it on its side.
+
+Secrets: commands are stored after ``${VAR}`` expansion, so they may carry
+tokens. ``describe()`` (what ``GET /api/config`` and MCP expose) therefore
+never includes a command, and a propagated ``HookError`` names the hook and
+its source only; the command and the hook's stderr go to the local server
+log, at WARNING. Only ``nanoidp plugins`` (the operator's terminal) prints
+commands.
+
+Precedence: the bootstrap surface (``bootstrap.yaml``, env) is the baseline
+for the policy values ``strict`` and ``timeout_seconds``; ``settings.yaml``
+overrides a value only when it declares it explicitly, and dropping the
+settings source (a reload after the file disappeared) restores the baseline.
 
 Bootstrap: ``on_before_load`` runs before ``settings.yaml`` is read, but hook
 configuration is declared in ``settings.yaml``, so the main use case (render
@@ -102,9 +117,9 @@ class ShellHook:
     ran: bool = False
 
     def describe(self) -> Dict[str, Any]:
+        """Public metadata: never the command, which may embed expanded secrets."""
         return {
             "hook": self.hook,
-            "command": self.command,
             "source": self.source,
             "failures": self.failures,
             "once": self.once,
@@ -113,6 +128,8 @@ class ShellHook:
 
 @dataclass
 class LoadedPlugin:
+    # The entry-point name, which is also the ``plugins.<name>`` key: the
+    # plugin's one identity. A ``name`` attribute on the object is ignored.
     name: str
     obj: Any
     api_version: int
@@ -142,16 +159,46 @@ class HookRegistry:
     changed); bootstrap entries persist for the life of the process.
     """
 
-    def __init__(self) -> None:
+    DEFAULT_STRICT = False
+    DEFAULT_TIMEOUT_SECONDS = 10.0
+    # Highest precedence first: an explicitly declared settings.yaml value
+    # overrides bootstrap.yaml's, which overrides the default.
+    _POLICY_PRECEDENCE = (SOURCE_SETTINGS, SOURCE_BOOTSTRAP_FILE)
+
+    def __init__(self, config_dir: Optional[Path] = None) -> None:
+        self.config_dir: Optional[Path] = config_dir
         self.shell_hooks: List[ShellHook] = []
         self.plugins: List[LoadedPlugin] = []
-        self.strict: bool = False
-        self.timeout_seconds: float = 10.0
+        # Policy values per source, only those a source declared explicitly.
+        self._policy: Dict[str, Dict[str, Any]] = {}
         # Failure counters of entries dropped by drop_source(), keyed so the
         # same declaration re-read from settings.yaml on reload keeps its
         # history instead of reporting a fresh zero.
         self._retired_shell: Dict[tuple, int] = {}
         self._retired_plugins: Dict[tuple, Dict[str, int]] = {}
+
+    # ----------------------------------------------------------------- policy
+
+    def _policy_value(self, key: str, default: Any) -> Any:
+        for source in self._POLICY_PRECEDENCE:
+            declared = self._policy.get(source, {})
+            if key in declared:
+                return declared[key]
+        return default
+
+    @property
+    def strict(self) -> bool:
+        return bool(self._policy_value("strict", self.DEFAULT_STRICT))
+
+    @property
+    def timeout_seconds(self) -> float:
+        return float(self._policy_value("timeout_seconds", self.DEFAULT_TIMEOUT_SECONDS))
+
+    def set_policy(self, source: str, **declared: Any) -> None:
+        """Record the policy values ``source`` declared explicitly (and only those)."""
+        self._policy.setdefault(source, {}).update(
+            {k: v for k, v in declared.items() if v is not None}
+        )
 
     # ------------------------------------------------------------------ setup
 
@@ -206,22 +253,37 @@ class HookRegistry:
                 self._retired_plugins[(p.name, p.source)] = dict(p.failures)
         self.shell_hooks = [h for h in self.shell_hooks if h.source != source]
         self.plugins = [p for p in self.plugins if p.source != source]
+        # A source that is gone no longer has a say in strict/timeout: the
+        # bootstrap baseline (or the default) applies again.
+        self._policy.pop(source, None)
 
     def configure_from_sections(
         self,
-        hooks: Mapping[str, Any],
+        hooks: Any,
         plugins: Mapping[str, Any],
         source: str,
     ) -> None:
-        """Apply a validated ``hooks:`` / ``plugins:`` pair from ``source``."""
+        """Apply a validated ``hooks:`` / ``plugins:`` pair from ``source``.
+
+        ``hooks`` is a ``HooksSection`` (preferred: only the policy values it
+        declares explicitly, per ``model_fields_set``, override lower
+        sources) or a plain mapping (every present key counts as declared).
+        """
+        if hasattr(hooks, "model_fields_set"):
+            declared = set(hooks.model_fields_set)
+            values = {k: getattr(hooks, k) for k in declared}
+        else:
+            values = dict(hooks)
+            declared = set(values)
         for hook in HOOK_NAMES:
-            command = hooks.get(hook)
+            command = values.get(hook)
             if command:
                 self.add_shell_hook(hook, command, source)
-        if "strict" in hooks and hooks["strict"] is not None:
-            self.strict = bool(hooks["strict"])
-        if "timeout_seconds" in hooks and hooks["timeout_seconds"] is not None:
-            self.timeout_seconds = float(hooks["timeout_seconds"])
+        self.set_policy(
+            source,
+            strict=values.get("strict") if "strict" in declared else None,
+            timeout_seconds=values.get("timeout_seconds") if "timeout_seconds" in declared else None,
+        )
         for name, config in plugins.items():
             self.add_plugin(name, source, config or {})
 
@@ -236,12 +298,21 @@ class HookRegistry:
             propagate=self.strict,
         )
 
+    def _config_dir_placeholder(self, fallback: Optional[Path] = None) -> str:
+        if self.config_dir is not None:
+            return str(self.config_dir)
+        return str(fallback) if fallback is not None else ""
+
     def run_config_saved(self, path: Path, kind: str) -> None:
         """The write is already committed; under ``strict`` a failure is raised
         to the caller AFTER the file is on disk."""
         self._dispatch(
             "on_config_saved",
-            shell_placeholders={"path": str(path), "kind": kind},
+            shell_placeholders={
+                "config_dir": self._config_dir_placeholder(path.parent),
+                "path": str(path),
+                "kind": kind,
+            },
             plugin_args=(path, kind),
             propagate=self.strict,
         )
@@ -251,7 +322,10 @@ class HookRegistry:
         try:
             self._dispatch(
                 "on_audit_event",
-                shell_placeholders={"event_type": str(event.get("event_type", ""))},
+                shell_placeholders={
+                    "config_dir": self._config_dir_placeholder(),
+                    "event_type": str(event.get("event_type", "")),
+                },
                 plugin_args=(dict(event),),
                 propagate=False,
                 stdin_json=dict(event),
@@ -282,10 +356,12 @@ class HookRegistry:
                 continue
             try:
                 fn(*plugin_args)
-            except Exception as exc:
+            except Exception:
                 plugin.failures[hook] += 1
-                message = f"plugin {plugin.name!r} {hook} failed: {exc}"
-                logger.warning(message)
+                message = f"plugin {plugin.name!r} {hook} failed"
+                # The exception text may carry whatever the plugin was sent
+                # (URLs with tokens, store errors): local log only.
+                logger.warning(message, exc_info=True)
                 errors.append(message)
         if errors and propagate:
             raise HookError("; ".join(errors))
@@ -302,6 +378,11 @@ class HookRegistry:
         # (${VAR}, jq filters) that must not be interpreted as placeholders.
         for key, value in placeholders.items():
             command = command.replace("{" + key + "}", value)
+        # Two messages on purpose: the one returned (and, under strict,
+        # propagated to the UI/API/MCP caller) names the hook and its source
+        # only; the one logged carries the command and stderr, which may
+        # embed secrets expanded from ${VAR}, and stays in the local log.
+        label = f"{shell_hook.hook} shell hook ({shell_hook.source})"
         try:
             result = subprocess.run(
                 command,
@@ -313,32 +394,30 @@ class HookRegistry:
                 input=json.dumps(stdin_json) if stdin_json is not None else None,
             )
         except subprocess.TimeoutExpired:
-            message = (
-                f"{shell_hook.hook} shell hook ({shell_hook.source}) timed out after "
-                f"{self.timeout_seconds}s: {shell_hook.command}"
-            )
-            logger.warning(message)
-            return message
+            logger.warning("%s timed out after %ss: %s", label, self.timeout_seconds, shell_hook.command)
+            return f"{label} failed (timed out after {self.timeout_seconds}s)"
         except OSError as exc:
-            message = f"{shell_hook.hook} shell hook ({shell_hook.source}) could not run: {exc}"
-            logger.warning(message)
-            return message
+            logger.warning("%s could not run: %s: %s", label, exc, shell_hook.command)
+            return f"{label} failed (could not run)"
         if result.returncode != 0:
             stderr = (result.stderr or "").strip()
-            message = (
-                f"{shell_hook.hook} shell hook ({shell_hook.source}) exited "
-                f"{result.returncode}: {shell_hook.command}"
-                + (f" [stderr: {stderr}]" if stderr else "")
+            logger.warning(
+                "%s exited %s: %s%s",
+                label,
+                result.returncode,
+                shell_hook.command,
+                f" [stderr: {stderr}]" if stderr else "",
             )
-            logger.warning(message)
-            return message
-        logger.debug("%s shell hook ok: %s", shell_hook.hook, shell_hook.command)
+            return f"{label} failed (exit {result.returncode})"
+        logger.debug("%s ok: %s", label, shell_hook.command)
         return None
 
     # ---------------------------------------------------------- introspection
 
     def describe(self) -> Dict[str, Any]:
-        """What ``nanoidp plugins``, ``GET /api/config`` and MCP report."""
+        """What ``GET /api/config`` and MCP report: metadata only, no commands
+        (they are stored after ``${VAR}`` expansion and may embed secrets;
+        ``/api/*`` is unauthenticated by design)."""
         return {
             "hook_api_version": HOOK_API_VERSION,
             "strict": self.strict,
@@ -348,8 +427,11 @@ class HookRegistry:
         }
 
     def format_report(self) -> str:
-        """Human-readable form of ``describe()`` for the CLI."""
+        """Human-readable form for the CLI. Unlike ``describe()`` it prints the
+        commands: ``nanoidp plugins`` runs in the operator's own terminal, the
+        only place where a command that may embed a secret is shown."""
         info = self.describe()
+        commands = {(h.hook, h.source): h.command for h in self.shell_hooks}
         lines = [
             f"hook API version: {info['hook_api_version']}",
             f"strict: {info['strict']}  timeout_seconds: {info['timeout_seconds']}",
@@ -361,7 +443,9 @@ class HookRegistry:
         for h in info["shell_hooks"]:
             once = "  [bootstrap, runs once]" if h["once"] else ""
             lines.append(f"  {h['hook']:<16} {h['source']:<14} failures={h['failures']}{once}")
-            lines.append(f"    {h['command']}")
+            lines.append(
+                f"    command (local only, may embed secrets): {commands[(h['hook'], h['source'])]}"
+            )
         lines.append("")
         lines.append("plugins:")
         if not info["plugins"]:
@@ -391,18 +475,14 @@ def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = 
     process.
     """
     env = os.environ if environ is None else environ
-    registry = HookRegistry()
+    registry = HookRegistry(config_dir=config_dir)
 
     bootstrap_file = config_dir / BOOTSTRAP_FILE
     if bootstrap_file.exists():
         with open(bootstrap_file, "r") as f:
             raw = yaml.safe_load(f) or {}
         document = BootstrapDocument.model_validate(raw)
-        registry.configure_from_sections(
-            document.hooks.model_dump(),
-            document.plugins,
-            SOURCE_BOOTSTRAP_FILE,
-        )
+        registry.configure_from_sections(document.hooks, document.plugins, SOURCE_BOOTSTRAP_FILE)
         # bootstrap.yaml's on_before_load runs before the first load only,
         # like the env hook: settings.yaml owns reloads.
         for hook in registry.shell_hooks:

--- a/src/nanoidp/hooks.py
+++ b/src/nanoidp/hooks.py
@@ -1,0 +1,432 @@
+"""
+Hooks and plugins v1: extension points for external configuration stores,
+not backends (#185).
+
+nanoidp keeps talking only to its YAML files. A hook observes what happens
+to those files (and to the audit log) and provides files before they are
+read; it never replaces persistence, never sees an HTTP request and never
+touches token issuance, so a broken hook cannot alter protocol behaviour.
+
+Three hooks, called synchronously from ``ConfigManager`` and the audit
+service, with ``HOOK_API_VERSION = 1`` (additive-only from here):
+
+- ``on_before_load(config_dir)``: before settings/users are read (startup and
+  every reload). Use: render files from a store into the directory.
+- ``on_config_saved(path, kind)``: after an atomic write of ``settings.yaml``
+  (``kind="settings"``) or ``users.yaml`` (``kind="users"``). Use: push to a
+  store, ``git commit``, notify.
+- ``on_audit_event(event)``: after an audit entry is recorded. Use: ship
+  audit elsewhere.
+
+Two implementations of the same contract share one dispatcher, so there is
+one contract: shell commands declared in YAML (placeholders ``{config_dir}``,
+``{path}``, ``{kind}``, ``{event_type}``; the audit event is also passed as
+JSON on stdin), and Python plugins discovered through the ``nanoidp.plugins``
+entry-point group. Order per hook: shell hook first, then plugins in
+declaration order.
+
+Error policy, per hook (identical for shell and Python):
+
+- ``on_before_load`` is the only hook that may block an operation, because it
+  runs before any mutation. Default: log and continue with whatever is in
+  the directory; ``hooks.strict: true``: the load fails with the hook's error.
+- ``on_config_saved`` runs after the atomic write, so the local save is
+  always committed. Default: log. ``strict``: the error is propagated to the
+  caller after the write (the file on disk is what was written).
+- ``on_audit_event`` never propagates, strict or not: an audit plugin failure
+  must not fail a ``/token`` whose token is already issued. Failures are
+  counted and surfaced by ``nanoidp plugins`` and ``GET /api/config``.
+
+Timeouts are failures. No threads or async in the core; a plugin that wants
+asynchrony does it on its side.
+
+Bootstrap: ``on_before_load`` runs before ``settings.yaml`` is read, but hook
+configuration is declared in ``settings.yaml``, so the main use case (render
+the files from a store) needs a surface outside the file it fetches:
+``NANOIDP_BOOTSTRAP_HOOK`` (a shell command run once before the first load),
+``NANOIDP_BOOTSTRAP_PLUGIN`` (an entry-point name), ``NANOIDP_PLUGIN_<NAME>_<KEY>``
+variables, and an optional ``bootstrap.yaml`` inside the config directory
+(``hooks:`` and ``plugins:`` keys only). See ``bootstrap_registry``.
+
+This module imports nothing from the package except ``config_documents`` (for
+the section models), so ``config.py`` and the audit service can both import
+it without a cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass, field
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import yaml
+
+from .config_documents import BootstrapDocument
+
+logger = logging.getLogger(__name__)
+
+HOOK_API_VERSION = 1
+
+HOOK_NAMES = ("on_before_load", "on_config_saved", "on_audit_event")
+
+ENTRY_POINT_GROUP = "nanoidp.plugins"
+
+BOOTSTRAP_HOOK_ENV = "NANOIDP_BOOTSTRAP_HOOK"
+BOOTSTRAP_PLUGIN_ENV = "NANOIDP_BOOTSTRAP_PLUGIN"
+PLUGIN_ENV_PREFIX = "NANOIDP_PLUGIN_"
+BOOTSTRAP_FILE = "bootstrap.yaml"
+
+# Where a hook or plugin was declared; reported by ``nanoidp plugins``.
+SOURCE_BOOTSTRAP_ENV = "bootstrap-env"
+SOURCE_BOOTSTRAP_FILE = "bootstrap.yaml"
+SOURCE_SETTINGS = "settings.yaml"
+
+
+class HookError(RuntimeError):
+    """A hook failed and the policy for that hook says the caller must know."""
+
+
+@dataclass
+class ShellHook:
+    hook: str
+    command: str
+    source: str
+    failures: int = 0
+    # Bootstrap shell hooks run once, before the first load, and never again.
+    once: bool = False
+    ran: bool = False
+
+    def describe(self) -> Dict[str, Any]:
+        return {
+            "hook": self.hook,
+            "command": self.command,
+            "source": self.source,
+            "failures": self.failures,
+            "once": self.once,
+        }
+
+
+@dataclass
+class LoadedPlugin:
+    name: str
+    obj: Any
+    api_version: int
+    source: str
+    config: Dict[str, Any] = field(default_factory=dict)
+    failures: Dict[str, int] = field(default_factory=lambda: dict.fromkeys(HOOK_NAMES, 0))
+
+    @property
+    def hooks(self) -> List[str]:
+        return [h for h in HOOK_NAMES if callable(getattr(self.obj, h, None))]
+
+    def describe(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "hook_api_version": self.api_version,
+            "hooks": self.hooks,
+            "source": self.source,
+            "failures": dict(self.failures),
+        }
+
+
+class HookRegistry:
+    """The single dispatcher every hook call goes through.
+
+    Holds shell hooks and plugins from all three surfaces. Entries sourced
+    from ``settings.yaml`` are replaced on every load (the file may have
+    changed); bootstrap entries persist for the life of the process.
+    """
+
+    def __init__(self) -> None:
+        self.shell_hooks: List[ShellHook] = []
+        self.plugins: List[LoadedPlugin] = []
+        self.strict: bool = False
+        self.timeout_seconds: float = 10.0
+        # Failure counters of entries dropped by drop_source(), keyed so the
+        # same declaration re-read from settings.yaml on reload keeps its
+        # history instead of reporting a fresh zero.
+        self._retired_shell: Dict[tuple, int] = {}
+        self._retired_plugins: Dict[tuple, Dict[str, int]] = {}
+
+    # ------------------------------------------------------------------ setup
+
+    def add_shell_hook(self, hook: str, command: str, source: str, once: bool = False) -> None:
+        if hook not in HOOK_NAMES:
+            raise ValueError(f"Unknown hook {hook!r}; expected one of {', '.join(HOOK_NAMES)}")
+        entry = ShellHook(hook=hook, command=command, source=source, once=once)
+        entry.failures = self._retired_shell.pop((hook, command, source), 0)
+        self.shell_hooks.append(entry)
+
+    def add_plugin(self, name: str, source: str, config: Optional[Mapping[str, Any]] = None) -> LoadedPlugin:
+        """Load ``name`` from the ``nanoidp.plugins`` entry-point group."""
+        if any(p.name == name for p in self.plugins):
+            raise ValueError(f"Plugin {name!r} is already loaded")
+        candidates = [ep for ep in metadata.entry_points(group=ENTRY_POINT_GROUP) if ep.name == name]
+        if not candidates:
+            raise ValueError(
+                f"Plugin {name!r} not found: no '{ENTRY_POINT_GROUP}' entry point with that "
+                f"name is installed (pip install the package that provides it)"
+            )
+        factory = candidates[0].load()
+        # An entry point may point at a class (instantiate it) or at a
+        # ready-made object.
+        obj = factory() if isinstance(factory, type) else factory
+        return self.register_plugin_object(name, obj, source, config)
+
+    def register_plugin_object(
+        self, name: str, obj: Any, source: str, config: Optional[Mapping[str, Any]] = None
+    ) -> LoadedPlugin:
+        """Register an already-constructed plugin (tests, in-process use)."""
+        api_version = getattr(obj, "hook_api_version", None)
+        if api_version != HOOK_API_VERSION:
+            raise ValueError(
+                f"Plugin {name!r} declares hook_api_version={api_version!r}; this nanoidp "
+                f"implements hook API version {HOOK_API_VERSION}. Upgrade the plugin or nanoidp."
+            )
+        plugin = LoadedPlugin(name=name, obj=obj, api_version=api_version, source=source, config=dict(config or {}))
+        plugin.failures.update(self._retired_plugins.pop((name, source), {}))
+        configure = getattr(obj, "configure", None)
+        if callable(configure):
+            configure(dict(plugin.config))
+        self.plugins.append(plugin)
+        return plugin
+
+    def drop_source(self, source: str) -> None:
+        """Forget every entry declared by ``source`` (used before re-reading settings.yaml)."""
+        for h in self.shell_hooks:
+            if h.source == source:
+                self._retired_shell[(h.hook, h.command, h.source)] = h.failures
+        for p in self.plugins:
+            if p.source == source:
+                self._retired_plugins[(p.name, p.source)] = dict(p.failures)
+        self.shell_hooks = [h for h in self.shell_hooks if h.source != source]
+        self.plugins = [p for p in self.plugins if p.source != source]
+
+    def configure_from_sections(
+        self,
+        hooks: Mapping[str, Any],
+        plugins: Mapping[str, Any],
+        source: str,
+    ) -> None:
+        """Apply a validated ``hooks:`` / ``plugins:`` pair from ``source``."""
+        for hook in HOOK_NAMES:
+            command = hooks.get(hook)
+            if command:
+                self.add_shell_hook(hook, command, source)
+        if "strict" in hooks and hooks["strict"] is not None:
+            self.strict = bool(hooks["strict"])
+        if "timeout_seconds" in hooks and hooks["timeout_seconds"] is not None:
+            self.timeout_seconds = float(hooks["timeout_seconds"])
+        for name, config in plugins.items():
+            self.add_plugin(name, source, config or {})
+
+    # --------------------------------------------------------------- dispatch
+
+    def run_before_load(self, config_dir: Path) -> None:
+        """May raise ``HookError`` under ``strict``; otherwise logs and returns."""
+        self._dispatch(
+            "on_before_load",
+            shell_placeholders={"config_dir": str(config_dir)},
+            plugin_args=(config_dir,),
+            propagate=self.strict,
+        )
+
+    def run_config_saved(self, path: Path, kind: str) -> None:
+        """The write is already committed; under ``strict`` a failure is raised
+        to the caller AFTER the file is on disk."""
+        self._dispatch(
+            "on_config_saved",
+            shell_placeholders={"path": str(path), "kind": kind},
+            plugin_args=(path, kind),
+            propagate=self.strict,
+        )
+
+    def run_audit_event(self, event: Mapping[str, Any]) -> None:
+        """Never raises, strict or not: hooks must not alter protocol behaviour."""
+        try:
+            self._dispatch(
+                "on_audit_event",
+                shell_placeholders={"event_type": str(event.get("event_type", ""))},
+                plugin_args=(dict(event),),
+                propagate=False,
+                stdin_json=dict(event),
+            )
+        except Exception:  # pragma: no cover - defensive, _dispatch already swallows
+            logger.exception("audit hook dispatch failed")
+
+    def _dispatch(
+        self,
+        hook: str,
+        shell_placeholders: Mapping[str, str],
+        plugin_args: tuple,
+        propagate: bool,
+        stdin_json: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        errors: List[str] = []
+        for shell_hook in [h for h in self.shell_hooks if h.hook == hook]:
+            if shell_hook.once and shell_hook.ran:
+                continue
+            shell_hook.ran = True
+            error = self._run_shell(shell_hook, shell_placeholders, stdin_json)
+            if error is not None:
+                shell_hook.failures += 1
+                errors.append(error)
+        for plugin in self.plugins:
+            fn = getattr(plugin.obj, hook, None)
+            if not callable(fn):
+                continue
+            try:
+                fn(*plugin_args)
+            except Exception as exc:
+                plugin.failures[hook] += 1
+                message = f"plugin {plugin.name!r} {hook} failed: {exc}"
+                logger.warning(message)
+                errors.append(message)
+        if errors and propagate:
+            raise HookError("; ".join(errors))
+
+    def _run_shell(
+        self,
+        shell_hook: ShellHook,
+        placeholders: Mapping[str, str],
+        stdin_json: Optional[Mapping[str, Any]],
+    ) -> Optional[str]:
+        """Run one shell hook; return an error message or None."""
+        command = shell_hook.command
+        # str.replace, not str.format: a command legitimately contains braces
+        # (${VAR}, jq filters) that must not be interpreted as placeholders.
+        for key, value in placeholders.items():
+            command = command.replace("{" + key + "}", value)
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                timeout=self.timeout_seconds,
+                capture_output=True,
+                text=True,
+                env=os.environ.copy(),
+                input=json.dumps(stdin_json) if stdin_json is not None else None,
+            )
+        except subprocess.TimeoutExpired:
+            message = (
+                f"{shell_hook.hook} shell hook ({shell_hook.source}) timed out after "
+                f"{self.timeout_seconds}s: {shell_hook.command}"
+            )
+            logger.warning(message)
+            return message
+        except OSError as exc:
+            message = f"{shell_hook.hook} shell hook ({shell_hook.source}) could not run: {exc}"
+            logger.warning(message)
+            return message
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            message = (
+                f"{shell_hook.hook} shell hook ({shell_hook.source}) exited "
+                f"{result.returncode}: {shell_hook.command}"
+                + (f" [stderr: {stderr}]" if stderr else "")
+            )
+            logger.warning(message)
+            return message
+        logger.debug("%s shell hook ok: %s", shell_hook.hook, shell_hook.command)
+        return None
+
+    # ---------------------------------------------------------- introspection
+
+    def describe(self) -> Dict[str, Any]:
+        """What ``nanoidp plugins``, ``GET /api/config`` and MCP report."""
+        return {
+            "hook_api_version": HOOK_API_VERSION,
+            "strict": self.strict,
+            "timeout_seconds": self.timeout_seconds,
+            "shell_hooks": [h.describe() for h in self.shell_hooks],
+            "plugins": [p.describe() for p in self.plugins],
+        }
+
+    def format_report(self) -> str:
+        """Human-readable form of ``describe()`` for the CLI."""
+        info = self.describe()
+        lines = [
+            f"hook API version: {info['hook_api_version']}",
+            f"strict: {info['strict']}  timeout_seconds: {info['timeout_seconds']}",
+            "",
+            "shell hooks:",
+        ]
+        if not info["shell_hooks"]:
+            lines.append("  (none)")
+        for h in info["shell_hooks"]:
+            once = "  [bootstrap, runs once]" if h["once"] else ""
+            lines.append(f"  {h['hook']:<16} {h['source']:<14} failures={h['failures']}{once}")
+            lines.append(f"    {h['command']}")
+        lines.append("")
+        lines.append("plugins:")
+        if not info["plugins"]:
+            lines.append("  (none)")
+        for p in info["plugins"]:
+            lines.append(
+                f"  {p['name']:<16} api={p['hook_api_version']} {p['source']:<14} "
+                f"hooks={','.join(p['hooks']) or '-'} failures={p['failures']}"
+            )
+        return "\n".join(lines)
+
+
+# ------------------------------------------------------------------ bootstrap
+
+
+def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = None) -> HookRegistry:
+    """Build the registry from the bootstrap surface, before settings.yaml exists.
+
+    Sources, in order: ``bootstrap.yaml`` in the config directory (``hooks:``
+    and ``plugins:`` only, validated by the same section models, unknown keys
+    refused), then the environment: ``NANOIDP_BOOTSTRAP_HOOK`` (an
+    ``on_before_load`` shell command that runs once, before the first load),
+    ``NANOIDP_BOOTSTRAP_PLUGIN`` (entry-point name) with its settings taken
+    from ``NANOIDP_PLUGIN_<NAME>_<KEY>`` variables (name upper-cased, ``-``
+    as ``_``, keys lower-cased). A bootstrap plugin is a plugin like any
+    other: loaded once, it takes part in every hook for the life of the
+    process.
+    """
+    env = os.environ if environ is None else environ
+    registry = HookRegistry()
+
+    bootstrap_file = config_dir / BOOTSTRAP_FILE
+    if bootstrap_file.exists():
+        with open(bootstrap_file, "r") as f:
+            raw = yaml.safe_load(f) or {}
+        document = BootstrapDocument.model_validate(raw)
+        registry.configure_from_sections(
+            document.hooks.model_dump(),
+            document.plugins,
+            SOURCE_BOOTSTRAP_FILE,
+        )
+        # bootstrap.yaml's on_before_load runs before the first load only,
+        # like the env hook: settings.yaml owns reloads.
+        for hook in registry.shell_hooks:
+            if hook.source == SOURCE_BOOTSTRAP_FILE and hook.hook == "on_before_load":
+                hook.once = True
+
+    command = env.get(BOOTSTRAP_HOOK_ENV)
+    if command:
+        registry.add_shell_hook("on_before_load", command, SOURCE_BOOTSTRAP_ENV, once=True)
+
+    plugin_name = env.get(BOOTSTRAP_PLUGIN_ENV)
+    if plugin_name:
+        registry.add_plugin(plugin_name, SOURCE_BOOTSTRAP_ENV, plugin_settings_from_env(plugin_name, env))
+
+    return registry
+
+
+def plugin_settings_from_env(plugin_name: str, environ: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
+    """``NANOIDP_PLUGIN_<NAME>_<KEY>=value`` -> ``{"<key>": "value"}``."""
+    env = os.environ if environ is None else environ
+    prefix = PLUGIN_ENV_PREFIX + plugin_name.upper().replace("-", "_") + "_"
+    return {
+        key[len(prefix):].lower(): value
+        for key, value in env.items()
+        if key.startswith(prefix) and len(key) > len(prefix)
+    }
+

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -683,7 +683,10 @@ _TOOLS: list[Tool] = [
     ),
     Tool(
         name="update_settings",
-        description="Update NanoIDP settings (issuer, audience, token expiry, SAML options, etc.)",
+        description="Update NanoIDP settings (issuer, audience, token expiry, SAML options, etc.). "
+        "hooks: and plugins: (#185) are YAML-only, like secret_key and require_ui_login: "
+        "they are reported by get_settings but cannot be changed here, since a command "
+        "editable through the surface it observes would be a remote-execution primitive.",
         input_schema={
             "type": "object",
             "properties": {
@@ -1291,6 +1294,8 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             },
             "authority_prefixes": settings.authority_prefixes,
             "allowed_identity_classes": settings.allowed_identity_classes,
+            # Hooks and plugins (#185): same block as GET /api/config.
+            "hooks": config.hooks.describe(),
         }
 
     elif name == "reload_config":

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -348,7 +348,11 @@ class Settings(BaseModel):
         description="When on, an on_before_load failure fails the load and an on_config_saved "
         "failure is propagated to the caller after the write. on_audit_event never propagates.",
     )
-    hooks_timeout_seconds: float = Field(default=10.0, gt=0, description="Per-hook timeout for shell hooks")
+    hooks_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description="Timeout for shell hooks only; a Python plugin manages its own timeouts",
+    )
     plugins: Dict[str, Dict[str, Any]] = Field(
         default_factory=dict,
         description="Python plugins to load from the 'nanoidp.plugins' entry-point group, "

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -325,6 +325,36 @@ class Settings(BaseModel):
         "mode). YAML-only, like require_ui_login and secret_key.",
     )
 
+    # Hooks and plugins (#185): extension points, not backends. Effective
+    # values as loaded from settings.yaml; reported by /api/config and MCP,
+    # never settable through them (YAML-only, like secret_key).
+    hooks_on_before_load: Optional[str] = Field(
+        default=None,
+        description="Shell command run before settings/users are read (startup and every reload); "
+        "placeholder {config_dir}. Use: render the files from an external store.",
+    )
+    hooks_on_config_saved: Optional[str] = Field(
+        default=None,
+        description="Shell command run after an atomic write of settings.yaml or users.yaml; "
+        "placeholders {path}, {kind}. The local save is already committed when it runs.",
+    )
+    hooks_on_audit_event: Optional[str] = Field(
+        default=None,
+        description="Shell command run after an audit entry is recorded; placeholder {event_type}, "
+        "event JSON on stdin. Never fails the request that produced the event.",
+    )
+    hooks_strict: bool = Field(
+        default=False,
+        description="When on, an on_before_load failure fails the load and an on_config_saved "
+        "failure is propagated to the caller after the write. on_audit_event never propagates.",
+    )
+    hooks_timeout_seconds: float = Field(default=10.0, gt=0, description="Per-hook timeout for shell hooks")
+    plugins: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Python plugins to load from the 'nanoidp.plugins' entry-point group, "
+        "keyed by name, each with its own settings mapping (plugin-owned keys).",
+    )
+
     # Logging
     log_level: str = Field(default="INFO", description="Logging level")
     log_token_requests: bool = Field(default=True, description="Log token requests")

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -186,6 +186,9 @@ def get_configuration() -> ResponseReturnValue:
             "rate_limit_enabled": settings.rate_limit_enabled,
             "debug": settings.debug,
         },
+        # Hooks and plugins (#185): what is loaded, from which surface, and
+        # the failure counters. YAML-only; reported, never settable here.
+        "hooks": config.hooks.describe(),
         "users_count": len(config.users),
     })
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -23,6 +23,7 @@ from flask.typing import ResponseReturnValue
 
 from ..branding import effective_logos_dir
 from ..config import OAuthClient, User, get_config
+from ..hooks import HookError
 from ..services import get_audit_log, get_token_service, get_yaml_writer
 from ._audit import audit_event
 from ._auth import ui_login_required
@@ -620,6 +621,13 @@ def settings() -> ResponseReturnValue:
         flash("Settings updated successfully", "success")
         return redirect(url_for("ui.settings"))
 
+    except HookError as e:
+        # The local write and the reload already happened (#185): the form's
+        # values are in effect, only the mirror hook failed. The message
+        # names the hook and its source, never the command.
+        logger.warning("Settings saved locally; mirror hook failed: %s", e)
+        flash(f"Settings saved locally; mirror hook failed: {e}", "error")
+        return redirect(url_for("ui.settings"))
     except Exception as e:
         logger.exception("Failed to update settings")
         flash(f"Failed to update settings: {e}", "error")

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -109,6 +109,15 @@ class AuditLog:
         else:
             logger.warning(log_msg)
 
+        # on_audit_event (#185): after the entry is recorded. The registry
+        # never lets a hook failure out of run_audit_event; the guard here
+        # covers the config singleton itself being unavailable.
+        try:
+            from ..config import get_config
+            get_config().hooks.run_audit_event(entry.to_dict())
+        except Exception:
+            logger.debug("audit hooks unavailable", exc_info=True)
+
     def _update_stats(self, event_type: str, status: str) -> None:
         """Update statistics counters."""
         self._stats["total_requests"] += 1

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -33,8 +33,11 @@ class YamlWriter:
         self.settings_file = self.config_dir / "settings.yaml"
 
     def _atomic_write(self, file_path: Path, data: Dict[str, Any]) -> None:
-        """Atomically write a YAML document (shared implementation, #83)."""
+        """Atomically write a YAML document (shared implementation, #83), then
+        notify the on_config_saved hooks through ConfigManager (#185)."""
         atomic_write_yaml(file_path, data)
+        kind = "users" if file_path.name == "users.yaml" else "settings"
+        get_config().notify_saved(file_path, kind)
 
     def _load_users_yaml(self) -> Dict[str, Any]:
         """Load the current users.yaml content."""

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -88,7 +88,6 @@ class YamlWriter:
 
         self._atomic_write(self.users_file, data)
 
-        # Reload config to pick up changes
 
     def delete_user(self, username: str) -> None:
         """
@@ -111,7 +110,6 @@ class YamlWriter:
 
         self._atomic_write(self.users_file, data)
 
-        # Reload config to pick up changes
 
     def set_default_user(self, username: str) -> None:
         """Set the default user for client_credentials grant."""

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -35,18 +35,29 @@ class YamlWriter:
 
     def _atomic_write(self, file_path: Path, data: Dict[str, Any]) -> None:
         """Atomically write a YAML document (shared implementation, #83), then
-        notify the on_config_saved hooks through ConfigManager (#185)."""
+        run the single post-write contract (#185):
+
+            write local -> notify the mirror (on_config_saved) -> refresh the
+            runtime FROM LOCAL DISK -> propagate a mirror failure if strict.
+
+        The refresh is ConfigManager.reload_local(), never reload(): a
+        reload() would run on_before_load and could pull a stale or
+        failed-to-update mirror back over the file just written, turning a
+        mirror hiccup into a silent rollback (#185 review). The disk is the
+        newest state after our own write; only an explicit reload consults
+        the mirror.
+        """
         atomic_write_yaml(file_path, data)
         kind = "users" if file_path.name == "users.yaml" else "settings"
+        config = get_config()
+        hook_error: Optional[HookError] = None
         try:
-            get_config().notify_saved(file_path, kind)
-        except HookError:
-            # Under hooks.strict the mirror failed AFTER the local write. The
-            # caller's own reload() will not run once we raise, so reload
-            # here first: disk and runtime must carry the same (new) value,
-            # only the mirror is behind (#185 review).
-            get_config().reload()
-            raise
+            config.notify_saved(file_path, kind)
+        except HookError as exc:
+            hook_error = exc
+        config.reload_local()
+        if hook_error is not None:
+            raise hook_error
 
     def _load_users_yaml(self) -> Dict[str, Any]:
         """Load the current users.yaml content."""
@@ -77,7 +88,7 @@ class YamlWriter:
 
         self._atomic_write(self.users_file, data)
 
-        get_config().reload()
+        # Reload config to pick up changes
 
     def delete_user(self, username: str) -> None:
         """
@@ -100,7 +111,7 @@ class YamlWriter:
 
         self._atomic_write(self.users_file, data)
 
-        get_config().reload()
+        # Reload config to pick up changes
 
     def set_default_user(self, username: str) -> None:
         """Set the default user for client_credentials grant."""
@@ -112,7 +123,6 @@ class YamlWriter:
         data["default_user"] = username
 
         self._atomic_write(self.users_file, data)
-        get_config().reload()
 
     # ==================== OAuth Client Operations ====================
 
@@ -146,7 +156,6 @@ class YamlWriter:
             clients.append(client_to_yaml(client))
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
     def delete_client(self, client_id: str) -> None:
         """Delete an OAuth client from settings.yaml."""
@@ -163,7 +172,6 @@ class YamlWriter:
         data["oauth"]["clients"] = new_clients
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
     # ==================== Settings Operations ====================
 
@@ -238,7 +246,6 @@ class YamlWriter:
                     oauth.pop("logos_dir", None)
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
     def update_saml_settings(
         self,
@@ -317,7 +324,6 @@ class YamlWriter:
                 saml.pop("groups_attr_name", None)
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
     def update_authority_prefixes(self, prefixes: Dict[str, str]) -> None:
         """Update authority prefix mappings."""
@@ -326,7 +332,6 @@ class YamlWriter:
             data["authority_prefixes"] = prefixes
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
     def update_allowed_identity_classes(self, classes: List[str]) -> None:
         """Update allowed identity classes."""
@@ -335,7 +340,6 @@ class YamlWriter:
             data["allowed_identity_classes"] = classes
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
     def update_login_settings(self, mode: Optional[str] = None) -> None:
         """Update the 'login' section (persona login mode, local dev
@@ -359,7 +363,6 @@ class YamlWriter:
             merge_optional_nested_field(data, "login", "mode", mode, login_mode_default)
 
         self._atomic_write(self.settings_file, data)
-        get_config().reload()
 
 
 # Global instance

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from ..config import OAuthClient, Settings, User, get_config
 from ..config_documents import document_defaults
+from ..hooks import HookError
 from ..serialization import (
     atomic_write_yaml,
     client_id_matches,
@@ -37,7 +38,15 @@ class YamlWriter:
         notify the on_config_saved hooks through ConfigManager (#185)."""
         atomic_write_yaml(file_path, data)
         kind = "users" if file_path.name == "users.yaml" else "settings"
-        get_config().notify_saved(file_path, kind)
+        try:
+            get_config().notify_saved(file_path, kind)
+        except HookError:
+            # Under hooks.strict the mirror failed AFTER the local write. The
+            # caller's own reload() will not run once we raise, so reload
+            # here first: disk and runtime must carry the same (new) value,
+            # only the mirror is behind (#185 review).
+            get_config().reload()
+            raise
 
     def _load_users_yaml(self) -> Dict[str, Any]:
         """Load the current users.yaml content."""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -608,3 +608,69 @@ class TestStrictSaveKeepsDiskAndRuntimeAligned:
         assert "Settings saved locally; mirror hook failed" in page
         assert get_config().settings.audience == "aligned"
         assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["oauth"]["audience"] == "aligned"
+
+
+class TestPostWriteRefreshNeverConsultsTheMirror:
+    """#185 review: the refresh after a local write must read the LOCAL files
+    only. If it ran on_before_load, a mirror that has not caught up (or whose
+    push just failed) would be copied back over the file just written: a
+    silent rollback, with the UI still reporting success."""
+
+    def _mirror_setup(self, tmp_path, strict):
+        remote = tmp_path / "remote"
+        remote.mkdir()
+        cfg = _write(tmp_path)
+        # the mirror holds the OLD configuration
+        (remote / "settings.yaml").write_text((tmp_path / "settings.yaml").read_text())
+        (tmp_path / "settings.yaml").write_text(
+            (tmp_path / "settings.yaml").read_text()
+            + yaml.safe_dump({"hooks": {
+                "on_before_load": f"cp {remote}/settings.yaml {{config_dir}}/settings.yaml",
+                "on_config_saved": "false",
+                "strict": strict,
+            }})
+        )
+        (remote / "settings.yaml").write_text((tmp_path / "settings.yaml").read_text())
+        return cfg, remote
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_failed_push_does_not_roll_the_write_back(self, tmp_path, strict):
+        from nanoidp.config import get_config
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        cfg, remote = self._mirror_setup(tmp_path, strict)
+        init_config(cfg)
+        assert get_config().settings.login_mode == "password"
+        writer = YamlWriter(cfg)
+        if strict:
+            with pytest.raises(HookError):
+                writer.update_login_settings(mode="persona")
+        else:
+            writer.update_login_settings(mode="persona")
+        local = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert local["login"]["mode"] == "persona", "local write must survive"
+        assert get_config().settings.login_mode == "persona", "runtime must follow the local disk"
+        assert "login" not in yaml.safe_load((remote / "settings.yaml").read_text()), "mirror untouched (push failed)"
+
+    def test_explicit_reload_still_pulls_from_the_mirror(self, tmp_path):
+        """The mirror is consulted by the EXTERNAL reload only."""
+        from nanoidp.config import get_config
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        cfg, remote = self._mirror_setup(tmp_path, strict=False)
+        init_config(cfg)
+        YamlWriter(cfg).update_login_settings(mode="persona")
+        assert get_config().settings.login_mode == "persona"
+        get_config().reload()  # on_before_load copies the old mirror back
+        assert get_config().settings.login_mode == "password"
+
+    def test_reload_local_does_not_run_before_load(self, tmp_path):
+        from nanoidp.config import get_config
+
+        log = tmp_path / "hooks.log"
+        init_config(_write(tmp_path, {"hooks": {"on_before_load": _record_cmd(log, "before")}}))
+        n = len(_lines(log))
+        get_config().reload_local()
+        assert len(_lines(log)) == n
+        get_config().reload()
+        assert len(_lines(log)) == n + 1

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -197,7 +197,7 @@ class TestErrorPolicy:
     def test_bootstrap_strict_blocks_the_first_load(self, tmp_path):
         cfg = _write(tmp_path)
         (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {"on_before_load": "exit 3", "strict": True}}))
-        with pytest.raises(HookError, match="exited 3"):
+        with pytest.raises(HookError, match=r"on_before_load shell hook \(bootstrap.yaml\) failed \(exit 3\)"):
             ConfigManager(cfg)
 
     def test_config_saved_failure_default_logs_and_file_is_written(self, tmp_path, caplog):
@@ -253,7 +253,6 @@ class TestErrorPolicy:
 
     def test_plugin_failure_follows_the_same_policy(self, tmp_path):
         class Broken:
-            name = "broken"
             hook_api_version = HOOK_API_VERSION
 
             def on_config_saved(self, path, kind):
@@ -266,8 +265,8 @@ class TestErrorPolicy:
         config.hooks.register_plugin_object("broken", Broken(), SOURCE_SETTINGS)
         config.save()  # default: logged
         assert config.hooks.plugins[0].failures["on_config_saved"] == 2  # users + settings
-        config.hooks.strict = True
-        with pytest.raises(HookError, match="plugin 'broken' on_config_saved failed: store down"):
+        config.hooks.set_policy(SOURCE_SETTINGS, strict=True)
+        with pytest.raises(HookError, match="plugin 'broken' on_config_saved failed$"):
             config.save()
         get_audit_log().log("x", "/x", "GET", "success")  # never raises
         assert config.hooks.plugins[0].failures["on_audit_event"] == 1
@@ -423,3 +422,189 @@ class TestRegistryUnit:
         r.add_shell_hook("on_before_load", "b", SOURCE_SETTINGS)
         r.drop_source(SOURCE_SETTINGS)
         assert [h.command for h in r.shell_hooks] == ["a"]
+
+
+class TestSecretsNeverLeaveTheProcess:
+    """#185 review, blocker: commands are stored after ${VAR} expansion and
+    /api/* is unauthenticated, so neither describe() nor a propagated
+    HookError may carry a command or a hook's stderr."""
+
+    SECRET = "s3cr3t-value"
+
+    def _app(self, tmp_path, monkeypatch, strict=True):
+        from nanoidp.app import create_app
+
+        monkeypatch.setenv("MIRROR_TOKEN", self.SECRET)
+        cfg = _write(tmp_path, {"hooks": {
+            "on_config_saved": 'echo "leaking ${MIRROR_TOKEN}" >&2; curl -s -H "Authorization: Bearer ${MIRROR_TOKEN}" http://127.0.0.1:9/ >/dev/null 2>&1; exit 1',
+            "strict": strict,
+        }})
+        app = create_app(config_dir=cfg)
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        return app
+
+    def test_api_config_and_mcp_expose_no_command(self, tmp_path, monkeypatch, mcp_call_tool):
+        import asyncio
+
+        import nanoidp.mcp_server as mcp
+
+        app = self._app(tmp_path, monkeypatch)
+        with app.test_client() as client:
+            body = client.get("/api/config").get_data(as_text=True)
+            block = client.get("/api/config").get_json()["hooks"]
+        assert self.SECRET not in body
+        assert all("command" not in h for h in block["shell_hooks"])
+        assert set(block["shell_hooks"][0]) == {"hook", "source", "failures", "once"}
+        mcp._config = ConfigManager(str(tmp_path))
+        result = asyncio.run(mcp_call_tool("get_settings", {}))
+        assert self.SECRET not in result.content[0].text
+        assert "command" not in result.content[0].text
+
+    def test_propagated_error_and_ui_flash_carry_no_command_or_stderr(self, tmp_path, monkeypatch, caplog):
+        from nanoidp.config import get_config
+
+        app = self._app(tmp_path, monkeypatch)
+        get_config().settings.audience = "changed"
+        with caplog.at_level("WARNING"):
+            with pytest.raises(HookError) as exc_info:
+                get_config()._save_settings()
+        message = str(exc_info.value)
+        assert message == "on_config_saved shell hook (settings.yaml) failed (exit 1)"
+        assert self.SECRET not in message and "curl" not in message
+        # the local log is the one place that has the command and stderr
+        assert self.SECRET in caplog.text and "[stderr: leaking" in caplog.text
+        # the UI flash under strict
+        with app.test_client() as client:
+            resp = client.post("/settings", data={"issuer": "http://localhost:8000", "audience": "x"}, follow_redirects=True)
+            page = resp.get_data(as_text=True)
+        assert self.SECRET not in page and "curl" not in page
+        assert "Settings saved locally; mirror hook failed" in page
+
+    def test_plugin_exception_text_is_not_propagated(self, tmp_path):
+        class Leaky:
+            hook_api_version = HOOK_API_VERSION
+
+            def on_config_saved(self, path, kind):
+                raise RuntimeError("https://store/?token=" + TestSecretsNeverLeaveTheProcess.SECRET)
+
+        config = init_config(_write(tmp_path, {"hooks": {"strict": True}}))
+        config.hooks.register_plugin_object("leaky", Leaky(), SOURCE_SETTINGS)
+        with pytest.raises(HookError) as exc_info:
+            config._save_settings()
+        assert str(exc_info.value) == "plugin 'leaky' on_config_saved failed"
+
+    def test_cli_report_is_the_only_place_with_commands(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIRROR_TOKEN", self.SECRET)
+        config = ConfigManager(_write(tmp_path, {"hooks": {"on_config_saved": "echo ${MIRROR_TOKEN}"}}))
+        assert "command" not in str(config.hooks.describe())
+        report = config.hooks.format_report()
+        assert "command (local only, may embed secrets): echo " + self.SECRET in report
+
+
+class TestSourcePrecedenceAndLifecycle:
+    """#185 review, blocker: bootstrap policy is the baseline, settings.yaml
+    overrides only what it declares, and a vanished settings.yaml takes its
+    entries and policy with it."""
+
+    def _bootstrap(self, tmp_path, **hooks):
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": hooks}))
+
+    def test_bootstrap_strict_survives_a_settings_file_without_hooks(self, tmp_path):
+        self._bootstrap(tmp_path, on_config_saved="false", strict=True, timeout_seconds=2)
+        config = ConfigManager(_write(tmp_path))  # no hooks: in settings.yaml
+        assert config.hooks.strict is True and config.hooks.timeout_seconds == 2.0
+        config.settings.audience = "changed"
+        with pytest.raises(HookError, match=r"\(bootstrap.yaml\) failed"):
+            config._save_settings()
+        config.reload()
+        assert config.hooks.strict is True and config.hooks.timeout_seconds == 2.0
+
+    def test_settings_overrides_only_what_it_declares(self, tmp_path):
+        self._bootstrap(tmp_path, on_config_saved="false", strict=True, timeout_seconds=2)
+        config = ConfigManager(_write(tmp_path, {"hooks": {"strict": False}}))
+        assert config.hooks.strict is False
+        assert config.hooks.timeout_seconds == 2.0  # not declared: bootstrap value stays
+        config.settings.audience = "changed"
+        config._save_settings()  # not strict any more: logged, not raised
+
+    def test_vanished_settings_file_drops_its_hooks_plugins_and_policy(self, tmp_path, fake_entry_points):
+        class Tracker:
+            hook_api_version = HOOK_API_VERSION
+
+        fake_entry_points["tracker"] = Tracker
+        self._bootstrap(tmp_path, on_config_saved="true", timeout_seconds=3)
+        cfg = _write(tmp_path, {"hooks": {"on_config_saved": "true", "strict": True, "timeout_seconds": 1}, "plugins": {"tracker": {}}})
+        config = ConfigManager(cfg)
+        assert {h.source for h in config.hooks.shell_hooks} == {SOURCE_BOOTSTRAP_FILE, SOURCE_SETTINGS}
+        assert [p.name for p in config.hooks.plugins] == ["tracker"]
+        assert config.hooks.strict is True and config.hooks.timeout_seconds == 1.0
+        (tmp_path / "settings.yaml").unlink()
+        config.reload()
+        assert {h.source for h in config.hooks.shell_hooks} == {SOURCE_BOOTSTRAP_FILE}
+        assert config.hooks.plugins == []
+        assert config.hooks.strict is False and config.hooks.timeout_seconds == 3.0
+
+    def test_bootstrap_yaml_rejects_non_positive_timeout(self, tmp_path):
+        for value in (0, -1):
+            self._bootstrap(tmp_path, timeout_seconds=value)
+            with pytest.raises(ValidationError):
+                ConfigManager(_write(tmp_path))
+
+
+class TestConfigDirPlaceholderOnSave:
+    def test_config_dir_is_available_to_on_config_saved_and_audit(self, tmp_path):
+        log = tmp_path / "hooks.log"
+        cfg = _write(tmp_path, {"hooks": {
+            "on_config_saved": f"echo 'saved {{config_dir}} {{kind}}' >> {log}",
+            "on_audit_event": f"echo 'audit {{config_dir}} {{event_type}}' >> {log}",
+        }})
+        config = init_config(cfg)
+        config._save_settings()
+        get_audit_log().log("token_request", "/token", "POST", "success")
+        assert f"saved {tmp_path} settings" in _lines(log)
+        assert f"audit {tmp_path} token_request" in _lines(log)
+
+    def test_git_worked_example_runs(self, tmp_path):
+        import shutil
+        import subprocess
+
+        if shutil.which("git") is None:
+            pytest.skip("git not installed")
+        cfg = _write(tmp_path, {"hooks": {
+            "on_config_saved": "git -C {config_dir} add {path} && git -C {config_dir} commit -q -m 'nanoidp: {kind} saved'",
+            "strict": True,
+        }})
+        subprocess.run(["git", "-C", cfg, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", cfg, "config", "user.email", "t@example.org"], check=True)
+        subprocess.run(["git", "-C", cfg, "config", "user.name", "t"], check=True)
+        config = ConfigManager(cfg)
+        config.settings.audience = "versioned"
+        config._save_settings()  # strict: a failing git command would raise
+        log = subprocess.run(["git", "-C", cfg, "log", "--oneline"], capture_output=True, text=True, check=True).stdout
+        assert "nanoidp: settings saved" in log
+
+
+class TestStrictSaveKeepsDiskAndRuntimeAligned:
+    def test_yaml_writer_reloads_before_propagating(self, tmp_path):
+        from nanoidp.config import get_config
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        init_config(_write(tmp_path, {"hooks": {"on_config_saved": "false", "strict": True}}))
+        assert get_config().settings.login_mode == "password"
+        with pytest.raises(HookError):
+            YamlWriter(str(tmp_path)).update_login_settings(mode="persona")
+        assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["login"]["mode"] == "persona"
+        assert get_config().settings.login_mode == "persona"  # runtime == disk
+
+    def test_ui_settings_save_under_strict_shows_new_value(self, tmp_path):
+        from nanoidp.app import create_app
+        from nanoidp.config import get_config
+
+        app = create_app(config_dir=_write(tmp_path, {"hooks": {"on_config_saved": "false", "strict": True}}))
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            page = client.post("/settings", data={"issuer": "http://localhost:8000", "audience": "aligned"}, follow_redirects=True).get_data(as_text=True)
+        assert "Settings saved locally; mirror hook failed" in page
+        assert get_config().settings.audience == "aligned"
+        assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["oauth"]["audience"] == "aligned"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,425 @@
+"""
+Hooks and plugins v1 (#185): the three extension points, the bootstrap
+surface, the per-hook error policy, plugin loading and introspection.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+import nanoidp.hooks as hooks_module
+from nanoidp.config import ConfigManager, init_config
+from nanoidp.config_documents import BootstrapDocument
+from nanoidp.hooks import (
+    HOOK_API_VERSION,
+    SOURCE_BOOTSTRAP_ENV,
+    SOURCE_BOOTSTRAP_FILE,
+    SOURCE_SETTINGS,
+    HookError,
+    HookRegistry,
+    plugin_settings_from_env,
+)
+from nanoidp.services.audit import get_audit_log
+
+REPO = Path(__file__).resolve().parent.parent
+ECHO_SRC = REPO / "examples" / "plugins" / "nanoidp-echo" / "src" / "nanoidp_echo" / "__init__.py"
+
+
+def _echo_plugin_class():
+    """Import the reference plugin from examples/ without installing it."""
+    spec = importlib.util.spec_from_file_location("nanoidp_echo", ECHO_SRC)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("nanoidp_echo", module)
+    spec.loader.exec_module(module)
+    return module.EchoPlugin
+
+
+def _write(tmp_path, settings=None, users=None):
+    doc = {"server": {"host": "127.0.0.1", "port": 8000}}
+    doc.update(settings or {})
+    (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+    (tmp_path / "users.yaml").write_text(yaml.safe_dump(users or {"users": {"alice": {"password": "x"}}}))
+    return str(tmp_path)
+
+
+def _record_cmd(log: Path, text: str) -> str:
+    return f"echo '{text}' >> {log}"
+
+
+def _lines(log: Path):
+    return log.read_text().splitlines() if log.exists() else []
+
+
+@pytest.fixture
+def fake_entry_points(monkeypatch):
+    """Register plugin classes under the nanoidp.plugins group in-process."""
+    registry = {}
+
+    def entry_points(group=None):
+        if group != hooks_module.ENTRY_POINT_GROUP:
+            return []
+        return [SimpleNamespace(name=name, load=lambda cls=cls: cls) for name, cls in registry.items()]
+
+    monkeypatch.setattr(hooks_module.metadata, "entry_points", entry_points)
+    return registry
+
+
+class TestShellHooksReceivePlaceholders:
+    def test_before_load_and_config_saved(self, tmp_path):
+        log = tmp_path / "hooks.log"
+        cfg = _write(tmp_path, {"hooks": {
+            "on_before_load": _record_cmd(log, "load {config_dir}"),
+            "on_config_saved": _record_cmd(log, "saved {kind} {path}"),
+        }})
+        config = ConfigManager(cfg)
+        # settings.yaml's on_before_load cannot run before the file that
+        # declares it is read: first load has no settings-sourced hook yet.
+        assert _lines(log) == []
+        config.reload()
+        assert _lines(log) == [f"load {tmp_path}"]
+        config.save()
+        lines = _lines(log)
+        assert f"saved users {tmp_path / 'users.yaml'}" in lines
+        assert f"saved settings {tmp_path / 'settings.yaml'}" in lines
+
+    def test_yaml_writer_saves_dispatch_too(self, tmp_path):
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        log = tmp_path / "hooks.log"
+        init_config(_write(tmp_path, {"hooks": {"on_config_saved": _record_cmd(log, "{kind}")}}))
+        YamlWriter(str(tmp_path)).update_login_settings(mode="persona")
+        assert "settings" in _lines(log)
+
+    def test_audit_event_gets_event_type_and_json_stdin(self, tmp_path):
+        log = tmp_path / "hooks.log"
+        init_config(_write(tmp_path, {"hooks": {
+            "on_audit_event": f"cat >> {log}; echo ' {{event_type}}' >> {log}",
+        }}))
+        get_audit_log().log("token_request", "/token", "POST", "success", username="alice")
+        text = log.read_text()
+        assert '"event_type": "token_request"' in text
+        assert text.rstrip().endswith("token_request")
+
+    def test_braces_in_commands_are_not_placeholders(self, tmp_path):
+        log = tmp_path / "hooks.log"
+        init_config(_write(tmp_path, {"hooks": {"on_config_saved": f"echo '${{HOME:-x}} {{kind}}' >> {log}"}}))
+        ConfigManager(str(tmp_path)).save()
+        assert _lines(log)[-1].endswith(" settings")
+
+
+class TestBootstrapSurface:
+    def test_env_hook_runs_once_before_first_load_not_on_reload(self, tmp_path, monkeypatch):
+        log = tmp_path / "hooks.log"
+        cfg = _write(tmp_path)
+        monkeypatch.setenv("NANOIDP_BOOTSTRAP_HOOK", _record_cmd(log, "bootstrap {config_dir}"))
+        config = ConfigManager(cfg)
+        assert _lines(log) == [f"bootstrap {tmp_path}"]
+        config.reload()
+        config.reload()
+        assert _lines(log) == [f"bootstrap {tmp_path}"]
+        hook = config.hooks.describe()["shell_hooks"][0]
+        assert hook["source"] == SOURCE_BOOTSTRAP_ENV and hook["once"] is True
+
+    def test_bootstrap_hook_can_render_the_settings_file(self, tmp_path, monkeypatch):
+        """The main use case: the file that declares everything else does not
+        exist until the bootstrap hook has run."""
+        rendered = tmp_path / "rendered.yaml"
+        rendered.write_text(yaml.safe_dump({"oauth": {"issuer": "http://rendered:1"}}))
+        (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {}}))
+        monkeypatch.setenv("NANOIDP_BOOTSTRAP_HOOK", f"cp {rendered} {{config_dir}}/settings.yaml")
+        assert not (tmp_path / "settings.yaml").exists()
+        config = ConfigManager(str(tmp_path))
+        assert config.settings.issuer == "http://rendered:1"
+
+    def test_bootstrap_yaml_hooks_and_unknown_key_refused(self, tmp_path):
+        log = tmp_path / "hooks.log"
+        cfg = _write(tmp_path)
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {
+            "on_before_load": _record_cmd(log, "file-bootstrap"),
+            "on_config_saved": _record_cmd(log, "file-saved"),
+        }}))
+        config = ConfigManager(cfg)
+        assert _lines(log) == ["file-bootstrap"]
+        config.reload()
+        assert _lines(log) == ["file-bootstrap"]  # before_load from bootstrap.yaml runs once
+        config.save()
+        assert _lines(log).count("file-saved") == 2  # users + settings, every save
+        assert {h["source"] for h in config.hooks.describe()["shell_hooks"]} == {SOURCE_BOOTSTRAP_FILE}
+
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {}, "oauth": {"issuer": "x"}}))
+        with pytest.raises(Exception, match="oauth"):
+            ConfigManager(cfg)
+
+    def test_bootstrap_yaml_only_hooks_and_plugins(self):
+        doc = BootstrapDocument.model_validate({"hooks": None, "plugins": None})
+        assert doc.hooks.on_before_load is None and doc.plugins == {}
+        with pytest.raises(ValidationError, match="server"):
+            BootstrapDocument.model_validate({"server": {}})
+
+    def test_plugin_settings_from_env(self):
+        env = {"NANOIDP_PLUGIN_MY_STORE_BUCKET": "b", "NANOIDP_PLUGIN_MY_STORE_PREFIX": "p", "NANOIDP_PLUGIN_OTHER_X": "1", "NANOIDP_PLUGIN_MY_STORE_": "ignored"}
+        assert plugin_settings_from_env("my-store", env) == {"bucket": "b", "prefix": "p"}
+
+    def test_bootstrap_plugin_from_env(self, tmp_path, monkeypatch, fake_entry_points):
+        fake_entry_points["echo"] = _echo_plugin_class()
+        record = tmp_path / "record.jsonl"
+        monkeypatch.setenv("NANOIDP_BOOTSTRAP_PLUGIN", "echo")
+        monkeypatch.setenv("NANOIDP_PLUGIN_ECHO_RECORD", str(record))
+        config = ConfigManager(_write(tmp_path))
+        plugin = config.hooks.plugins[0]
+        assert plugin.source == SOURCE_BOOTSTRAP_ENV and plugin.config == {"record": str(record)}
+        # a bootstrap plugin takes part in every hook for the life of the process
+        config.reload()
+        hooks_seen = [line for line in record.read_text().splitlines() if "on_before_load" in line]
+        assert len(hooks_seen) == 2
+
+
+class TestErrorPolicy:
+    def test_before_load_failure_is_logged_by_default(self, tmp_path, caplog):
+        cfg = _write(tmp_path, {"hooks": {"on_before_load": "false"}})
+        config = ConfigManager(cfg)
+        with caplog.at_level("WARNING"):
+            config.reload()
+        assert "on_before_load shell hook (settings.yaml) exited 1" in caplog.text
+        assert config.hooks.describe()["shell_hooks"][0]["failures"] == 1
+
+    def test_before_load_failure_blocks_under_strict(self, tmp_path):
+        cfg = _write(tmp_path, {"hooks": {"on_before_load": "false", "strict": True}})
+        config = ConfigManager(cfg)  # first load: the file's strict is not known yet
+        with pytest.raises(HookError, match="on_before_load"):
+            config.reload()
+
+    def test_bootstrap_strict_blocks_the_first_load(self, tmp_path):
+        cfg = _write(tmp_path)
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {"on_before_load": "exit 3", "strict": True}}))
+        with pytest.raises(HookError, match="exited 3"):
+            ConfigManager(cfg)
+
+    def test_config_saved_failure_default_logs_and_file_is_written(self, tmp_path, caplog):
+        config = ConfigManager(_write(tmp_path, {"hooks": {"on_config_saved": "echo boom >&2; false"}}))
+        config.settings.audience = "changed"
+        with caplog.at_level("WARNING"):
+            config.save()
+        assert "on_config_saved shell hook (settings.yaml) exited 1" in caplog.text
+        assert "[stderr: boom]" in caplog.text
+        assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["oauth"]["audience"] == "changed"
+
+    def test_config_saved_failure_propagates_under_strict_after_the_write(self, tmp_path):
+        config = ConfigManager(_write(tmp_path, {"hooks": {"on_config_saved": "false", "strict": True}}))
+        config.settings.audience = "changed"
+        with pytest.raises(HookError, match="on_config_saved"):
+            config._save_settings()
+        # the local save is committed regardless
+        on_disk = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert on_disk["oauth"]["audience"] == "changed"
+
+    def test_strict_save_stops_at_the_first_failed_write(self, tmp_path):
+        """ConfigManager.save() writes users.yaml then settings.yaml; under
+        strict the users hook failure propagates before settings.yaml is
+        touched. Documented behaviour: each write is committed before its
+        hook runs, and a propagated failure ends the sequence."""
+        config = ConfigManager(_write(tmp_path, {"hooks": {"on_config_saved": "false", "strict": True}}))
+        config.settings.audience = "changed"
+        with pytest.raises(HookError):
+            config.save()
+        on_disk = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert (on_disk.get("oauth") or {}).get("audience") != "changed"
+
+    def test_config_saved_strict_reaches_yaml_writer_callers(self, tmp_path):
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        init_config(_write(tmp_path, {"hooks": {"on_config_saved": "false", "strict": True}}))
+        with pytest.raises(HookError):
+            YamlWriter(str(tmp_path)).update_login_settings(mode="persona")
+        assert yaml.safe_load((tmp_path / "settings.yaml").read_text())["login"]["mode"] == "persona"
+
+    def test_audit_event_failure_never_propagates_even_under_strict(self, tmp_path):
+        config = init_config(_write(tmp_path, {"hooks": {"on_audit_event": "false", "strict": True}}))
+        get_audit_log().log("token_request", "/token", "POST", "success")
+        get_audit_log().log("token_request", "/token", "POST", "success")
+        assert config.hooks.describe()["shell_hooks"][0]["failures"] == 2
+
+    def test_timeout_is_a_failure(self, tmp_path, caplog):
+        config = ConfigManager(_write(tmp_path, {"hooks": {"on_config_saved": "sleep 5", "timeout_seconds": 0.2}}))
+        with caplog.at_level("WARNING"):
+            config.save()
+        assert "timed out after 0.2s" in caplog.text
+        assert config.hooks.timeout_seconds == 0.2
+
+    def test_plugin_failure_follows_the_same_policy(self, tmp_path):
+        class Broken:
+            name = "broken"
+            hook_api_version = HOOK_API_VERSION
+
+            def on_config_saved(self, path, kind):
+                raise RuntimeError("store down")
+
+            def on_audit_event(self, event):
+                raise RuntimeError("audit down")
+
+        config = init_config(_write(tmp_path))
+        config.hooks.register_plugin_object("broken", Broken(), SOURCE_SETTINGS)
+        config.save()  # default: logged
+        assert config.hooks.plugins[0].failures["on_config_saved"] == 2  # users + settings
+        config.hooks.strict = True
+        with pytest.raises(HookError, match="plugin 'broken' on_config_saved failed: store down"):
+            config.save()
+        get_audit_log().log("x", "/x", "GET", "success")  # never raises
+        assert config.hooks.plugins[0].failures["on_audit_event"] == 1
+
+
+class TestPlugins:
+    def test_entry_point_plugin_discovered_configured_and_called(self, tmp_path, fake_entry_points):
+        fake_entry_points["echo"] = _echo_plugin_class()
+        record = tmp_path / "record.jsonl"
+        config = init_config(_write(tmp_path, {"plugins": {"echo": {"record": str(record)}}}))
+        plugin = config.hooks.plugins[0]
+        assert plugin.name == "echo" and plugin.source == SOURCE_SETTINGS
+        assert plugin.hooks == ["on_before_load", "on_config_saved", "on_audit_event"]
+        assert plugin.obj.record == record  # configure() received plugins.echo
+        config.save()
+        get_audit_log().log("login", "/login", "POST", "success")
+        hooks_recorded = [yaml.safe_load(line)["hook"] for line in record.read_text().splitlines()]
+        assert hooks_recorded == ["on_config_saved", "on_config_saved", "on_audit_event"]
+        config.reload()
+        assert yaml.safe_load(record.read_text().splitlines()[-1])["hook"] == "on_before_load"
+        # reload re-reads settings.yaml: the plugin is re-registered, not duplicated
+        assert [p.name for p in config.hooks.plugins] == ["echo"]
+
+    def test_bare_plugin_entry_means_no_settings(self, tmp_path, fake_entry_points):
+        fake_entry_points["echo"] = _echo_plugin_class()
+        config = ConfigManager(_write(tmp_path, {"plugins": {"echo": None}}))
+        assert config.hooks.plugins[0].config == {}
+        assert config.settings.plugins == {"echo": {}}
+
+    def test_unknown_plugin_is_a_clear_error(self, tmp_path, fake_entry_points):
+        with pytest.raises(ValueError, match="Plugin 'nope' not found: no 'nanoidp.plugins' entry point"):
+            ConfigManager(_write(tmp_path, {"plugins": {"nope": {}}}))
+
+    def test_api_version_mismatch_refused(self, tmp_path, fake_entry_points):
+        class Old:
+            name = "old"
+            hook_api_version = 0
+
+        fake_entry_points["old"] = Old
+        with pytest.raises(ValueError, match="declares hook_api_version=0; this nanoidp implements hook API version 1"):
+            ConfigManager(_write(tmp_path, {"plugins": {"old": {}}}))
+
+    def test_shell_hook_runs_before_plugins(self, tmp_path):
+        order = []
+
+        class P:
+            name = "p"
+            hook_api_version = 1
+
+            def on_config_saved(self, path, kind):
+                order.append(f"plugin:{kind}")
+
+        log = tmp_path / "hooks.log"
+        config = init_config(_write(tmp_path, {"hooks": {"on_config_saved": _record_cmd(log, "shell")}}))
+        config.hooks.register_plugin_object("p", P(), SOURCE_SETTINGS)
+        config._save_settings()
+        assert _lines(log) == ["shell"] and order == ["plugin:settings"]
+
+    def test_plugins_section_shape_is_validated_but_keys_are_not(self, tmp_path):
+        with pytest.raises(ValueError, match="plugins.echo must be a mapping"):
+            ConfigManager(_write(tmp_path, {"plugins": {"echo": "x"}}))
+        with pytest.raises(ValueError, match="plugins must be a mapping"):
+            ConfigManager(_write(tmp_path, {"plugins": ["echo"]}))
+
+
+class TestIntrospection:
+    def test_api_config_and_mcp_report_the_same_block(self, tmp_path, mcp_call_tool):
+        import asyncio
+
+        from nanoidp.app import create_app
+
+        log = tmp_path / "hooks.log"
+        app = create_app(config_dir=_write(tmp_path, {"hooks": {"on_config_saved": _record_cmd(log, "x"), "timeout_seconds": 3}}))
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            block = client.get("/api/config").get_json()["hooks"]
+        assert block["hook_api_version"] == HOOK_API_VERSION
+        assert block["strict"] is False and block["timeout_seconds"] == 3.0
+        assert block["shell_hooks"][0]["hook"] == "on_config_saved"
+        assert block["shell_hooks"][0]["source"] == SOURCE_SETTINGS
+        assert block["plugins"] == []
+
+        import nanoidp.mcp_server as mcp
+        mcp._config = ConfigManager(str(tmp_path))
+        result = asyncio.run(mcp_call_tool("get_settings", {}))
+        payload = yaml.safe_load(result.content[0].text)
+        assert payload["hooks"] == block
+
+    def test_update_settings_schema_says_hooks_are_yaml_only(self, mcp_list_tools):
+        import asyncio
+
+        tools = asyncio.run(mcp_list_tools())
+        update = next(t for t in tools if t.name == "update_settings")
+        assert "YAML-only" in update.description
+        assert "hooks" not in update.input_schema["properties"]
+        assert "plugins" not in update.input_schema["properties"]
+
+    def test_cli_plugins_subcommand(self, tmp_path, capsys, monkeypatch):
+        from nanoidp.__main__ import main
+
+        log = tmp_path / "hooks.log"
+        cfg = _write(tmp_path, {"hooks": {"on_before_load": _record_cmd(log, "l")}})
+        monkeypatch.setattr(sys, "argv", ["nanoidp", "plugins", "--config", cfg])
+        main()
+        out = capsys.readouterr().out
+        assert "hook API version: 1" in out
+        assert "on_before_load   settings.yaml  failures=0" in out
+        assert "plugins:\n  (none)" in out
+
+    def test_cli_bootstrap_hook_flag_maps_to_env(self, monkeypatch, tmp_path):
+        from nanoidp import __main__ as main_mod
+
+        called = {}
+        monkeypatch.setattr(sys, "argv", ["nanoidp", "--bootstrap-hook", "echo hi", "--config", _write(tmp_path)])
+        # setenv (not delenv) so monkeypatch restores the variable to absent
+        # after main() has overwritten it; otherwise it leaks into later tests.
+        monkeypatch.setenv("NANOIDP_BOOTSTRAP_HOOK", "overwritten-by-main")
+        import nanoidp.app as app_mod
+        monkeypatch.setattr(app_mod, "run_app", lambda **kw: called.update(kw))
+        main_mod.main()
+        import os
+        assert os.environ["NANOIDP_BOOTSTRAP_HOOK"] == "echo hi"
+        assert called["config_dir"] == _write(tmp_path)
+
+    def test_shipped_config_declares_no_hooks(self):
+        config = ConfigManager(str(REPO / "config"))
+        info = config.hooks.describe()
+        assert info["shell_hooks"] == [] and info["plugins"] == []
+        assert config.settings.hooks_on_before_load is None and config.settings.plugins == {}
+
+    def test_hooks_survive_a_settings_save_untouched(self, tmp_path):
+        """The writer manages its own keys only; hooks:/plugins: are preserved
+        verbatim (read-modify-write, #87) and never materialized."""
+        cfg = _write(tmp_path, {"hooks": {"on_config_saved": "true", "strict": True}, "plugins": {}})
+        config = ConfigManager(cfg)
+        config.settings.audience = "a"
+        config.save()
+        on_disk = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert on_disk["hooks"] == {"on_config_saved": "true", "strict": True}
+        cfg2 = _write(tmp_path)
+        ConfigManager(cfg2).save()
+        assert "hooks" not in yaml.safe_load((tmp_path / "settings.yaml").read_text())
+
+
+class TestRegistryUnit:
+    def test_unknown_hook_name_refused(self):
+        with pytest.raises(ValueError, match="Unknown hook"):
+            HookRegistry().add_shell_hook("on_login", "true", SOURCE_SETTINGS)
+
+    def test_drop_source_keeps_other_sources(self):
+        r = HookRegistry()
+        r.add_shell_hook("on_before_load", "a", SOURCE_BOOTSTRAP_ENV, once=True)
+        r.add_shell_hook("on_before_load", "b", SOURCE_SETTINGS)
+        r.drop_source(SOURCE_SETTINGS)
+        assert [h.command for h in r.shell_hooks] == ["a"]


### PR DESCRIPTION
Closes #185. Extension points, not backends: three synchronous hooks on the file and audit lifecycle, implementable as shell commands from YAML or as separately packaged Python plugins. nanoidp keeps talking only to its files; a plugin cannot become the storage, intercept requests or touch token issuance.

## Contract v1 (`HOOK_API_VERSION = 1`)

- `on_before_load(config_dir)` before settings/users are read (startup and every reload); `on_config_saved(path, kind)` after every atomic write of either file (one dispatch point, `ConfigManager.notify_saved`, reached by `ConfigManager.save()` and by every `YamlWriter` write); `on_audit_event(event)` after an audit entry is recorded.
- Shell hooks in `settings.yaml` (`hooks:` section, placeholders `{config_dir}`, `{path}`, `{kind}`, `{event_type}`; the audit event as JSON on stdin; `timeout_seconds`, default 10). Python plugins through the `nanoidp.plugins` entry-point group, configured under `plugins.<name>:`; `hook_api_version` other than 1 refused with a clear message. One dispatcher (`hooks.py`, `HookRegistry`): shell hook first, then plugins in declaration order.
- Bootstrap surface for hooks that must run before `settings.yaml` exists: `NANOIDP_BOOTSTRAP_HOOK` / `--bootstrap-hook` (run once before the first load, not on reload), `NANOIDP_BOOTSTRAP_PLUGIN` plus `NANOIDP_PLUGIN_<NAME>_<KEY>` variables, and `<config_dir>/bootstrap.yaml` (`hooks:` and `plugins:` keys only, unknown keys refused).

## Error policy, per hook (as in the issue)

- `on_before_load`: default log and continue; `hooks.strict: true` fails the load. Note in the guide: `strict` declared in `settings.yaml` cannot apply to the very first load, use `bootstrap.yaml` for that.
- `on_config_saved`: the local save is always committed first; default log; under `strict` the error is propagated to the caller after the write (UI flash "Settings saved locally; mirror hook failed", `/api` error, MCP `isError`), hooks must be idempotent. One post-write contract, owned by `YamlWriter._atomic_write`: write local -> notify the mirror -> refresh the runtime FROM LOCAL DISK (`ConfigManager.reload_local()`, which never runs `on_before_load`) -> propagate under `strict`. Disk and runtime therefore always carry the written value; a mirror that has not caught up cannot roll the write back. Only the explicit reload (startup, `POST /api/config/reload`, MCP `reload_config`) runs `on_before_load`. A multi-step save stops at the first failed write under `strict`.
- `on_audit_event`: never propagates, strict or not; failures are counted per hook.

## Introspection and parity

- `nanoidp plugins` lists hooks and plugins with API version, implemented hooks, failure counters and the surface each came from (`bootstrap-env`, `bootstrap.yaml`, `settings.yaml`); it is the only place that prints commands (local terminal, marked as possibly embedding secrets). `/api/config` and MCP expose `hook`, `source`, `failures`, `once` and never the command; propagated `HookError` messages are fixed-format, without command or stderr.
- Policy (`strict`, `timeout_seconds`) is kept per source: settings.yaml overrides only what it explicitly declares, bootstrap is the baseline, and dropping the settings source (missing file on reload) restores it. `timeout_seconds` is shell-only (`gt=0` on the document); plugin identity is the entry-point name.
- `GET /api/config` and the MCP `get_settings` tool expose the same `hooks` block; `update_settings` documents that `hooks:`/`plugins:` are YAML-only (same treatment as `secret_key` and `require_ui_login`). The writer leaves both sections untouched (read-modify-write), tested.
- `examples/test_agent.py`: `API Hooks Block` check, and a line-count check against `NANOIDP_E2E_HOOK_LOG` when the e2e server was started with a recording hook (skips cleanly otherwise).
- Reference plugin `examples/plugins/nanoidp-echo` (installable package with the entry point; logs every hook and records calls to a file from its settings), used in-process by the tests.

## Docs

`book/src/guides/extending.md` (contract, error-policy table, bootstrap, worked `git commit` and "render from a store before load" examples, plugin skeleton), linked from SUMMARY and the configuration reference; SECURITY.md paragraph on the trust boundary (plugins run with the process's privileges; shell hooks run whatever the operator-owned YAML says); MCP_WORKFLOW.md note; CHANGELOG.

## Verification

- 50 new tests (`tests/test_hooks.py`): placeholders on load/save/audit, bootstrap once and not on reload, default vs strict per hook with the file still written for `on_config_saved`, audit never propagating and counting, timeout, plugin discovery/config/call, API version mismatch refused, `bootstrap.yaml` unknown key refused, `/api/config` and MCP parity, writer preserves the sections, shipped configs still load with zero warnings; secrets never in `/api/config`/MCP/errors/flash; source precedence and lifecycle; `{config_dir}` on save and audit (git example runs for real); strict keeps disk and runtime aligned; a failed push with a stale mirror never rolls the write back (strict and non-strict) while an explicit reload still pulls from the mirror. 1310 passed, ruff/mypy clean, `lint-imports` 2 kept.
- Live: bootstrap hook wrote one `before-load <config_dir>` line and none on reload; a UI settings save produced `saved settings <path>` lines (four, the settings page does four atomic writes, pre-existing); failing `on_config_saved` in default mode logged with stderr and counted, in strict mode the file had the new value and the UI flashed the error; a failing `on_audit_event` (`false`) counted 2 failures across two `/token` calls that completed normally with their audit entries recorded.
