### PR TITLE
test: exercise the installed reference plugin and the bootstrap surface end to end

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,9 +27,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+          # The reference plugin, installed the way a user would: the entry
+          # point must be discovered from a real package (#185).
+          pip install examples/plugins/nanoidp-echo
 
       - name: Start server
+        # Bootstrap surface exercised for real: the echo plugin through
+        # NANOIDP_BOOTSTRAP_PLUGIN + NANOIDP_PLUGIN_ECHO_RECORD, and a shell
+        # on_config_saved hook through config/bootstrap.yaml (the unit suite
+        # registers plugins in-process; this is the only place the installed
+        # package and the env/bootstrap.yaml path are tested end to end).
+        env:
+          NANOIDP_BOOTSTRAP_PLUGIN: echo
+          NANOIDP_PLUGIN_ECHO_RECORD: ${{ github.workspace }}/echo-record.jsonl
         run: |
+          printf 'hooks:\n  on_config_saved: "echo saved {kind} {path} >> %s/hooks.log"\n' "$PWD" > config/bootstrap.yaml
           python -m nanoidp > server.log 2>&1 &
           for i in $(seq 1 30); do
             curl -sf http://localhost:8000/api/health && exit 0
@@ -40,6 +52,10 @@ jobs:
           exit 1
 
       - name: Run e2e agent
+        env:
+          NANOIDP_E2E_HOOK_LOG: ${{ github.workspace }}/hooks.log
+          NANOIDP_E2E_PLUGIN: echo
+          NANOIDP_E2E_PLUGIN_RECORD: ${{ github.workspace }}/echo-record.jsonl
         run: python examples/test_agent.py
 
       - name: Start oauth21 server
@@ -112,6 +128,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+          pip install examples/plugins/nanoidp-echo
 
       - name: MCP stdio smoke test
+        env:
+          NANOIDP_BOOTSTRAP_PLUGIN: echo
+          NANOIDP_PLUGIN_ECHO_RECORD: ${{ github.workspace }}/echo-record-mcp.jsonl
+          NANOIDP_E2E_PLUGIN: echo
         run: python examples/mcp_smoke_test.py --config ./config

--- a/examples/mcp_smoke_test.py
+++ b/examples/mcp_smoke_test.py
@@ -71,6 +71,21 @@ async def run(config_dir: str) -> int:
                 return 1
             print("[OK] get_keys_info")
 
+            # NANOIDP_E2E_PLUGIN: the installed reference plugin, bootstrapped
+            # through NANOIDP_BOOTSTRAP_PLUGIN, must be visible to an agent
+            # through get_settings (#185 parity with /api/config).
+            expected_plugin = os.environ.get("NANOIDP_E2E_PLUGIN")
+            if expected_plugin:
+                result = await session.call_tool("get_settings", {})
+                settings = json.loads(result.content[0].text)
+                block = settings.get("hooks") or {}
+                names = [p.get("name") for p in block.get("plugins", [])]
+                failed = [f.get("name") for f in block.get("plugins_failed", [])]
+                if expected_plugin not in names:
+                    print(f"[FAIL] plugin {expected_plugin!r} not in get_settings hooks: {names}, failed={failed}")
+                    return 1
+                print(f"[OK] get_settings lists plugin {expected_plugin!r} (hook API {block.get('hook_api_version')})")
+
     print("\n[SUCCESS] MCP stdio smoke test passed")
     return 0
 

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -3404,6 +3404,25 @@ class NanoIDPTestAgent:
                     f"/api/config lacks a hooks block with hook_api_version 1: {block!r}",
                     before,
                 )
+            # NANOIDP_E2E_PLUGIN names a plugin that MUST be loaded (the e2e
+            # workflow installs examples/plugins/nanoidp-echo and bootstraps
+            # it); without the variable the plugin part is skipped, the block
+            # itself is always checked.
+            expected_plugin = os.environ.get("NANOIDP_E2E_PLUGIN")
+            if expected_plugin:
+                loaded = {p.get("name"): p for p in block.get("plugins", [])}
+                plugin = loaded.get(expected_plugin)
+                failed = [f.get("name") for f in block.get("plugins_failed", [])]
+                if plugin is None or plugin.get("hook_api_version") != 1 or not {
+                    "on_before_load", "on_config_saved", "on_audit_event"
+                } <= set(plugin.get("hooks", [])):
+                    return self._add_result(
+                        "API Hooks Block",
+                        TestCategory.API,
+                        False,
+                        f"plugin {expected_plugin!r} not loaded as expected: {plugin!r}, failed={failed}",
+                        block,
+                    )
             saved_hooks = [h for h in block.get("shell_hooks", []) if h.get("hook") == "on_config_saved"]
             if not saved_hooks:
                 return self._add_result(
@@ -3444,16 +3463,49 @@ class NanoIDPTestAgent:
             lines_after = self._count_lines(log_path)
             ran_clean = failures_after == failures_before
             logged = lines_after > lines_before if log_path else True
+            # The plugin's own record file (NANOIDP_PLUGIN_ECHO_RECORD on the
+            # server side) must have gained an on_config_saved line for this
+            # save and carry on_audit_event lines: the installed package was
+            # really dispatched, not just listed.
+            record_ok = True
+            record_note = ""
+            record_path = os.environ.get("NANOIDP_E2E_PLUGIN_RECORD")
+            if expected_plugin and record_path:
+                entries = self._read_jsonl(record_path)
+                saved_entries = [e for e in entries if e.get("hook") == "on_config_saved"]
+                audit_entries = [e for e in entries if e.get("hook") == "on_audit_event"]
+                record_ok = bool(saved_entries) and bool(audit_entries) and any(
+                    e.get("kind") == "settings" for e in saved_entries
+                )
+                record_note = f", plugin record: {len(saved_entries)} saves / {len(audit_entries)} audit events"
+            elif expected_plugin:
+                record_note = ", plugin listed (no record file to check)"
             return self._add_result(
                 "API Hooks Block",
                 TestCategory.API,
-                ran_clean and logged,
+                ran_clean and logged and record_ok,
                 f"on_config_saved ran on a settings save: failures {failures_before}->{failures_after}"
-                + (f", log lines {lines_before}->{lines_after}" if log_path else ""),
+                + (f", log lines {lines_before}->{lines_after}" if log_path else "")
+                + record_note,
                 {"before": block, "after": after},
             )
         except Exception as e:
             return self._add_result("API Hooks Block", TestCategory.API, False, str(e))
+
+    @staticmethod
+    def _read_jsonl(path: Optional[str]) -> list:
+        if not path or not os.path.exists(path):
+            return []
+        entries = []
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except ValueError:
+                        continue
+        return entries
 
     @staticmethod
     def _count_lines(path: Optional[str]) -> int:

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -3413,7 +3413,12 @@ class NanoIDPTestAgent:
                 loaded = {p.get("name"): p for p in block.get("plugins", [])}
                 plugin = loaded.get(expected_plugin)
                 failed = [f.get("name") for f in block.get("plugins_failed", [])]
-                if plugin is None or plugin.get("hook_api_version") != 1 or not {
+                # The plugin must come from NANOIDP_BOOTSTRAP_PLUGIN (source
+                # bootstrap-env), not from a settings.yaml declaration: the
+                # bootstrap surface is what this check exists to prove.
+                if plugin is None or plugin.get("hook_api_version") != 1 or plugin.get(
+                    "source"
+                ) != "bootstrap-env" or not {
                     "on_before_load", "on_config_saved", "on_audit_event"
                 } <= set(plugin.get("hooks", [])):
                     return self._add_result(
@@ -3424,6 +3429,23 @@ class NanoIDPTestAgent:
                         block,
                     )
             saved_hooks = [h for h in block.get("shell_hooks", []) if h.get("hook") == "on_config_saved"]
+            log_path = os.environ.get("NANOIDP_E2E_HOOK_LOG")
+            if log_path:
+                # The e2e workflow declares the hook in config/bootstrap.yaml:
+                # with the log path set, the hook is mandatory and must carry
+                # that source, so a bootstrap.yaml that silently stopped
+                # loading cannot pass as "nothing configured".
+                bootstrap_hooks = [h for h in saved_hooks if h.get("source") == "bootstrap.yaml"]
+                if not bootstrap_hooks:
+                    return self._add_result(
+                        "API Hooks Block",
+                        TestCategory.API,
+                        False,
+                        "NANOIDP_E2E_HOOK_LOG is set but no on_config_saved hook from "
+                        f"bootstrap.yaml is registered: {saved_hooks!r}",
+                        block,
+                    )
+                saved_hooks = bootstrap_hooks
             if not saved_hooks:
                 return self._add_result(
                     "API Hooks Block",
@@ -3433,7 +3455,6 @@ class NanoIDPTestAgent:
                     f"(block present, {len(block.get('plugins', []))} plugins)",
                     {"skipped": True, "hooks": block},
                 )
-            log_path = os.environ.get("NANOIDP_E2E_HOOK_LOG")
             lines_before = self._count_lines(log_path)
             saml_config = before.get("saml", {})
             # A no-op settings round-trip: same values posted back, derived


### PR DESCRIPTION
Closes the gap noticed after #199: the reference plugin `examples/plugins/nanoidp-echo` and the bootstrap surface were never exercised through a real installation. The unit suite registers the plugin in-process (shared venv), and the e2e workflow configured no hook, so `test_agent`'s hooks check degraded to "block present, 0 plugins".

- **e2e workflow**, both jobs: `pip install examples/plugins/nanoidp-echo` (entry-point discovery from a real package); the HTTP server starts with `NANOIDP_BOOTSTRAP_PLUGIN=echo` and `NANOIDP_PLUGIN_ECHO_RECORD`, plus a shell `on_config_saved` hook declared in `config/bootstrap.yaml` appending to `NANOIDP_E2E_HOOK_LOG`; the MCP job bootstraps the same plugin.
- **`examples/test_agent.py`**: with `NANOIDP_E2E_PLUGIN` set the hooks check no longer degrades: the plugin must be listed with `hook_api_version` 1 and all three hooks, and with `NANOIDP_E2E_PLUGIN_RECORD` its record file must contain `on_config_saved` (kind `settings`) and `on_audit_event` lines after the settings round-trip. Without the variable the behaviour is unchanged.
- **`examples/mcp_smoke_test.py`**: with `NANOIDP_E2E_PLUGIN` set, `get_settings` must list the plugin (parity with `/api/config`).

Verified locally replicating the workflow (package installed into the venv, bootstrap env + `bootstrap.yaml`): `test_agent` all green with `API Hooks Block` reporting the shell hook run and the plugin record (saves and audit events); MCP smoke `[OK] get_settings lists plugin 'echo' (hook API 1)`. Negatives: a wrong `NANOIDP_E2E_PLUGIN` name fails the check; with the package uninstalled the bootstrap currently aborts startup on `main` (that is finding 1 of #200, after which it becomes a listed `plugins_failed` entry). No production code touched.