### PR TITLE
chore: bump to 2.7.0rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.7.0rc3"
+version = "2.7.0rc4"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Fourth release candidate for 2.7.0. Since rc3, all merged through reviewed PRs:

- #178 (#172): `--profile` overrides YAML for every value, survives reloads, never persisted; stricter-dev hardening re-derived on every reload; `/api/config` exposes the effective profile.
- #179 (#149): import contracts enforced in CI (import-linter).
- #180 (#81): native-app redirect URIs per RFC 8252 (private-use schemes with the section 7.1 minimum rule, loopback port variability).
- #182 (#175 piece 1): `config_version` in both YAML files.
- #183 (#181): SAML `entity_id`/`sso_url` derived from the effective issuer when unset.
- #184: the unit suite no longer rewrites the repo's `config/`.
- #197 (#175 piece 2): settings/users loaded through document models; unknown keys warned with their path.
- #199 (#185): hooks and plugins v1 (shell hooks, entry-point plugins, bootstrap surface, error policy, fail-without-commit strict reloads).
- #200: review fixes over the whole range (plugin registration under the error policy, JSON errors on reload, audit logging never loads config, secret redaction, ordered plugin snapshot).
- #201: the reference plugin and the bootstrap surface exercised end to end.

Security review over the full range: no findings; CodeQL: zero open alerts. CHANGELOG stays [Unreleased] per the pre-release policy; the rc content goes in the GitHub pre-release notes.