### PR TITLE
fix: hook registration under the error policy, JSON errors on reload, audit logging never loads config (review before 2.7.0rc4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NANOIDP_PLUGIN_<NAME>_<KEY>` settings, and `bootstrap.yaml` in the config
   directory (`hooks:` and `plugins:` only). `nanoidp plugins`, `GET
   /api/config` and the MCP `get_settings` tool report what is loaded, from
-  which surface, with failure counters; `hooks:`/`plugins:` are YAML-only.
-  Reference plugin `examples/plugins/nanoidp-echo`; guide "Extending nanoidp:
-  hooks and plugins".
+  which surface, with failure counters and the plugins that could not be
+  loaded (`plugins_failed`: a missing package or a wrong `hook_api_version`
+  is reported, never fatal unless `strict`); `hooks:`/`plugins:` are
+  YAML-only. `bootstrap.yaml` goes through the same loader as
+  `settings.yaml` (placeholders, unknown-key warnings). A strict
+  `on_before_load` failure is a JSON `503` on `POST /api/config/reload` and
+  an error result from the MCP `reload_config` tool. Audit logging never
+  constructs the configuration and an audit event produced inside a load is
+  not dispatched to hooks. An unchanged `hooks:`/`plugins:` declaration is
+  not re-applied on the refresh that follows a local write, so plugins are
+  not re-instantiated on every save. Reference plugin
+  `examples/plugins/nanoidp-echo`; guide "Extending nanoidp: hooks and
+  plugins".
 - **Import contracts enforced in CI** (#149): `import-linter` now pins the
   package layering (`routes -> services -> config`) and the invariant that
   `serialization.py` has no runtime imports from the package (it is what
@@ -133,7 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profile_override=)`), the effective profile and its hardening are re-derived
   after every settings load, and a save serializes the DECLARED state
   (`ConfigManager.persistable_settings()`), so neither the override nor
-  the hardening it implies is ever written into the operator's file. `GET /api/config` exposes `security_profile`,
+  the hardening it implies is ever written into the operator's file. `GET /api/config` and the MCP `get_settings` tool expose `security_profile`,
   `profile_override` and the derived `effective` values; the e2e agent checks
   they are stable across a reload.
 - **`users.yaml` now expands `${VAR}` / `${VAR:default}` placeholders** like

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -98,7 +98,7 @@ outside the normal config covers it:
 |---|---|---|
 | `NANOIDP_BOOTSTRAP_HOOK="<command>"` or `nanoidp --bootstrap-hook "<command>"` | an `on_before_load` shell command | once, before the first load |
 | `NANOIDP_BOOTSTRAP_PLUGIN=<name>` with `NANOIDP_PLUGIN_<NAME>_<KEY>=<value>` | a plugin and its settings (name upper-cased, `-` as `_`) | loaded once, then takes part in every hook |
-| `bootstrap.yaml` in the configuration directory | `hooks:` and `plugins:` only, same schema as `settings.yaml`; any other key is refused | its `on_before_load` once, its other hooks and plugins always |
+| `bootstrap.yaml` in the configuration directory | `hooks:` and `plugins:` only, same schema and same loader as `settings.yaml`: `${VAR}` placeholders expand, an unknown key is warned with its path and ignored, a wrong type stops startup | its `on_before_load` once, its other hooks and plugins always |
 
 Precedence of the policy values (`strict`, `timeout_seconds`): the
 bootstrap surface is the baseline; `settings.yaml` overrides a value only
@@ -115,6 +115,14 @@ and saves. `nanoidp plugins` shows which surface each entry came from
 from `settings.yaml` cannot apply to the very first load (the file is not
 known yet): to make a failed bootstrap render fatal, set `strict: true` in
 `bootstrap.yaml`.
+
+A plugin that cannot be loaded (its package is not installed, it declares
+another `hook_api_version`, its `configure()` raises) follows the same
+policy as `on_before_load`: logged at ERROR, listed under `plugins_failed`
+by `nanoidp plugins`, `GET /api/config` and the MCP `get_settings` tool,
+and skipped; under `strict` the load fails. A failed `on_before_load` under
+`strict` is reported by `POST /api/config/reload` as a JSON `503` and by the
+MCP `reload_config` tool as an error result, never as an HTML error page.
 
 ## Worked example: version every change in git
 

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -120,9 +120,20 @@ A plugin that cannot be loaded (its package is not installed, it declares
 another `hook_api_version`, its `configure()` raises) follows the same
 policy as `on_before_load`: logged at ERROR, listed under `plugins_failed`
 by `nanoidp plugins`, `GET /api/config` and the MCP `get_settings` tool,
-and skipped; under `strict` the load fails. A failed `on_before_load` under
-`strict` is reported by `POST /api/config/reload` as a JSON `503` and by the
-MCP `reload_config` tool as an error result, never as an HTML error page.
+and skipped; under `strict` the load fails. The public `reason` is one of
+nanoidp's own diagnoses (`not installed`, `incompatible hook_api_version=N
+(expected 1)`, `already loaded`, `initialization failed`); the exception
+text itself, which may embed the plugin's settings, goes to the local log
+only. A plugin that failed in non-strict mode is retried only when the
+`hooks:`/`plugins:` declaration changes or the process restarts: a reload
+with an unchanged declaration does not re-apply it.
+
+A failed `on_before_load` or plugin load under `strict` is reported by
+`POST /api/config/reload` as a JSON `503` (`kind` names the phase:
+`on_before_load` or `plugin_load`) and by the MCP `reload_config` tool as an
+error result, never as an HTML error page. Such a reload fails without
+commit: the running settings, the profile hardening and the registered
+plugins stay exactly as they were until a later reload succeeds.
 
 ## Worked example: version every change in git
 

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -71,6 +71,11 @@ class ConfigManager:
         # the first load because settings.yaml may be what a hook renders;
         # settings.yaml's own hooks: / plugins: are merged in after each load.
         self.hooks: HookRegistry = bootstrap_registry(self.config_dir)
+        # Last settings.yaml hooks:/plugins: declaration applied to the
+        # registry; an unchanged declaration is not re-applied on the next
+        # load, so a post-write refresh does not drop and re-instantiate
+        # plugins (review before 2.7.0rc4).
+        self._hooks_snapshot: Optional[tuple] = None
         self._load_config()
 
     def _find_config_dir(self) -> str:
@@ -171,6 +176,7 @@ class ConfigManager:
             # A vanished settings.yaml takes its hooks, plugins and policy
             # with it (#185 review); bootstrap entries stay.
             self.hooks.drop_source(SOURCE_SETTINGS)
+            self._hooks_snapshot = None
             self._set_default_settings()
             return
 
@@ -193,11 +199,20 @@ class ConfigManager:
 
     def _configure_hooks_from(self, hooks: HooksSection, plugins: Dict[str, Dict[str, Any]]) -> None:
         """Replace the settings.yaml-sourced hooks/plugins with the file's
-        current declaration (#185); bootstrap entries are untouched."""
+        current declaration (#185); bootstrap entries are untouched. Skipped
+        when the declaration is identical to the one already applied."""
+        snapshot = (
+            hooks.model_dump(),
+            frozenset(hooks.model_fields_set),
+            {k: dict(v) for k, v in plugins.items()},
+        )
+        if snapshot == self._hooks_snapshot:
+            return
         self.hooks.drop_source(SOURCE_SETTINGS)
         # The HooksSection itself, not model_dump(): only the policy values
         # the file declares explicitly override the bootstrap baseline.
         self.hooks.configure_from_sections(hooks, plugins, SOURCE_SETTINGS)
+        self._hooks_snapshot = snapshot
 
     def notify_saved(self, path: Path, kind: str) -> None:
         """The single on_config_saved call site for every write path (#185):
@@ -407,6 +422,16 @@ class ConfigManager:
 # Global config instance
 _config: Optional[ConfigManager] = None
 _config_lock = threading.Lock()
+
+
+def get_config_if_loaded() -> Optional[ConfigManager]:
+    """The global config instance if one exists, without constructing it.
+
+    For callers that must never trigger a load (the audit log, which may be
+    written from inside a hook while the singleton is being built under
+    _config_lock): None means "no configuration yet", not an error.
+    """
+    return _config
 
 
 def get_config() -> ConfigManager:

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -201,10 +201,13 @@ class ConfigManager:
         """Replace the settings.yaml-sourced hooks/plugins with the file's
         current declaration (#185); bootstrap entries are untouched. Skipped
         when the declaration is identical to the one already applied."""
+        # Plugins as an ORDERED tuple, not a dict: dict equality ignores
+        # order, and the v1 contract runs plugins in declaration order, so a
+        # file that only reorders them must be re-applied (#200 review).
         snapshot = (
             hooks.model_dump(),
             frozenset(hooks.model_fields_set),
-            {k: dict(v) for k, v in plugins.items()},
+            tuple((name, dict(cfg)) for name, cfg in plugins.items()),
         )
         if snapshot == self._hooks_snapshot:
             return

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -194,8 +194,14 @@ class ConfigManager:
         # domain Settings is built from it with every validator it already
         # had. ${VAR} expansion and config_version stay at the edge, above.
         document = load_settings_document(data, settings_file)
-        self.settings = document.to_settings()
+        # Fail without commit (#200 review): build the candidate, apply the
+        # file's hooks/plugins (which may raise under strict and then rolls
+        # the registry back), and only then promote the candidate. A reload
+        # that answers 503 leaves settings, profile hardening and registry
+        # exactly as they were.
+        candidate = document.to_settings()
         self._configure_hooks_from(document.hooks, document.plugins)
+        self.settings = candidate
 
     def _configure_hooks_from(self, hooks: HooksSection, plugins: Dict[str, Dict[str, Any]]) -> None:
         """Replace the settings.yaml-sourced hooks/plugins with the file's
@@ -211,10 +217,11 @@ class ConfigManager:
         )
         if snapshot == self._hooks_snapshot:
             return
-        self.hooks.drop_source(SOURCE_SETTINGS)
         # The HooksSection itself, not model_dump(): only the policy values
         # the file declares explicitly override the bootstrap baseline.
-        self.hooks.configure_from_sections(hooks, plugins, SOURCE_SETTINGS)
+        # replace_source rolls the registry back if registration raises, and
+        # the snapshot is recorded only on success so a retry re-applies.
+        self.hooks.replace_source(hooks, plugins, SOURCE_SETTINGS)
         self._hooks_snapshot = snapshot
 
     def notify_saved(self, path: Path, kind: str) -> None:

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -333,12 +333,6 @@ class SettingsDocument(BaseModel):
             log_token_requests=self.logging.log_token_requests,
             log_saml_requests=self.logging.log_saml_requests,
             verbose_logging=self.logging.verbose_logging,
-            hooks_on_before_load=self.hooks.on_before_load,
-            hooks_on_config_saved=self.hooks.on_config_saved,
-            hooks_on_audit_event=self.hooks.on_audit_event,
-            hooks_strict=self.hooks.strict,
-            hooks_timeout_seconds=self.hooks.timeout_seconds,
-            plugins=self.plugins,
         )
 
 
@@ -502,6 +496,12 @@ def load_settings_document(data: Dict[str, Any], file_path: Path) -> SettingsDoc
 
 def load_users_document(data: Dict[str, Any], file_path: Path) -> UsersDocument:
     return _load_document(UsersDocument, data, file_path)
+
+
+def load_bootstrap_document(data: Dict[str, Any], file_path: Path) -> BootstrapDocument:
+    """``bootstrap.yaml`` goes through the same unknown-key / wrong-type
+    reporting as ``settings.yaml`` (review before 2.7.0rc4)."""
+    return _load_document(BootstrapDocument, data, file_path)
 
 
 def document_defaults() -> Dict[str, Any]:

--- a/src/nanoidp/hooks.py
+++ b/src/nanoidp/hooks.py
@@ -293,6 +293,47 @@ class HookRegistry:
         # bootstrap baseline (or the default) applies again.
         self._policy.pop(source, None)
 
+    # ----------------------------------------------------------- transactions
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Copy of every piece of registry state, for rollback (#200 review).
+
+        Plugin objects are shared, not copied: a rolled-back reload keeps the
+        instances that were serving before, which is the point."""
+        return {
+            "shell_hooks": list(self.shell_hooks),
+            "plugins": list(self.plugins),
+            "policy": {k: dict(v) for k, v in self._policy.items()},
+            "retired_shell": dict(self._retired_shell),
+            "retired_plugins": {k: dict(v) for k, v in self._retired_plugins.items()},
+            "failed_plugins": {k: [dict(f) for f in v] for k, v in self._failed_plugins.items()},
+        }
+
+    def restore(self, snap: Dict[str, Any]) -> None:
+        """Put the registry back to a snapshot() state."""
+        self.shell_hooks = list(snap["shell_hooks"])
+        self.plugins = list(snap["plugins"])
+        self._policy = {k: dict(v) for k, v in snap["policy"].items()}
+        self._retired_shell = dict(snap["retired_shell"])
+        self._retired_plugins = {k: dict(v) for k, v in snap["retired_plugins"].items()}
+        self._failed_plugins = {k: [dict(f) for f in v] for k, v in snap["failed_plugins"].items()}
+
+    def replace_source(self, hooks: Any, plugins: Mapping[str, Any], source: str) -> None:
+        """Atomically replace everything ``source`` declares.
+
+        drop_source + configure_from_sections, but if registration raises
+        (strict plugin failure) the registry is restored to exactly what it
+        was, so a failed reload never leaves old plugins dropped and new ones
+        half loaded (#200 review: a failed reload must not commit).
+        """
+        snap = self.snapshot()
+        try:
+            self.drop_source(source)
+            self.configure_from_sections(hooks, plugins, source)
+        except HookError:
+            self.restore(snap)
+            raise
+
     def configure_from_sections(
         self,
         hooks: Any,

--- a/src/nanoidp/hooks.py
+++ b/src/nanoidp/hooks.py
@@ -105,7 +105,30 @@ SOURCE_SETTINGS = "settings.yaml"
 
 
 class HookError(RuntimeError):
-    """A hook failed and the policy for that hook says the caller must know."""
+    """A hook failed and the policy for that hook says the caller must know.
+
+    ``message`` is always a synthetic string built by the registry (hook
+    name, source, exit code); it never embeds a command, stderr or a
+    plugin's exception text, so callers may put it in an HTTP/MCP
+    response. ``kind`` says which phase failed: the hook name
+    (``on_before_load``, ``on_config_saved``) or ``plugin_load`` for a
+    plugin that could not be registered during a load.
+    """
+
+    def __init__(self, message: str, kind: str = "hook") -> None:
+        super().__init__(message)
+        self.message = message
+        self.kind = kind
+
+
+class PluginLoadError(ValueError):
+    """A plugin could not be registered, for a reason nanoidp itself
+    diagnosed. ``public_reason`` is safe to expose (it is built from names
+    and versions, never from plugin-provided text)."""
+
+    def __init__(self, message: str, public_reason: str) -> None:
+        super().__init__(message)
+        self.public_reason = public_reason
 
 
 @dataclass
@@ -222,12 +245,13 @@ class HookRegistry:
     def add_plugin(self, name: str, source: str, config: Optional[Mapping[str, Any]] = None) -> LoadedPlugin:
         """Load ``name`` from the ``nanoidp.plugins`` entry-point group."""
         if any(p.name == name for p in self.plugins):
-            raise ValueError(f"Plugin {name!r} is already loaded")
+            raise PluginLoadError(f"Plugin {name!r} is already loaded", "already loaded")
         candidates = [ep for ep in metadata.entry_points(group=ENTRY_POINT_GROUP) if ep.name == name]
         if not candidates:
-            raise ValueError(
+            raise PluginLoadError(
                 f"Plugin {name!r} not found: no '{ENTRY_POINT_GROUP}' entry point with that "
-                f"name is installed (pip install the package that provides it)"
+                f"name is installed (pip install the package that provides it)",
+                "not installed",
             )
         factory = candidates[0].load()
         # An entry point may point at a class (instantiate it) or at a
@@ -241,9 +265,10 @@ class HookRegistry:
         """Register an already-constructed plugin (tests, in-process use)."""
         api_version = getattr(obj, "hook_api_version", None)
         if api_version != HOOK_API_VERSION:
-            raise ValueError(
+            raise PluginLoadError(
                 f"Plugin {name!r} declares hook_api_version={api_version!r}; this nanoidp "
-                f"implements hook API version {HOOK_API_VERSION}. Upgrade the plugin or nanoidp."
+                f"implements hook API version {HOOK_API_VERSION}. Upgrade the plugin or nanoidp.",
+                f"incompatible hook_api_version={api_version!r} (expected {HOOK_API_VERSION})",
             )
         plugin = LoadedPlugin(name=name, obj=obj, api_version=api_version, source=source, config=dict(config or {}))
         plugin.failures.update(self._retired_plugins.pop((name, source), {}))
@@ -312,13 +337,23 @@ class HookRegistry:
             try:
                 self.add_plugin(name, source, config or {})
             except Exception as exc:
-                reason = str(exc) or exc.__class__.__name__
-                logger.error("plugin %r (%s) could not be loaded: %s", name, source, reason)
+                # The public reason is one of nanoidp's own short diagnoses;
+                # the exception text (import error, constructor, configure(),
+                # which may embed the plugin's settings and therefore secrets)
+                # goes to the local log only (#200 review).
+                if isinstance(exc, PluginLoadError):
+                    reason = exc.public_reason
+                else:
+                    reason = "initialization failed"
+                logger.error(
+                    "plugin %r (%s) could not be loaded: %s", name, source, str(exc) or exc.__class__.__name__
+                )
                 self._failed_plugins.setdefault(source, []).append({"name": name, "reason": reason})
                 failed.append(name)
         if failed and self.strict:
             raise HookError(
-                f"plugin(s) {', '.join(repr(n) for n in failed)} from {source} could not be loaded"
+                f"plugin(s) {', '.join(repr(n) for n in failed)} from {source} could not be loaded",
+                kind="plugin_load",
             )
 
     # --------------------------------------------------------------- dispatch
@@ -418,7 +453,7 @@ class HookRegistry:
                 logger.warning(message, exc_info=True)
                 errors.append(message)
         if errors and propagate:
-            raise HookError("; ".join(errors))
+            raise HookError("; ".join(errors), kind=hook)
 
     def _run_shell(
         self,

--- a/src/nanoidp/hooks.py
+++ b/src/nanoidp/hooks.py
@@ -74,6 +74,7 @@ import json
 import logging
 import os
 import subprocess
+import threading
 from dataclasses import dataclass, field
 from importlib import metadata
 from pathlib import Path
@@ -81,7 +82,8 @@ from typing import Any, Dict, List, Mapping, Optional
 
 import yaml
 
-from .config_documents import BootstrapDocument
+from .config_documents import load_bootstrap_document
+from .serialization import expand_env_vars
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +178,14 @@ class HookRegistry:
         # history instead of reporting a fresh zero.
         self._retired_shell: Dict[tuple, int] = {}
         self._retired_plugins: Dict[tuple, Dict[str, int]] = {}
+        # Plugins a source declared but that could not be loaded (missing
+        # entry point, wrong hook_api_version, configure() raised): reported,
+        # never fatal unless strict (review before 2.7.0rc4).
+        self._failed_plugins: Dict[str, List[Dict[str, str]]] = {}
+        # Set while on_before_load runs on this thread: an audit event logged
+        # from inside a load must not re-enter the registry (or the config
+        # singleton, whose construction may hold a non-reentrant lock).
+        self._loading = threading.local()
 
     # ----------------------------------------------------------------- policy
 
@@ -253,6 +263,7 @@ class HookRegistry:
                 self._retired_plugins[(p.name, p.source)] = dict(p.failures)
         self.shell_hooks = [h for h in self.shell_hooks if h.source != source]
         self.plugins = [p for p in self.plugins if p.source != source]
+        self._failed_plugins.pop(source, None)
         # A source that is gone no longer has a say in strict/timeout: the
         # bootstrap baseline (or the default) applies again.
         self._policy.pop(source, None)
@@ -284,18 +295,51 @@ class HookRegistry:
             strict=values.get("strict") if "strict" in declared else None,
             timeout_seconds=values.get("timeout_seconds") if "timeout_seconds" in declared else None,
         )
+        self.load_plugins(plugins, source)
+
+    def load_plugins(self, plugins: Mapping[str, Any], source: str) -> None:
+        """Load every plugin ``source`` declares, following the error policy.
+
+        A plugin that cannot be loaded (no entry point installed, wrong
+        ``hook_api_version``, ``configure()`` raising) is logged at ERROR,
+        recorded in ``describe()["plugins_failed"]`` and skipped; under
+        ``strict`` the load fails with a ``HookError`` naming the plugins,
+        after every plugin was attempted. Registration is part of the load,
+        so it follows on_before_load's policy, not an unconditional abort.
+        """
+        failed: List[str] = []
         for name, config in plugins.items():
-            self.add_plugin(name, source, config or {})
+            try:
+                self.add_plugin(name, source, config or {})
+            except Exception as exc:
+                reason = str(exc) or exc.__class__.__name__
+                logger.error("plugin %r (%s) could not be loaded: %s", name, source, reason)
+                self._failed_plugins.setdefault(source, []).append({"name": name, "reason": reason})
+                failed.append(name)
+        if failed and self.strict:
+            raise HookError(
+                f"plugin(s) {', '.join(repr(n) for n in failed)} from {source} could not be loaded"
+            )
 
     # --------------------------------------------------------------- dispatch
 
     def run_before_load(self, config_dir: Path) -> None:
         """May raise ``HookError`` under ``strict``; otherwise logs and returns."""
-        self._dispatch(
-            "on_before_load",
-            shell_placeholders={"config_dir": str(config_dir)},
-            plugin_args=(config_dir,),
-            propagate=self.strict,
+        self._loading.active = True
+        try:
+            self._dispatch(
+                "on_before_load",
+                shell_placeholders={"config_dir": str(config_dir)},
+                plugin_args=(config_dir,),
+                propagate=self.strict,
+            )
+        finally:
+            self._loading.active = False
+
+    def has_hook(self, hook: str) -> bool:
+        """True when at least one shell hook or plugin implements ``hook``."""
+        return any(h.hook == hook for h in self.shell_hooks) or any(
+            callable(getattr(p.obj, hook, None)) for p in self.plugins
         )
 
     def _config_dir_placeholder(self, fallback: Optional[Path] = None) -> str:
@@ -319,6 +363,14 @@ class HookRegistry:
 
     def run_audit_event(self, event: Mapping[str, Any]) -> None:
         """Never raises, strict or not: hooks must not alter protocol behaviour."""
+        # Nothing registered: no dict copies, no iteration (the default case).
+        if not self.has_hook("on_audit_event"):
+            return
+        # An audit event produced while on_before_load is running on this
+        # thread (a plugin logging from its load hook) stays in the audit log
+        # but is not dispatched: no recursion into a half-built registry.
+        if getattr(self._loading, "active", False):
+            return
         try:
             self._dispatch(
                 "on_audit_event",
@@ -341,6 +393,8 @@ class HookRegistry:
         propagate: bool,
         stdin_json: Optional[Mapping[str, Any]] = None,
     ) -> None:
+        if not self.has_hook(hook):
+            return
         errors: List[str] = []
         for shell_hook in [h for h in self.shell_hooks if h.hook == hook]:
             if shell_hook.once and shell_hook.ran:
@@ -424,6 +478,11 @@ class HookRegistry:
             "timeout_seconds": self.timeout_seconds,
             "shell_hooks": [h.describe() for h in self.shell_hooks],
             "plugins": [p.describe() for p in self.plugins],
+            "plugins_failed": [
+                {"name": f["name"], "source": source, "reason": f["reason"]}
+                for source, entries in self._failed_plugins.items()
+                for f in entries
+            ],
         }
 
     def format_report(self) -> str:
@@ -455,6 +514,8 @@ class HookRegistry:
                 f"  {p['name']:<16} api={p['hook_api_version']} {p['source']:<14} "
                 f"hooks={','.join(p['hooks']) or '-'} failures={p['failures']}"
             )
+        for f in info["plugins_failed"]:
+            lines.append(f"  {f['name']:<16} NOT LOADED ({f['source']}): {f['reason']}")
         return "\n".join(lines)
 
 
@@ -479,9 +540,13 @@ def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = 
 
     bootstrap_file = config_dir / BOOTSTRAP_FILE
     if bootstrap_file.exists():
+        # Same path as settings.yaml: ${VAR} expansion first, then the
+        # document loader (unknown keys warned with their path, wrong types
+        # reported as "<file>: invalid value at <path>").
         with open(bootstrap_file, "r") as f:
             raw = yaml.safe_load(f) or {}
-        document = BootstrapDocument.model_validate(raw)
+        raw = expand_env_vars(raw)
+        document = load_bootstrap_document(raw, bootstrap_file)
         registry.configure_from_sections(document.hooks, document.plugins, SOURCE_BOOTSTRAP_FILE)
         # bootstrap.yaml's on_before_load runs before the first load only,
         # like the env hook: settings.yaml owns reloads.
@@ -495,7 +560,9 @@ def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = 
 
     plugin_name = env.get(BOOTSTRAP_PLUGIN_ENV)
     if plugin_name:
-        registry.add_plugin(plugin_name, SOURCE_BOOTSTRAP_ENV, plugin_settings_from_env(plugin_name, env))
+        registry.load_plugins(
+            {plugin_name: plugin_settings_from_env(plugin_name, env)}, SOURCE_BOOTSTRAP_ENV
+        )
 
     return registry
 

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -1312,7 +1312,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         try:
             config.reload()
         except HookError as exc:
-            return {"success": False, "error": f"Reload failed: {exc}"}
+            return {"success": False, "error": f"Reload failed: {exc.message}", "kind": exc.kind}
         return {"success": True, "message": "Configuration reloaded"}
 
     elif name == "update_settings":

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -58,6 +58,7 @@ from mcp.types import (
 
 from . import __version__
 from .config import ConfigManager, OAuthClient, User, init_config
+from .hooks import HookError
 from .models import HEX_COLOR_PATTERN, normalize_saml_attr_name
 from .services import (
     build_discovery_document,
@@ -1265,6 +1266,15 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
             "security_profile": settings.security_profile,
+            # Same as GET /api/config (#172): whether the profile comes from
+            # the CLI, and the values the effective profile forces.
+            "profile_override": config.profile_override,
+            "effective": {
+                "require_pkce": settings.require_pkce,
+                "password_hashing": settings.password_hashing,
+                "rate_limit_enabled": settings.rate_limit_enabled,
+                "debug": settings.debug,
+            },
             "login_mode": settings.login_mode,
             "refresh_token_rotation": settings.refresh_token_rotation,
             "require_pkce": settings.require_pkce,
@@ -1299,7 +1309,10 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         }
 
     elif name == "reload_config":
-        config.reload()
+        try:
+            config.reload()
+        except HookError as exc:
+            return {"success": False, "error": f"Reload failed: {exc}"}
         return {"success": True, "message": "Configuration reloaded"}
 
     elif name == "update_settings":

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -325,39 +325,6 @@ class Settings(BaseModel):
         "mode). YAML-only, like require_ui_login and secret_key.",
     )
 
-    # Hooks and plugins (#185): extension points, not backends. Effective
-    # values as loaded from settings.yaml; reported by /api/config and MCP,
-    # never settable through them (YAML-only, like secret_key).
-    hooks_on_before_load: Optional[str] = Field(
-        default=None,
-        description="Shell command run before settings/users are read (startup and every reload); "
-        "placeholder {config_dir}. Use: render the files from an external store.",
-    )
-    hooks_on_config_saved: Optional[str] = Field(
-        default=None,
-        description="Shell command run after an atomic write of settings.yaml or users.yaml; "
-        "placeholders {path}, {kind}. The local save is already committed when it runs.",
-    )
-    hooks_on_audit_event: Optional[str] = Field(
-        default=None,
-        description="Shell command run after an audit entry is recorded; placeholder {event_type}, "
-        "event JSON on stdin. Never fails the request that produced the event.",
-    )
-    hooks_strict: bool = Field(
-        default=False,
-        description="When on, an on_before_load failure fails the load and an on_config_saved "
-        "failure is propagated to the caller after the write. on_audit_event never propagates.",
-    )
-    hooks_timeout_seconds: float = Field(
-        default=10.0,
-        gt=0,
-        description="Timeout for shell hooks only; a Python plugin manages its own timeouts",
-    )
-    plugins: Dict[str, Dict[str, Any]] = Field(
-        default_factory=dict,
-        description="Python plugins to load from the 'nanoidp.plugins' entry-point group, "
-        "keyed by name, each with its own settings mapping (plugin-owned keys).",
-    )
 
     # Logging
     log_level: str = Field(default="INFO", description="Logging level")

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -8,6 +8,7 @@ from flask import Blueprint, jsonify, request
 from flask.typing import ResponseReturnValue
 
 from ..config import get_config
+from ..hooks import HookError
 from ..services import get_audit_log, get_token_service
 from ._issuer import effective_issuer, effective_saml_entity_id, effective_saml_sso_url
 
@@ -197,7 +198,12 @@ def get_configuration() -> ResponseReturnValue:
 def reload_config() -> ResponseReturnValue:
     """Reload configuration from files."""
     config = get_config()
-    config.reload()
+    try:
+        config.reload()
+    except HookError as exc:
+        # A strict on_before_load (or plugin load) failure is a JSON error,
+        # not Flask's HTML 500: this endpoint's callers parse JSON.
+        return jsonify({"status": "error", "error": str(exc), "hook": "on_before_load"}), 503
     return jsonify({
         "status": "reloaded",
         "users_count": len(config.users),

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -201,9 +201,11 @@ def reload_config() -> ResponseReturnValue:
     try:
         config.reload()
     except HookError as exc:
-        # A strict on_before_load (or plugin load) failure is a JSON error,
-        # not Flask's HTML 500: this endpoint's callers parse JSON.
-        return jsonify({"status": "error", "error": str(exc), "hook": "on_before_load"}), 503
+        # A strict on_before_load or plugin-load failure is a JSON error, not
+        # Flask's HTML 500: this endpoint's callers parse JSON. exc.message is
+        # the registry's synthetic text (never a command, stderr or plugin
+        # exception text) and exc.kind names the phase that failed.
+        return jsonify({"status": "error", "error": exc.message, "kind": exc.kind}), 503
     return jsonify({
         "status": "reloaded",
         "users_count": len(config.users),

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -90,11 +90,12 @@ class AuditLog:
             self._update_stats(event_type, status)
 
         # Verbose logging controlled by settings (late import to avoid circular dependency)
-        try:
-            from ..config import get_config
-            verbose = get_config().settings.verbose_logging
-        except Exception:
-            verbose = True  # Default to verbose if config not available
+        # Never construct the configuration from a log call: an audit event
+        # logged while the singleton is being built (a plugin's on_before_load)
+        # would block on the non-reentrant init lock (review before 2.7.0rc4).
+        from ..config import get_config_if_loaded
+        loaded = get_config_if_loaded()
+        verbose = loaded.settings.verbose_logging if loaded is not None else True
 
         # Build log message - include identifiers only if verbose logging is enabled
         log_msg = f"[{event_type}] {method} {endpoint} - {status}"
@@ -112,11 +113,11 @@ class AuditLog:
         # on_audit_event (#185): after the entry is recorded. The registry
         # never lets a hook failure out of run_audit_event; the guard here
         # covers the config singleton itself being unavailable.
-        try:
-            from ..config import get_config
-            get_config().hooks.run_audit_event(entry.to_dict())
-        except Exception:
-            logger.debug("audit hooks unavailable", exc_info=True)
+        if loaded is not None:
+            try:
+                loaded.hooks.run_audit_event(entry.to_dict())
+            except Exception:
+                logger.debug("audit hooks unavailable", exc_info=True)
 
     def _update_stats(self, event_type: str, status: str) -> None:
         """Update statistics counters."""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4,6 +4,8 @@ surface, the per-hook error policy, plugin loading and introspection.
 """
 
 import importlib.util
+import logging
+import pathlib
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -136,7 +138,7 @@ class TestBootstrapSurface:
         config = ConfigManager(str(tmp_path))
         assert config.settings.issuer == "http://rendered:1"
 
-    def test_bootstrap_yaml_hooks_and_unknown_key_refused(self, tmp_path):
+    def test_bootstrap_yaml_hooks_and_unknown_key_warned(self, tmp_path, caplog):
         log = tmp_path / "hooks.log"
         cfg = _write(tmp_path)
         (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {
@@ -151,9 +153,12 @@ class TestBootstrapSurface:
         assert _lines(log).count("file-saved") == 2  # users + settings, every save
         assert {h["source"] for h in config.hooks.describe()["shell_hooks"]} == {SOURCE_BOOTSTRAP_FILE}
 
+        # Same reporting as settings.yaml: an unknown key is warned with its
+        # path and ignored, not a raw pydantic error (review before 2.7.0rc4).
         (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {}, "oauth": {"issuer": "x"}}))
-        with pytest.raises(Exception, match="oauth"):
+        with caplog.at_level(logging.WARNING):
             ConfigManager(cfg)
+        assert any("bootstrap.yaml: unknown key oauth (ignored)" in r.getMessage() for r in caplog.records)
 
     def test_bootstrap_yaml_only_hooks_and_plugins(self):
         doc = BootstrapDocument.model_validate({"hooks": None, "plugins": None})
@@ -294,20 +299,31 @@ class TestPlugins:
         fake_entry_points["echo"] = _echo_plugin_class()
         config = ConfigManager(_write(tmp_path, {"plugins": {"echo": None}}))
         assert config.hooks.plugins[0].config == {}
-        assert config.settings.plugins == {"echo": {}}
 
-    def test_unknown_plugin_is_a_clear_error(self, tmp_path, fake_entry_points):
-        with pytest.raises(ValueError, match="Plugin 'nope' not found: no 'nanoidp.plugins' entry point"):
-            ConfigManager(_write(tmp_path, {"plugins": {"nope": {}}}))
+    def test_unknown_plugin_is_reported_not_fatal(self, tmp_path, fake_entry_points, caplog):
+        """Registration follows the error policy (review before 2.7.0rc4): a
+        missing package must not abort the load or a post-write refresh."""
+        with caplog.at_level(logging.ERROR):
+            config = ConfigManager(_write(tmp_path, {"plugins": {"nope": {}}}))
+        failed = config.hooks.describe()["plugins_failed"]
+        assert failed == [{"name": "nope", "source": SOURCE_SETTINGS, "reason": failed[0]["reason"]}]
+        assert "Plugin 'nope' not found: no 'nanoidp.plugins' entry point" in failed[0]["reason"]
+        assert any("plugin 'nope'" in r.getMessage() for r in caplog.records)
+        assert "NOT LOADED" in config.hooks.format_report()
 
-    def test_api_version_mismatch_refused(self, tmp_path, fake_entry_points):
+    def test_unknown_plugin_blocks_the_load_under_strict(self, tmp_path, fake_entry_points):
+        with pytest.raises(HookError, match="plugin\\(s\\) 'nope' from settings.yaml could not be loaded"):
+            ConfigManager(_write(tmp_path, {"plugins": {"nope": {}}, "hooks": {"strict": True}}))
+
+    def test_api_version_mismatch_reported(self, tmp_path, fake_entry_points):
         class Old:
-            name = "old"
             hook_api_version = 0
 
         fake_entry_points["old"] = Old
-        with pytest.raises(ValueError, match="declares hook_api_version=0; this nanoidp implements hook API version 1"):
-            ConfigManager(_write(tmp_path, {"plugins": {"old": {}}}))
+        config = ConfigManager(_write(tmp_path, {"plugins": {"old": {}}}))
+        assert config.hooks.plugins == []
+        reason = config.hooks.describe()["plugins_failed"][0]["reason"]
+        assert "declares hook_api_version=0; this nanoidp implements hook API version 1" in reason
 
     def test_shell_hook_runs_before_plugins(self, tmp_path):
         order = []
@@ -394,8 +410,7 @@ class TestIntrospection:
     def test_shipped_config_declares_no_hooks(self):
         config = ConfigManager(str(REPO / "config"))
         info = config.hooks.describe()
-        assert info["shell_hooks"] == [] and info["plugins"] == []
-        assert config.settings.hooks_on_before_load is None and config.settings.plugins == {}
+        assert info["shell_hooks"] == [] and info["plugins"] == [] and info["plugins_failed"] == []
 
     def test_hooks_survive_a_settings_save_untouched(self, tmp_path):
         """The writer manages its own keys only; hooks:/plugins: are preserved
@@ -548,7 +563,7 @@ class TestSourcePrecedenceAndLifecycle:
     def test_bootstrap_yaml_rejects_non_positive_timeout(self, tmp_path):
         for value in (0, -1):
             self._bootstrap(tmp_path, timeout_seconds=value)
-            with pytest.raises(ValidationError):
+            with pytest.raises(ValueError, match="bootstrap.yaml: invalid value at hooks.timeout_seconds"):
                 ConfigManager(_write(tmp_path))
 
 
@@ -674,3 +689,174 @@ class TestPostWriteRefreshNeverConsultsTheMirror:
         assert len(_lines(log)) == n
         get_config().reload()
         assert len(_lines(log)) == n + 1
+
+
+class TestReviewBeforeRc4:
+    """Findings of the code review on v2.7.0-rc3..main, each pinned."""
+
+    def test_failed_plugin_does_not_break_saves_and_is_reported_by_the_api(self, tmp_path, fake_entry_points):
+        from nanoidp.app import create_app
+        from nanoidp.config import get_config
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        app = create_app(config_dir=_write(tmp_path, {"plugins": {"store": {}}}))
+        app.config["TESTING"] = True
+        YamlWriter(str(tmp_path)).update_login_settings(mode="persona")  # post-write refresh must not raise
+        assert get_config().settings.login_mode == "persona"
+        with app.test_client() as client:
+            block = client.get("/api/config").get_json()["hooks"]
+        assert block["plugins_failed"][0]["name"] == "store"
+
+    def test_reload_endpoint_returns_json_on_hook_error(self, tmp_path):
+        from nanoidp.app import create_app
+
+        cfg = _write(tmp_path)
+        app = create_app(config_dir=cfg)
+        app.config["TESTING"] = True
+        # declare the failing strict hook AFTER the first load so startup passes
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["hooks"] = {"on_before_load": "false", "strict": True}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        with app.test_client() as client:
+            client.post("/api/config/reload")  # picks the declaration up (hook not yet registered)
+            resp = client.post("/api/config/reload")
+        assert resp.status_code == 503
+        assert resp.is_json
+        assert resp.get_json()["status"] == "error"
+        assert "on_before_load shell hook (settings.yaml) failed (exit 1)" in resp.get_json()["error"]
+
+    def test_mcp_reload_returns_error_result_on_hook_error(self, tmp_path, mcp_call_tool):
+        import asyncio
+
+        import nanoidp.mcp_server as mcp
+
+        cfg = _write(tmp_path)
+        mcp._config = ConfigManager(cfg)
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["hooks"] = {"on_before_load": "false", "strict": True}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        mcp._config.reload()
+        result = asyncio.run(mcp_call_tool("reload_config", {}))
+        payload = yaml.safe_load(result.content[0].text)
+        assert payload["success"] is False
+        assert "Reload failed: on_before_load shell hook (settings.yaml) failed (exit 1)" in payload["error"]
+
+    def test_audit_from_a_plugin_before_load_completes_and_is_not_dispatched(self, tmp_path, fake_entry_points):
+        from nanoidp.config import init_config
+        from nanoidp.services.audit import get_audit_log
+
+        seen = []
+
+        class Chatty:
+            hook_api_version = 1
+
+            def on_before_load(self, config_dir):
+                get_audit_log().log(event_type="plugin_boot", endpoint="/plugin", method="HOOK", status="success")
+
+            def on_audit_event(self, event):
+                seen.append(event["event_type"])
+
+        fake_entry_points["chatty"] = Chatty
+        cfg = _write(tmp_path, {"plugins": {"chatty": {}}})
+        config = init_config(cfg)
+        config.reload()  # plugin registered now: its on_before_load logs an audit event
+        assert "plugin_boot" not in seen  # not dispatched while loading: no recursion
+        get_audit_log().log(event_type="after", endpoint="/x", method="GET", status="success")
+        assert "after" in seen
+
+    def test_audit_logging_never_constructs_the_config(self, monkeypatch):
+        import nanoidp.config as config_module
+        from nanoidp.services.audit import get_audit_log
+
+        assert config_module._config is None
+
+        def boom(*a, **k):
+            raise AssertionError("ConfigManager constructed from an audit log call")
+
+        monkeypatch.setattr(config_module, "ConfigManager", boom)
+        get_audit_log().log(event_type="x", endpoint="/x", method="GET", status="success")
+        assert config_module._config is None
+
+    def test_bootstrap_yaml_expands_placeholders_and_reports_errors_like_settings(self, tmp_path, monkeypatch, caplog, fake_entry_points):
+        monkeypatch.setenv("STORE_URL", "s3://bucket")
+        fake_entry_points["echo"] = _echo_plugin_class()
+        cfg = _write(tmp_path)
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"plugins": {"echo": {"url": "${STORE_URL}"}}}))
+        config = ConfigManager(cfg)
+        assert config.hooks.plugins[0].config == {"url": "s3://bucket"}
+
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {"timeout_seconds": "x"}}))
+        with pytest.raises(ValueError, match="bootstrap.yaml: invalid value at hooks.timeout_seconds"):
+            ConfigManager(cfg)
+
+        (tmp_path / "bootstrap.yaml").write_text(yaml.safe_dump({"hooks": {"on_before_laod": "true"}}))
+        with caplog.at_level(logging.WARNING):
+            ConfigManager(cfg)
+        assert any("bootstrap.yaml: unknown key hooks.on_before_laod (ignored)" in r.getMessage() for r in caplog.records)
+
+    def test_mcp_get_settings_carries_the_profile_keys_of_api_config(self, tmp_path, mcp_call_tool):
+        import asyncio
+
+        import nanoidp.mcp_server as mcp
+        from nanoidp.app import create_app
+
+        app = create_app(config_dir=_write(tmp_path), profile="stricter-dev")
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            api = client.get("/api/config").get_json()
+        mcp._config = ConfigManager(str(tmp_path), profile_override="stricter-dev")
+        result = asyncio.run(mcp_call_tool("get_settings", {}))
+        payload = yaml.safe_load(result.content[0].text)
+        for key in ("security_profile", "profile_override", "effective", "config_version", "hooks"):
+            assert payload[key] == api[key], key
+        assert payload["effective"]["require_pkce"] is True
+
+    def test_plugins_are_not_reinstantiated_on_a_post_write_refresh(self, tmp_path, fake_entry_points):
+        from nanoidp.config import init_config
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        instances = []
+
+        class Counting:
+            hook_api_version = 1
+
+            def __init__(self):
+                instances.append(self)
+
+            def configure(self, settings):
+                self.settings = settings
+
+        fake_entry_points["counting"] = Counting
+        cfg = _write(tmp_path, {"plugins": {"counting": {"v": 1}}})
+        init_config(cfg)
+        writer = YamlWriter(cfg)
+        for mode in ("persona", "password", "persona"):
+            writer.update_login_settings(mode=mode)
+        assert len(instances) == 1
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["plugins"] = {"counting": {"v": 2}}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        writer.update_login_settings(mode="password")
+        assert len(instances) == 2 and instances[-1].settings == {"v": 2}
+
+    def test_settings_model_has_no_hook_fields(self):
+        from nanoidp.models import Settings
+
+        s = Settings()
+        for name in ("hooks_on_before_load", "hooks_on_config_saved", "hooks_on_audit_event",
+                     "hooks_strict", "hooks_timeout_seconds", "plugins"):
+            assert not hasattr(s, name), name
+
+    def test_dispatch_is_skipped_when_nothing_is_registered(self, monkeypatch):
+        registry = HookRegistry()
+
+        def boom(*a, **k):
+            raise AssertionError("_dispatch called with nothing registered")
+
+        monkeypatch.setattr(registry, "_dispatch", boom)
+        registry.run_audit_event({"event_type": "x"})  # the hot path: no copies, no dispatch
+        # the other hooks reach _dispatch, which returns before iterating
+        monkeypatch.undo()
+        monkeypatch.setattr(registry, "_run_shell", boom)
+        registry.run_config_saved(pathlib.Path("/tmp/x.yaml"), "settings")
+        registry.run_before_load(pathlib.Path("/tmp"))

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -961,3 +961,53 @@ class TestReloadErrorNamesThePhase:
             client.post("/api/config/reload")  # registers the hook (first reload reads the file)
             resp = client.post("/api/config/reload")
         assert resp.status_code == 503 and resp.get_json()["kind"] == "on_before_load"
+
+
+
+class TestStrictReloadFailsWithoutCommit:
+    """#200 review: a live process whose reload fails under strict must keep
+    its previous settings, profile hardening and registry untouched."""
+
+    def test_plugin_load_failure_leaves_runtime_and_registry_intact(self, tmp_path, fake_entry_points):
+        from nanoidp.app import create_app
+        from nanoidp.config import get_config
+
+        class Keep:
+            hook_api_version = 1
+
+        fake_entry_points["keep"] = Keep
+        app = create_app(config_dir=_write(tmp_path, {"plugins": {"keep": {}}}), profile="stricter-dev")
+        app.config["TESTING"] = True
+        config = get_config()
+        assert config.settings.security_profile == "stricter-dev" and config.settings.require_pkce is True
+        old_settings = config.settings
+        old_plugins = list(config.hooks.plugins)
+        old_snapshot = config.hooks.snapshot()
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["hooks"] = {"strict": True}
+        doc["plugins"] = {"keep": {}, "missing": {}}
+        doc.setdefault("oauth", {})["audience"] = "changed-on-disk"
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        with app.test_client() as client:
+            resp = client.post("/api/config/reload")
+        assert resp.status_code == 503 and resp.get_json()["kind"] == "plugin_load"
+        # runtime: the previous Settings object, still hardened, audience unchanged
+        assert config.settings is old_settings
+        assert config.settings.security_profile == "stricter-dev"
+        assert config.settings.require_pkce is True
+        assert config.settings.password_hashing is True
+        assert config.settings.rate_limit_enabled is True
+        assert config.settings.debug is False
+        assert config.settings.audience != "changed-on-disk"
+        # registry: same plugin instances, same policy, nothing half-applied
+        assert config.hooks.plugins == old_plugins
+        assert config.hooks.snapshot() == old_snapshot
+        assert config.hooks.strict is False
+        # fixing the file makes the next reload succeed and commit
+        doc["plugins"] = {"keep": {}}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        with app.test_client() as client:
+            assert client.post("/api/config/reload").status_code == 200
+        assert config.settings.audience == "changed-on-disk"
+        assert config.settings.security_profile == "stricter-dev" and config.settings.require_pkce is True
+        assert config.hooks.strict is True

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -307,7 +307,7 @@ class TestPlugins:
             config = ConfigManager(_write(tmp_path, {"plugins": {"nope": {}}}))
         failed = config.hooks.describe()["plugins_failed"]
         assert failed == [{"name": "nope", "source": SOURCE_SETTINGS, "reason": failed[0]["reason"]}]
-        assert "Plugin 'nope' not found: no 'nanoidp.plugins' entry point" in failed[0]["reason"]
+        assert failed[0]["reason"] == "not installed"
         assert any("plugin 'nope'" in r.getMessage() for r in caplog.records)
         assert "NOT LOADED" in config.hooks.format_report()
 
@@ -323,7 +323,7 @@ class TestPlugins:
         config = ConfigManager(_write(tmp_path, {"plugins": {"old": {}}}))
         assert config.hooks.plugins == []
         reason = config.hooks.describe()["plugins_failed"][0]["reason"]
-        assert "declares hook_api_version=0; this nanoidp implements hook API version 1" in reason
+        assert reason == "incompatible hook_api_version=0 (expected 1)"
 
     def test_shell_hook_runs_before_plugins(self, tmp_path):
         order = []
@@ -860,3 +860,104 @@ class TestReviewBeforeRc4:
         monkeypatch.setattr(registry, "_run_shell", boom)
         registry.run_config_saved(pathlib.Path("/tmp/x.yaml"), "settings")
         registry.run_before_load(pathlib.Path("/tmp"))
+
+
+
+class TestPluginFailureReasonsNeverExposeExceptionText:
+    """#200 review: plugins_failed.reason must be one of nanoidp's own short
+    diagnoses; a configure() exception that embeds plugin settings (tokens)
+    stays in the local log."""
+
+    def test_configure_exception_is_redacted_everywhere(self, tmp_path, monkeypatch, caplog, fake_entry_points):
+        monkeypatch.setenv("PLUGIN_TOKEN", "s3cr3t-plugin-token")
+
+        class Leaky:
+            hook_api_version = 1
+
+            def configure(self, settings):
+                raise RuntimeError(f"cannot connect to {settings['url']} with token {settings['token']}")
+
+        fake_entry_points["leaky"] = Leaky
+        from nanoidp.app import create_app
+        from nanoidp.config import get_config
+
+        with caplog.at_level(logging.ERROR):
+            app = create_app(config_dir=_write(tmp_path, {"plugins": {"leaky": {"url": "https://store", "token": "${PLUGIN_TOKEN}"}}}))
+        app.config["TESTING"] = True
+        failed = get_config().hooks.describe()["plugins_failed"]
+        assert failed == [{"name": "leaky", "source": SOURCE_SETTINGS, "reason": "initialization failed"}]
+        with app.test_client() as client:
+            body = client.get("/api/config").get_data(as_text=True)
+        assert "s3cr3t-plugin-token" not in body and "cannot connect" not in body
+        # the detail is in the local log
+        assert any("s3cr3t-plugin-token" in r.getMessage() for r in caplog.records)
+        # strict: the propagated message names the plugin only
+        get_config().hooks.drop_source(SOURCE_SETTINGS)
+        cfg = _write(tmp_path, {"hooks": {"strict": True}, "plugins": {"leaky": {"url": "u", "token": "${PLUGIN_TOKEN}"}}})
+        with pytest.raises(HookError) as info:
+            ConfigManager(cfg)
+        assert info.value.kind == "plugin_load"
+        assert "s3cr3t-plugin-token" not in str(info.value) and "leaky" in str(info.value)
+
+
+class TestPluginDeclarationOrderIsHonouredOnReload:
+    def test_reordering_plugins_reapplies_them(self, tmp_path, fake_entry_points):
+        from nanoidp.config import get_config
+        from nanoidp.services.yaml_writer import YamlWriter
+
+        calls = []
+
+        def make(tag):
+            class P:
+                hook_api_version = 1
+
+                def on_config_saved(self, path, kind):
+                    calls.append(tag)
+            return P
+
+        fake_entry_points["pa"] = make("a")
+        fake_entry_points["pb"] = make("b")
+        cfg = _write(tmp_path, {"plugins": {"pa": {}, "pb": {}}})
+        init_config(cfg)
+        assert [p.name for p in get_config().hooks.plugins] == ["pa", "pb"]
+        YamlWriter(cfg).update_login_settings(mode="persona")
+        assert calls == ["a", "b"]
+        # rewrite the file with the plugins reordered, same configs
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["plugins"] = {"pb": {}, "pa": {}}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
+        get_config().reload_local()
+        assert [p.name for p in get_config().hooks.plugins] == ["pb", "pa"]
+        calls.clear()
+        YamlWriter(cfg).update_login_settings(mode="password")
+        assert calls[:2] == ["b", "a"]
+
+
+class TestReloadErrorNamesThePhase:
+    def test_plugin_load_failure_is_reported_as_plugin_load(self, tmp_path):
+        from nanoidp.app import create_app
+
+        app = create_app(config_dir=_write(tmp_path))
+        app.config["TESTING"] = True
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["hooks"] = {"strict": True}
+        doc["plugins"] = {"missing": {}}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        with app.test_client() as client:
+            resp = client.post("/api/config/reload")
+        assert resp.status_code == 503
+        body = resp.get_json()
+        assert body["kind"] == "plugin_load" and "missing" in body["error"]
+
+    def test_before_load_failure_is_reported_as_on_before_load(self, tmp_path):
+        from nanoidp.app import create_app
+
+        app = create_app(config_dir=_write(tmp_path))
+        app.config["TESTING"] = True
+        doc = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        doc["hooks"] = {"on_before_load": "false", "strict": True}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(doc))
+        with app.test_client() as client:
+            client.post("/api/config/reload")  # registers the hook (first reload reads the file)
+            resp = client.post("/api/config/reload")
+        assert resp.status_code == 503 and resp.get_json()["kind"] == "on_before_load"


### PR DESCRIPTION
Fixes for the eight confirmed findings of the code review run over `v2.7.0-rc3..main` before cutting 2.7.0rc4 (the security review over the same range had no findings). All in #199's hooks code except 5 (#178 parity).

1. **Plugin registration follows the error policy.** A plugin that cannot be loaded (entry point missing, `hook_api_version` mismatch, `configure()` raising) no longer aborts the settings load or the post-write refresh: logged at ERROR, listed in `describe()["plugins_failed"]` (`/api/config`, MCP, `nanoidp plugins` as `NOT LOADED`) and skipped; under `hooks.strict: true` a `HookError` naming the plugins is raised from the load, like a failing `on_before_load`. The public `reason` is one of nanoidp's own diagnoses (`not installed`, `incompatible hook_api_version=N (expected 1)`, `already loaded`, `initialization failed`); exception text from import/constructor/`configure()`, which may embed plugin settings, stays in the local log. Before, `settings.yaml` declaring `plugins: {store: {}}` on a host without the package broke every UI/MCP save.
   **A strict reload fails without commit**: the candidate `Settings` is promoted only after the registry applied the file's hooks/plugins, and `HookRegistry.replace_source()` restores a snapshot if registration raises, so a 503 reload leaves settings, profile hardening (`--profile stricter-dev`) and plugin instances exactly as they were; fixing the file and reloading again commits.
2. **JSON contract on reload.** `HookError(message, kind)`: `message` is the registry's synthetic text (never a command, stderr or plugin exception text), `kind` the hook name or `plugin_load`. `POST /api/config/reload` returns `{"status":"error","error": message, "kind": kind}` with 503 instead of a 500 HTML page; MCP `reload_config` returns `success: false` with the same `kind`.
3. **Audit logging never loads config and cannot deadlock.** `get_config_if_loaded()` (no lock, no construction) is what `audit.py` uses; a thread-local flag makes `run_audit_event` a no-op while `run_before_load` is executing, so a plugin that logs an audit event from `on_before_load` during `init_config` neither recurses nor blocks on the non-reentrant singleton lock.
4. **`bootstrap.yaml` parity with `settings.yaml`**: `safe_load` -> `expand_env_vars` -> the shared document loader, so `${VAR}` expands in plugin settings and a typo yields the `"<file>: unknown key ..."` warning / `"invalid value at <path>"` error instead of a raw pydantic `ValidationError`.
5. **MCP parity for #178**: `get_settings` exposes `profile_override` and the `effective` block; a test asserts `/api/config` and MCP agree on `security_profile`, `profile_override`, `effective`, `config_version`, `hooks`.
6. **No plugin churn on the post-write refresh**: `_configure_hooks_from` keeps an order-sensitive snapshot of the applied `hooks:`/`plugins:` sections and skips reconfiguration when unchanged, so plugins are instantiated once across saves and re-instantiated when their config or declaration order changes. Consequence, stated in the guide: a plugin that failed in non-strict mode is retried only when the declaration changes or on restart.
7. **Dead state removed**: the six `Settings.hooks_*`/`plugins` fields written by `to_settings()` and read by nothing; the registry is the only live state.
8. **Early return** in `run_audit_event`/`_dispatch` when nothing implements the hook, before any dict copy.

## Verification

- 1326 passed (16 new), ruff/mypy clean, `lint-imports` 2 kept; CodeQL: zero open alerts (alert 26 on `str(exc)` fixed by the structured `HookError`; 24/25 on audit.py are re-raises of alerts dismissed before, dismissed again with a note).
- Live: `plugins: {store: {}}` on a host without the package -> server starts, saves work, `/api/config.hooks.plugins_failed` names it with the reason; with `hooks: {on_before_load: "false", strict: true}` added and reloaded, `POST /api/config/reload` -> `503 application/json` with the message above; `examples/test_agent.py` 54/54; `effective` and `profile_override` present on both surfaces.

Note on strict semantics, unchanged and now documented: a failing `on_before_load` declared in `settings.yaml` under `strict` fails every reload until the file is fixed and the process restarted, because the registered hook runs before the file is re-read (the hook is supposed to render that file). With `strict`, a failed plugin at startup refuses to start, same as a failed `on_before_load`; non-strict stays the default.
