### PR TITLE
fix: the react-spa-pkce preset loads again (#198)

### DIFF
--- a/examples/react-spa-pkce/settings.yaml
+++ b/examples/react-spa-pkce/settings.yaml
@@ -13,7 +13,7 @@ oauth:
   refresh_token_expiry_minutes: 1440  # 24 hours
   clients:
     - client_id: "spa-client"
-      client_secret: "spa-not-a-secret"  # placeholder: PKCE clients get no real secret; a public-client mode (no secret at all) is #188
+      client_secret: "spa-not-a-secret"  # schema placeholder until #188; unused by the SPA PKCE flow, not a real secret
       description: "React SPA with PKCE"
 
 # CORS configuration for SPA

--- a/examples/react-spa-pkce/settings.yaml
+++ b/examples/react-spa-pkce/settings.yaml
@@ -13,7 +13,7 @@ oauth:
   refresh_token_expiry_minutes: 1440  # 24 hours
   clients:
     - client_id: "spa-client"
-      client_secret: ""  # Public client, no secret needed for PKCE
+      client_secret: "spa-not-a-secret"  # placeholder: PKCE clients get no real secret; a public-client mode (no secret at all) is #188
       description: "React SPA with PKCE"
 
 # CORS configuration for SPA

--- a/tests/test_config_documents.py
+++ b/tests/test_config_documents.py
@@ -124,14 +124,10 @@ class TestShippedFilesLoadWithoutWarnings:
         with caplog.at_level(logging.WARNING, logger="nanoidp.config_documents"):
             document = load_settings_document(data, path)
         assert not [r for r in caplog.records if "unknown key" in r.getMessage()], caplog.text
-        if path.parent.name == "react-spa-pkce":
-            # Pre-existing, independent of this refactor: the preset ships a
-            # public client with client_secret "" which OAuthClient refuses
-            # (min_length=1). Tracked under #188 (public clients).
-            with pytest.raises(ValueError, match="client_secret"):
-                document.to_settings()
-        else:
-            document.to_settings()
+        # Every shipped preset must actually load (#198): react-spa-pkce used
+        # to ship client_secret "" which OAuthClient refuses; it now carries a
+        # placeholder until #188 introduces real public clients.
+        document.to_settings()
 
     @pytest.mark.parametrize("path", SHIPPED_USERS, ids=lambda p: str(p.relative_to(REPO)))
     def test_users(self, path, caplog):


### PR DESCRIPTION
Closes #198. One-line preset fix: `client_secret: ""` was refused by `OAuthClient` (min_length 1), so `nanoidp --config examples/react-spa-pkce` failed at startup. The preset now ships a commented placeholder secret; the PKCE flow is unaffected (the SPA never sends it) and dropping the secret entirely is #188 (public clients, agentic milestone). The shipped-files test loses its special case: every shipped preset must load. Fits the 2.7 freeze as a packaging regression fix.