### PR TITLE
feat: generated config schema, validate-config CLI and strict validation (#175 pieces 3-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (checked before `${VAR}` expansion).
 
 ### Added
+- **Generated config schema, `validate-config` and strict validation** (#175,
+  pieces 3 and 4). Three additions to the config contract, none of which
+  restates it a seventh time:
+  - `nanoidp config-schema` prints the JSON Schema of `settings.yaml`,
+    `users.yaml` and `bootstrap.yaml`, generated from the document models
+    (`--file` for one of them, `--write` to regenerate the committed
+    artifact from a source checkout). The artifact is
+    `docs/schema/config.v1.json`: one standalone schema per file under the
+    keys `settings`, `users` and `bootstrap`, next to the `config_version`
+    they describe, ready to point an editor's YAML-schema support at. A test
+    fails when the committed file no longer matches the models, and parity
+    tests fail when the MCP `update_settings` tool or the web UI's settings
+    form grows a knob that is not a key of the contract - or offers one of
+    the YAML-only fields (`secret_key`, `require_ui_login`, `hooks`,
+    `plugins`).
+  - `config_validation: warn|strict` (top level of `settings.yaml`, default
+    `warn`) and the server flag `--strict-config` decide what an unknown key
+    does: log its path and keep loading, or refuse to start and refuse every
+    later reload with the same message. The flag wins over the file for that
+    run only and is never written back, like `--profile` (#172). One
+    contract per directory: `users.yaml` and `bootstrap.yaml` follow what
+    `settings.yaml` declares. Wrong types stay errors in both modes.
+  - `nanoidp validate-config [--config DIR] [--strict]` lints a
+    configuration directory without starting anything: one line per finding,
+    exit 0 when clean or with warnings only, exit 1 on errors and on
+    warnings under `--strict`. It reads the three files through the same
+    loaders the server uses and nothing else - no `ConfigManager`, no hook
+    dispatched, no plugin imported, `bootstrap.yaml` checked for its shape
+    only - so it is safe as a pre-commit or CI step on a directory whose
+    hooks name commands. MCP agents get the same check as the read-only
+    `validate_config` tool (`{valid, findings}`), which brings the MCP
+    surface to 26 tools.
 - **Hooks and plugins v1** (#185): extension points for external
   configuration stores, not backends. Three synchronous hooks with
   `HOOK_API_VERSION = 1`: `on_before_load(config_dir)` before the files are

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -227,6 +227,12 @@ with nanoidp's environment: the file is operator-owned by definition, the
 same trust boundary as `secret_key` or `management_secret`. Neither surface
 is reachable from the web UI or MCP.
 
+Checking a configuration directory is not the same as loading one:
+`nanoidp validate-config` and the MCP `validate_config` tool validate the
+shape of `hooks:` and `plugins:` without dispatching a hook or importing a
+plugin, so linting a directory someone else wrote executes nothing
+([Configuration](../reference/configuration.md#validating-your-configuration)).
+
 ## What hooks are not
 
 There are no hooks on the protocol path (`on_token_issued`, `on_login` and

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -95,7 +95,14 @@ config_validation: warn     # default: log the key and its path, keep loading
 The value belongs to the configuration directory as a whole: `users.yaml`
 and `bootstrap.yaml` follow what `settings.yaml` declares. Wrong types and
 refused values are errors in both modes and always have been; `strict` is
-only about the unknown key. The server flag `--strict-config` turns strict
+only about the unknown key. `settings.yaml` and `users.yaml` are validated
+on startup and on every reload; `bootstrap.yaml` is validated when the
+bootstrap surface is loaded, at startup (`validate-config` checks all
+three, so for `bootstrap.yaml` it reports what would stop the NEXT
+startup, not the next reload). A load that fails validates and commits
+nothing: the running settings, users, validation mode and hooks stay
+exactly as they were, in the same fail-without-commit contract as the
+hook registry. The server flag `--strict-config` turns strict
 on for one run, wins over the file, and is never written back:
 
 ```bash

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -37,8 +37,10 @@ The contract is a single integer, not semver:
   or the MCP server preserve it if present and never add it.
 - **Unknown keys are reported.** A key nanoidp does not know (a typo such
   as `oauth.isuer`) is logged as a warning with its path and ignored; the
-  file still loads. Inside a user entry, unknown keys become that user's
-  `attributes`, as they always have.
+  file still loads, unless the directory is validated strictly (see
+  [Validating your configuration](#validating-your-configuration)). Inside a
+  user entry, unknown keys become that user's `attributes`, as they always
+  have.
 - **Optional additions never bump it.** New optional keys with defaults keep
   the version; only renames, removals or semantic changes of existing keys
   do, and such a bump ships with a migration step in the loader.
@@ -49,6 +51,101 @@ The contract is a single integer, not semver:
 `GET /api/config` and the MCP `get_settings` tool report the effective
 `config_version`, so external tools and agents know which contract to target.
 The CHANGELOG carries a "Config schema" section whenever it changes.
+
+### The generated schema artifact
+
+The machine-readable form of the contract lives in the repository at
+[`docs/schema/config.v1.json`](https://github.com/cdelmonte-zg/nanoidp/blob/main/docs/schema/config.v1.json):
+one standalone JSON Schema per file, under the keys `settings`, `users` and
+`bootstrap`, next to the `config_version` they describe. Point an editor's
+YAML-schema support at the entry matching the file to get completion and
+typo detection while writing it.
+
+It is generated, never hand-written - that is the whole point, since a
+hand-written schema would be one more place the contract could disagree
+with itself:
+
+```bash
+nanoidp config-schema                 # the full document, on stdout
+nanoidp config-schema --file users    # one file's schema
+nanoidp config-schema --write         # regenerate docs/schema/config.v1.json
+```
+
+`--write` targets a path inside the repository and therefore works from a
+source checkout only; from an installed package, redirect stdout instead. A
+test fails when the committed file no longer matches the models, with the
+command to run.
+
+One thing the schema cannot express: a `${VAR}` placeholder is a string
+until it is expanded, and its expansion is a string too, which nanoidp then
+coerces to the field's type. A plain JSON Schema check therefore flags
+`port: ${PORT:8000}` against `"type": "integer"`. Use `nanoidp
+validate-config` for that check - it runs the real loader.
+
+## Validating your configuration
+
+Unknown keys are reported, not ignored. What "reported" means is a choice:
+
+```yaml
+# settings.yaml
+config_validation: warn     # default: log the key and its path, keep loading
+# config_validation: strict # refuse to start
+```
+
+The value belongs to the configuration directory as a whole: `users.yaml`
+and `bootstrap.yaml` follow what `settings.yaml` declares. Wrong types and
+refused values are errors in both modes and always have been; `strict` is
+only about the unknown key. The server flag `--strict-config` turns strict
+on for one run, wins over the file, and is never written back:
+
+```bash
+nanoidp --strict-config          # unknown key -> refuse to start
+```
+
+To check a directory without starting anything:
+
+```bash
+$ nanoidp validate-config --config ./config
+validate-config: ./config
+warning: config/settings.yaml: unknown key oauth.isuer
+0 error(s), 1 warning(s)
+$ echo $?
+0
+$ nanoidp validate-config --config ./config --strict
+validate-config: ./config (strict)
+warning: config/settings.yaml: unknown key oauth.isuer
+0 error(s), 1 warning(s) (strict: warnings fail)
+$ echo $?
+1
+```
+
+One line per finding; exit 0 when clean, or with warnings only and no
+`--strict`; exit 1 on any error, and on any warning under `--strict` (a
+directory that declares `config_validation: strict` is strict either way,
+since that is a directory the server would refuse to start on).
+
+The command reads the three files through the same loaders the server uses,
+and does nothing else: no server, no `ConfigManager`, no hook dispatched, no
+plugin imported. `bootstrap.yaml` is checked for its shape only, because a
+lint step that ran the commands a directory declares would be a remote
+execution primitive triggered by looking at it. That is what makes it safe
+as a pre-commit or CI step:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: nanoidp-validate-config
+        name: nanoidp validate-config
+        entry: nanoidp validate-config --config ./config --strict
+        language: system
+        files: ^config/.*\.yaml$
+        pass_filenames: false
+```
+
+MCP agents have the same check as the read-only `validate_config` tool,
+which returns `{valid, findings}` for the running config directory.
 
 ## Users (`config/users.yaml`)
 
@@ -194,6 +291,11 @@ saml:
 # Optional; local dev/testing convenience, off by default - see "Login mode" above
 # login:
 #   mode: persona   # password (default) | persona
+
+# Optional; how an unknown key is reported - see "Validating your configuration"
+# below. Also settable at startup with --strict-config, which wins over this
+# value for that run only and is never written back
+# config_validation: strict   # warn (default) | strict
 
 authority_prefixes:
   roles: "ROLE_"

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -29,6 +29,7 @@ readonly mode, and the exposure warnings, see the
 | `update_settings` | Update IdP settings |
 | `save_config` | Persist the current configuration to the YAML files |
 | `reload_config` | Reload configuration from files |
+| `validate_config` | Lint the running config directory without starting or executing anything (no hook, no plugin): `{valid, findings}` |
 | `get_oidc_discovery` | Get OIDC discovery document (same document as `/.well-known/openid-configuration`) |
 | `get_jwks` | Get JSON Web Key Set |
 | `get_audit_log` | Get audit log entries (filter by limit, event type, username) |

--- a/docs/schema/config.v1.json
+++ b/docs/schema/config.v1.json
@@ -1,0 +1,726 @@
+{
+  "bootstrap": {
+    "$defs": {
+      "HooksSection": {
+        "additionalProperties": false,
+        "description": "``hooks:`` (#185): shell commands run at the three extension points.\n\nAbsent = no hooks. ``strict`` applies to plugins too; ``timeout_seconds``\nis for shell hooks only (a plugin manages its own timeouts). Policy\nvalues declared here override ``bootstrap.yaml``'s; undeclared ones do\nnot (``model_fields_set`` decides). YAML-only (and ``bootstrap.yaml``/env): never settable from the UI\nor MCP, since a command editable through the surface it observes would\nbe a remote-execution primitive.",
+        "properties": {
+          "on_audit_event": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Audit Event"
+          },
+          "on_before_load": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Before Load"
+          },
+          "on_config_saved": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Config Saved"
+          },
+          "strict": {
+            "default": false,
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "timeout_seconds": {
+            "default": 10.0,
+            "exclusiveMinimum": 0,
+            "title": "Timeout Seconds",
+            "type": "number"
+          }
+        },
+        "title": "HooksSection",
+        "type": "object"
+      }
+    },
+    "$id": "https://cdelmonte-zg.github.io/nanoidp/schema/config.v1-bootstrap.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "description": "``bootstrap.yaml`` (#185): the hook surface that exists before\n``settings.yaml`` can be read. Only ``hooks:`` and ``plugins:`` are\nallowed, validated by the same section models; anything else is refused\nso the file cannot quietly grow into a second settings file.",
+    "properties": {
+      "hooks": {
+        "$ref": "#/$defs/HooksSection"
+      },
+      "plugins": {
+        "additionalProperties": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "title": "Plugins",
+        "type": "object"
+      }
+    },
+    "title": "BootstrapDocument",
+    "type": "object"
+  },
+  "config_version": 1,
+  "description": "One JSON Schema per configuration file, generated from the document models in nanoidp.config_documents by `nanoidp config-schema --write`. Do not edit by hand. Each of settings, users and bootstrap is a standalone schema; validate a file against the entry of the same name.",
+  "settings": {
+    "$defs": {
+      "ClientEntry": {
+        "additionalProperties": false,
+        "description": "One ``oauth.clients[]`` entry. ``additional_audiences`` and\n``redirect_uris`` stay ``Any`` here because the loader accepts a scalar\nstring as a one-element list and reports unsupported shapes with a\nclient-scoped message (#35); that coercion runs in ``to_client()``.",
+        "properties": {
+          "additional_audiences": {
+            "default": null,
+            "title": "Additional Audiences"
+          },
+          "background_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Background Color"
+          },
+          "client_id": {
+            "default": "",
+            "title": "Client Id",
+            "type": "string"
+          },
+          "client_secret": {
+            "default": "",
+            "title": "Client Secret",
+            "type": "string"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "footer_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Footer Color"
+          },
+          "header_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Header Color"
+          },
+          "redirect_uris": {
+            "default": null,
+            "title": "Redirect Uris"
+          },
+          "show_client_id": {
+            "default": true,
+            "title": "Show Client Id",
+            "type": "boolean"
+          },
+          "show_description": {
+            "default": false,
+            "title": "Show Description",
+            "type": "boolean"
+          }
+        },
+        "title": "ClientEntry",
+        "type": "object"
+      },
+      "HooksSection": {
+        "additionalProperties": false,
+        "description": "``hooks:`` (#185): shell commands run at the three extension points.\n\nAbsent = no hooks. ``strict`` applies to plugins too; ``timeout_seconds``\nis for shell hooks only (a plugin manages its own timeouts). Policy\nvalues declared here override ``bootstrap.yaml``'s; undeclared ones do\nnot (``model_fields_set`` decides). YAML-only (and ``bootstrap.yaml``/env): never settable from the UI\nor MCP, since a command editable through the surface it observes would\nbe a remote-execution primitive.",
+        "properties": {
+          "on_audit_event": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Audit Event"
+          },
+          "on_before_load": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Before Load"
+          },
+          "on_config_saved": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "On Config Saved"
+          },
+          "strict": {
+            "default": false,
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "timeout_seconds": {
+            "default": 10.0,
+            "exclusiveMinimum": 0,
+            "title": "Timeout Seconds",
+            "type": "number"
+          }
+        },
+        "title": "HooksSection",
+        "type": "object"
+      },
+      "JwtSection": {
+        "additionalProperties": false,
+        "properties": {
+          "algorithm": {
+            "default": "RS256",
+            "title": "Algorithm",
+            "type": "string"
+          },
+          "keys_dir": {
+            "default": "./keys",
+            "title": "Keys Dir",
+            "type": "string"
+          }
+        },
+        "title": "JwtSection",
+        "type": "object"
+      },
+      "LoggingSection": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": null,
+            "title": "Format"
+          },
+          "level": {
+            "default": "INFO",
+            "title": "Level",
+            "type": "string"
+          },
+          "log_saml_requests": {
+            "default": true,
+            "title": "Log Saml Requests",
+            "type": "boolean"
+          },
+          "log_token_requests": {
+            "default": true,
+            "title": "Log Token Requests",
+            "type": "boolean"
+          },
+          "verbose_logging": {
+            "default": true,
+            "title": "Verbose Logging",
+            "type": "boolean"
+          }
+        },
+        "title": "LoggingSection",
+        "type": "object"
+      },
+      "LoginSection": {
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "default": "password",
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "title": "LoginSection",
+        "type": "object"
+      },
+      "OAuthSection": {
+        "additionalProperties": false,
+        "properties": {
+          "audience": {
+            "default": "default",
+            "title": "Audience",
+            "type": "string"
+          },
+          "clients": {
+            "items": {
+              "$ref": "#/$defs/ClientEntry"
+            },
+            "title": "Clients",
+            "type": "array"
+          },
+          "device_verification_base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Device Verification Base Url"
+          },
+          "issuer": {
+            "default": "http://localhost:8000",
+            "title": "Issuer",
+            "type": "string"
+          },
+          "issuer_allowlist": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Issuer Allowlist"
+          },
+          "issuer_from_proxy_headers": {
+            "default": false,
+            "title": "Issuer From Proxy Headers",
+            "type": "boolean"
+          },
+          "issuer_from_request": {
+            "default": false,
+            "title": "Issuer From Request",
+            "type": "boolean"
+          },
+          "logos_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Logos Dir"
+          },
+          "refresh_token_expiry_minutes": {
+            "default": null,
+            "title": "Refresh Token Expiry Minutes"
+          },
+          "refresh_token_rotation": {
+            "default": false,
+            "title": "Refresh Token Rotation",
+            "type": "boolean"
+          },
+          "require_pkce": {
+            "default": false,
+            "title": "Require Pkce",
+            "type": "boolean"
+          },
+          "token_expiry_minutes": {
+            "default": 60,
+            "title": "Token Expiry Minutes",
+            "type": "integer"
+          }
+        },
+        "title": "OAuthSection",
+        "type": "object"
+      },
+      "SamlSection": {
+        "additionalProperties": false,
+        "properties": {
+          "c14n_algorithm": {
+            "default": "exc_c14n",
+            "title": "C14N Algorithm",
+            "type": "string"
+          },
+          "default_acs_url": {
+            "default": "http://localhost:8080/login/saml2/sso/samlIdp",
+            "title": "Default Acs Url",
+            "type": "string"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Entity Id"
+          },
+          "export_groups": {
+            "default": false,
+            "title": "Export Groups",
+            "type": "boolean"
+          },
+          "export_roles": {
+            "default": false,
+            "title": "Export Roles",
+            "type": "boolean"
+          },
+          "groups_attr_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "groups",
+            "title": "Groups Attr Name"
+          },
+          "roles_attr_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "roles",
+            "title": "Roles Attr Name"
+          },
+          "sign_responses": {
+            "default": true,
+            "title": "Sign Responses",
+            "type": "boolean"
+          },
+          "sp_certificates": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sp Certificates"
+          },
+          "sso_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Sso Url"
+          },
+          "strict_binding": {
+            "default": false,
+            "title": "Strict Binding",
+            "type": "boolean"
+          },
+          "want_authn_requests_signed": {
+            "default": false,
+            "title": "Want Authn Requests Signed",
+            "type": "boolean"
+          }
+        },
+        "title": "SamlSection",
+        "type": "object"
+      },
+      "ServerSection": {
+        "additionalProperties": false,
+        "properties": {
+          "debug": {
+            "default": false,
+            "title": "Debug",
+            "type": "boolean"
+          },
+          "host": {
+            "default": "127.0.0.1",
+            "title": "Host",
+            "type": "string"
+          },
+          "port": {
+            "default": 8000,
+            "title": "Port",
+            "type": "integer"
+          }
+        },
+        "title": "ServerSection",
+        "type": "object"
+      },
+      "SessionSection": {
+        "additionalProperties": false,
+        "properties": {
+          "enforce_password_check": {
+            "default": false,
+            "title": "Enforce Password Check",
+            "type": "boolean"
+          },
+          "permanent": {
+            "default": null,
+            "title": "Permanent"
+          },
+          "require_ui_login": {
+            "default": false,
+            "title": "Require Ui Login",
+            "type": "boolean"
+          },
+          "secret_key": {
+            "default": "dev-secret-key-change-in-production",
+            "title": "Secret Key",
+            "type": "string"
+          }
+        },
+        "title": "SessionSection",
+        "type": "object"
+      }
+    },
+    "$id": "https://cdelmonte-zg.github.io/nanoidp/schema/config.v1-settings.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "description": "Top-level shape of ``settings.yaml``.",
+    "properties": {
+      "allowed_identity_classes": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Allowed Identity Classes",
+        "type": "array"
+      },
+      "authority_prefixes": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "Authority Prefixes",
+        "type": "object"
+      },
+      "config_validation": {
+        "default": "warn",
+        "title": "Config Validation",
+        "type": "string"
+      },
+      "config_version": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Config Version"
+      },
+      "cors_allowed_origins": {
+        "default": null,
+        "title": "Cors Allowed Origins"
+      },
+      "device_flow": {
+        "default": null,
+        "title": "Device Flow"
+      },
+      "hooks": {
+        "$ref": "#/$defs/HooksSection"
+      },
+      "jwt": {
+        "$ref": "#/$defs/JwtSection"
+      },
+      "logging": {
+        "$ref": "#/$defs/LoggingSection"
+      },
+      "login": {
+        "$ref": "#/$defs/LoginSection"
+      },
+      "oauth": {
+        "$ref": "#/$defs/OAuthSection"
+      },
+      "plugins": {
+        "additionalProperties": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "title": "Plugins",
+        "type": "object"
+      },
+      "saml": {
+        "$ref": "#/$defs/SamlSection"
+      },
+      "security_profile": {
+        "default": "dev",
+        "title": "Security Profile",
+        "type": "string"
+      },
+      "server": {
+        "$ref": "#/$defs/ServerSection"
+      },
+      "session": {
+        "$ref": "#/$defs/SessionSection"
+      }
+    },
+    "title": "SettingsDocument",
+    "type": "object"
+  },
+  "title": "NanoIDP configuration directory",
+  "users": {
+    "$defs": {
+      "UserEntry": {
+        "additionalProperties": true,
+        "description": "One ``users.<name>`` mapping. Defaults mirror the old loader: a\nmissing ``password`` is ``None`` (persona-only user), ``roles`` default\nto ``[\"USER\"]``, ``email`` to ``<username>@example.org`` (filled in by\n``to_user`` because it needs the key).",
+        "properties": {
+          "attributes": {
+            "additionalProperties": true,
+            "title": "Attributes",
+            "type": "object"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Email"
+          },
+          "entitlements": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Entitlements",
+            "type": "array"
+          },
+          "groups": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Groups",
+            "type": "array"
+          },
+          "identity_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Identity Class"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Password"
+          },
+          "roles": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Roles",
+            "type": "array"
+          },
+          "source_acl": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Acl",
+            "type": "array"
+          },
+          "tenant": {
+            "default": "default",
+            "title": "Tenant",
+            "type": "string"
+          }
+        },
+        "title": "UserEntry",
+        "type": "object"
+      }
+    },
+    "$id": "https://cdelmonte-zg.github.io/nanoidp/schema/config.v1-users.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "description": "Top-level shape of ``users.yaml``.",
+    "properties": {
+      "config_version": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Config Version"
+      },
+      "default_user": {
+        "default": "admin",
+        "title": "Default User",
+        "type": "string"
+      },
+      "users": {
+        "additionalProperties": {
+          "$ref": "#/$defs/UserEntry"
+        },
+        "title": "Users",
+        "type": "object"
+      }
+    },
+    "title": "UsersDocument",
+    "type": "object"
+  }
+}

--- a/examples/mcp_smoke_test.py
+++ b/examples/mcp_smoke_test.py
@@ -24,7 +24,7 @@ from mcp.client.stdio import stdio_client
 
 # Deliberately a hard number: the docs advertise the tool count, so growing or
 # shrinking the MCP surface must consciously update both (metadata never lies).
-EXPECTED_TOOLS = 25
+EXPECTED_TOOLS = 26
 
 
 async def run(config_dir: str) -> int:
@@ -63,6 +63,18 @@ async def run(config_dir: str) -> int:
                 print(f"[FAIL] discovery document incomplete: {discovery!r}")
                 return 1
             print(f"[OK] get_oidc_discovery: issuer={discovery['issuer']}")
+
+            # validate_config (#175 piece 4): the config the server is running
+            # on must lint clean through the same loaders, and the call must
+            # be inert (no hook, no plugin, no reload).
+            result = await session.call_tool("validate_config", {})
+            validation = json.loads(result.content[0].text)
+            if not validation.get("valid"):
+                print(f"[FAIL] validate_config reported the config invalid: {validation!r}")
+                return 1
+            print(
+                f"[OK] validate_config: valid, {len(validation.get('findings', []))} finding(s)"
+            )
 
             result = await session.call_tool("get_keys_info", {})
             keys_info = json.loads(result.content[0].text)

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -11,8 +11,10 @@ Usage:
 import argparse
 import os
 import sys
+from typing import Optional
 
 from nanoidp import __version__
+from nanoidp.config_schema import SCHEMA_ARTIFACT, SCHEMA_MODELS
 from nanoidp.models import SECURITY_PROFILES
 
 # Add src to path for development
@@ -140,6 +142,33 @@ Default credentials:
 """)
 
 
+def validate_config_command(config_dir: Optional[str], strict: bool) -> int:
+    """``nanoidp validate-config``: lint a config directory, print one line
+    per finding, return the exit code.
+
+    Nothing is started and nothing is executed: no ConfigManager, no hook
+    dispatch, no plugin import (see ``nanoidp.config_validation``). That is
+    what makes it safe as a pre-commit or CI step on a directory whose
+    bootstrap.yaml names commands.
+    """
+    from nanoidp.config_validation import effective_strict, report, validate_config_dir
+
+    # Same precedence the server's own discovery uses (ConfigManager).
+    directory: str = (
+        config_dir
+        or os.getenv("NANOIDP_CONFIG_DIR")
+        or os.getenv("MOCK_IDP_CONFIG_DIR")
+        or "./config"
+    )
+    strict_run = effective_strict(directory, strict)
+    findings = validate_config_dir(directory)
+    lines, code = report(findings, strict_run)
+    print(f"validate-config: {directory} (strict)" if strict_run else f"validate-config: {directory}")
+    for line in lines:
+        print(line)
+    return code
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="NanoIDP - Lightweight Identity Provider for testing OAuth2/OIDC and SAML integrations"
@@ -182,6 +211,42 @@ def main() -> None:
         help="Path to configuration directory",
     )
 
+    # config-schema subcommand (#175 piece 3)
+    schema_parser = subparsers.add_parser(
+        "config-schema",
+        help="Print the JSON Schema of the configuration files, generated from the "
+        "document models (settings.yaml, users.yaml, bootstrap.yaml)",
+    )
+    schema_parser.add_argument(
+        "--file",
+        choices=sorted(SCHEMA_MODELS),
+        default=None,
+        help="Print only this file's schema instead of the full document",
+    )
+    schema_parser.add_argument(
+        "--write",
+        action="store_true",
+        help=f"Write the full document to {SCHEMA_ARTIFACT} in the source checkout "
+        "instead of printing it (works from a checkout only)",
+    )
+
+    # validate-config subcommand (#175 piece 4)
+    validate_parser = subparsers.add_parser(
+        "validate-config",
+        help="Validate settings.yaml, users.yaml and bootstrap.yaml without starting "
+        "the server; no hook is run and no plugin is loaded",
+    )
+    validate_parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to configuration directory",
+    )
+    validate_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on warnings too (what --strict-config does at startup)",
+    )
+
     # Main server arguments (when no subcommand)
     parser.add_argument(
         "--bootstrap-hook",
@@ -221,6 +286,15 @@ def main() -> None:
         "YAML value applies (default: dev)",
     )
 
+    parser.add_argument(
+        "--strict-config",
+        action="store_true",
+        help="Refuse to start when a configuration file contains an unknown key, "
+        "instead of logging a warning and ignoring it. Overrides settings.yaml's "
+        "config_validation for this run only and is never written back; wrong "
+        "types are errors either way",
+    )
+
     args = parser.parse_args()
 
     # Handle init command
@@ -232,6 +306,32 @@ def main() -> None:
         """)
         init_config(args.config_dir)
         return
+
+    # Handle config-schema command
+    if args.command == "config-schema":
+        from nanoidp.config_schema import build_schema_document, file_schema, render, write_artifact
+        if args.write:
+            if args.file:
+                print(
+                    "config-schema --write always writes the full document; "
+                    "drop --file (or redirect a single file's schema yourself)",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            try:
+                target = write_artifact()
+            except (RuntimeError, OSError) as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                sys.exit(1)
+            print(f"  [written] {target}")
+            return
+        document = file_schema(args.file) if args.file else build_schema_document()
+        print(render(document), end="")
+        return
+
+    # Handle validate-config command
+    if args.command == "validate-config":
+        sys.exit(validate_config_command(args.config, args.strict))
 
     # Handle plugins command
     if args.command == "plugins":
@@ -264,6 +364,8 @@ def main() -> None:
         debug=args.debug,
         config_dir=args.config,
         profile=args.profile,
+        # Only a given flag is an override; without it settings.yaml decides.
+        strict_config=True if args.strict_config else None,
     )
 
 

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -21,7 +21,11 @@ from .services import init_crypto_service
 limiter: Optional[Limiter] = None
 
 
-def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) -> Flask:
+def create_app(
+    config_dir: Optional[str] = None,
+    profile: Optional[str] = None,
+    strict_config: Optional[bool] = None,
+) -> Flask:
     """Create and configure the Flask application."""
     global limiter
 
@@ -31,7 +35,10 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
     # reload(); the stricter-dev runtime hardening is derived from the
     # EFFECTIVE profile inside ConfigManager, so YAML and CLI mean the same
     # thing and neither is lost on the first UI/MCP save (#68 review, #172).
-    config = init_config(config_dir, profile_override=profile)
+    # --strict-config follows the same contract (#175 piece 4): given, it
+    # wins over settings.yaml's config_validation for this run only; omitted
+    # (None), the file decides.
+    config = init_config(config_dir, profile_override=profile, strict_config=strict_config)
     settings = config.settings
 
     # Configure logging
@@ -116,6 +123,9 @@ def create_app(config_dir: Optional[str] = None, profile: Optional[str] = None) 
 
     logger.info("NanoIDP initialized")
     logger.info(f"  - Security profile: {settings.security_profile}")
+    logger.info(
+        f"  - Config validation: {'strict' if config.strict_config else 'warn'}"
+    )
     logger.info(f"  - Password hashing: {'bcrypt' if settings.password_hashing else 'plaintext'}")
     logger.info(f"  - Issuer: {settings.issuer}")
     logger.info(f"  - Users: {len(config.users)}")
@@ -135,9 +145,10 @@ def run_app(
     debug: Optional[bool] = None,
     config_dir: Optional[str] = None,
     profile: Optional[str] = None,
+    strict_config: Optional[bool] = None,
 ) -> None:
     """Run the Flask application."""
-    app = create_app(config_dir, profile=profile)
+    app = create_app(config_dir, profile=profile, strict_config=strict_config)
     config = get_config()
     settings = config.settings
 

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -126,7 +126,7 @@ class ConfigManager:
         Needed before the document loader runs (it decides how that loader
         reports) and before bootstrap.yaml is read. A file that cannot be
         parsed at all returns the default here and fails with its real error
-        a moment later, in _read_settings, where the message belongs.
+        a moment later, in _stage_directory, where the message belongs.
         """
         settings_file = self.config_dir / "settings.yaml"
         if not settings_file.exists():
@@ -134,26 +134,31 @@ class ConfigManager:
         try:
             with open(settings_file, "r") as f:
                 data = yaml.safe_load(f) or {}
-        except Exception:  # noqa: BLE001 - reported by _read_settings
+        except Exception:  # noqa: BLE001 - reported by _stage_directory
             return "warn"
         return declared_validation_mode(data) if isinstance(data, dict) else "warn"
 
-    def _load_config(self) -> None:
-        """Load all configuration files."""
+    def _load_config(self, run_before_load: bool = True) -> None:
+        """Load all configuration files as ONE directory transaction.
+
+        The transactional boundary is the whole configuration directory
+        (#204 review): settings.yaml AND users.yaml are parsed and validated
+        into candidates first, and only when both are valid does anything
+        touch the runtime. A failed load (strict unknown key in either file,
+        wrong types, version mismatch, strict plugin failure) leaves
+        settings, users, default_user, strict_config, config_version, the
+        profile hardening and the hook registry exactly as they were.
+        """
         # on_before_load: bootstrap hooks run once (first load only), the
         # settings.yaml-declared ones on every load. The registry enforces
         # the once-only rule; under hooks.strict a failure raises HookError
         # here, before anything is read.
-        self.hooks.run_before_load(self.config_dir)
-        self._load_settings()
-        self._load_users()
+        if run_before_load:
+            self.hooks.run_before_load(self.config_dir)
+        staged = self._stage_directory()
+        self._commit_directory(staged)
         logger.info(f"Loaded configuration from {self.config_dir}")
         logger.info(f"Loaded {len(self.users)} users")
-
-    def _load_settings(self) -> None:
-        """Load settings from settings.yaml, then apply the effective profile."""
-        self._read_settings()
-        self._apply_profile()
 
     # Settings fields the stricter-dev profile forces at runtime (#47, #68).
     # Listed once so _apply_profile() and persistable_settings() cannot drift:
@@ -168,31 +173,22 @@ class ConfigManager:
         "debug": False,
     }
 
-    def _apply_profile(self) -> None:
-        """Make the effective security profile real on the freshly built Settings.
+    def _apply_profile(self, settings: Settings) -> Dict[str, Any]:
+        """Make the effective security profile real on a candidate Settings.
 
-        Two things used to happen once in create_app() and were lost on the
-        first reload() - i.e. on the first UI/MCP save (#172): the CLI
-        --profile override, and the stricter-dev runtime hardening. Both
-        belong here, next to the only place Settings is rebuilt, so every
-        reload re-derives them.
-
-        self.settings is the EFFECTIVE state. Every value this method forces
-        is recorded in self._declared with the value the file declared (or
-        the model default), so persistable_settings() can hand the writer
-        the declared state and neither the override nor its derived effects
-        ever reach settings.yaml (#172 review). oauth21 needs no mutation;
-        its protocol strictness derives from security_profile via Settings
-        properties (#68).
+        Pure with respect to the manager: mutates only the candidate and
+        RETURNS the declared-value snapshot; the caller commits both. See
+        _STRICTER_DEV_HARDENING and persistable_settings().
         """
-        self._declared = {}
+        declared: Dict[str, Any] = {}
         if self.profile_override is not None:
-            self._declared["security_profile"] = self.settings.security_profile
-            self.settings.security_profile = self.profile_override
-        if self.settings.security_profile == "stricter-dev":
+            declared["security_profile"] = settings.security_profile
+            settings.security_profile = self.profile_override
+        if settings.security_profile == "stricter-dev":
             for field, forced in self._STRICTER_DEV_HARDENING.items():
-                self._declared[field] = getattr(self.settings, field)
-                setattr(self.settings, field, forced)
+                declared[field] = getattr(settings, field)
+                setattr(settings, field, forced)
+        return declared
 
     def persistable_settings(self) -> Settings:
         """The declared configuration state, as opposed to the effective one.
@@ -207,45 +203,84 @@ class ConfigManager:
             return self.settings
         return self.settings.model_copy(update=self._declared)
 
-    def _read_settings(self) -> None:
-        """Build Settings from settings.yaml (defaults when the file is absent)."""
+    def _stage_directory(self) -> Dict[str, Any]:
+        """Parse and validate the whole directory into candidates, committing
+        nothing. Any exception here leaves the manager untouched."""
+        staged: Dict[str, Any] = {}
         settings_file = self.config_dir / "settings.yaml"
-
         if not settings_file.exists():
             logger.warning(f"Settings file not found: {settings_file}, using defaults")
+            staged["settings_missing"] = True
+            staged["strict"] = self._effective_strict("warn")
+            staged["version"] = IMPLICIT_CONFIG_VERSION
+            staged["settings"] = self._default_settings()
+            staged["hooks_section"] = None
+            staged["plugins"] = {}
+        else:
+            with open(settings_file, "r") as f:
+                data = yaml.safe_load(f) or {}
+            # Candidate strictness: an edited config_validation takes effect
+            # on the load that reads it, an explicit --strict-config keeps
+            # winning, and a load that FAILS never changes the running mode
+            # (#204 review).
+            staged["settings_missing"] = False
+            staged["strict"] = self._effective_strict(declared_validation_mode(data))
+            # Refuse files written for a newer contract before reading any
+            # key (#175): a silently half-understood file is worse than a
+            # clear stop.
+            staged["version"] = check_config_version(data, settings_file)
+            data = _expand_env_vars(data)
+            # YAML -> document model -> domain model (#175 piece 2).
+            document = load_settings_document(data, settings_file, strict=staged["strict"])
+            staged["settings"] = document.to_settings()
+            staged["hooks_section"] = document.hooks
+            staged["plugins"] = document.plugins
+        # The profile hardening is part of the candidate, not a later step.
+        staged["declared"] = self._apply_profile(staged["settings"])
+
+        users_file = self.config_dir / "users.yaml"
+        if not users_file.exists():
+            logger.warning(f"Users file not found: {users_file}, using defaults")
+            staged["users"], staged["default_user"] = self._default_users(), "admin"
+        else:
+            with open(users_file, "r") as f:
+                udata = yaml.safe_load(f) or {}
+            # config_version is checked BEFORE placeholder expansion: it must
+            # be a literal integer, never ${VAR} (#175 review).
+            users_version = check_config_version(udata, users_file)
+            # One contract for the whole directory (#175 review).
+            if users_version != staged["version"]:
+                raise ValueError(
+                    f"{users_file}: config_version {users_version} does not match "
+                    f"settings.yaml's config_version {staged['version']}; the "
+                    f"configuration directory follows one contract version"
+                )
+            udata = _expand_env_vars(udata)
+            staged["users"], staged["default_user"] = load_users_document(
+                udata, users_file, strict=staged["strict"]
+            ).to_users()
+        return staged
+
+    def _commit_directory(self, staged: Dict[str, Any]) -> None:
+        """Promote a fully validated staging to the runtime.
+
+        The hook registry goes first because it is the only step that can
+        still fail (strict plugin load), and replace_source() rolls itself
+        back on failure (#200 review); everything after is plain assignment.
+        """
+        if staged["settings_missing"]:
             # A vanished settings.yaml takes its hooks, plugins and policy
             # with it (#185 review); bootstrap entries stay.
             self.hooks.drop_source(SOURCE_SETTINGS)
             self._hooks_snapshot = None
-            self._set_default_settings()
-            return
-
-        with open(settings_file, "r") as f:
-            data = yaml.safe_load(f) or {}
-
-        # Re-derived on every load: an edited config_validation takes effect
-        # on the next reload, an explicit --strict-config keeps winning.
-        self.strict_config = self._effective_strict(declared_validation_mode(data))
-
-        # Refuse files written for a newer contract before reading any key
-        # (#175): a silently half-understood file is worse than a clear stop.
-        self.config_version = check_config_version(data, settings_file)
-        data = _expand_env_vars(data)
-
-        # YAML -> document model -> domain model (#175 piece 2). The document
-        # model is the single statement of the file format: unknown keys are
-        # reported with their path, defaults live on the model, and the
-        # domain Settings is built from it with every validator it already
-        # had. ${VAR} expansion and config_version stay at the edge, above.
-        document = load_settings_document(data, settings_file, strict=self.strict_config)
-        # Fail without commit (#200 review): build the candidate, apply the
-        # file's hooks/plugins (which may raise under strict and then rolls
-        # the registry back), and only then promote the candidate. A reload
-        # that answers 503 leaves settings, profile hardening and registry
-        # exactly as they were.
-        candidate = document.to_settings()
-        self._configure_hooks_from(document.hooks, document.plugins)
-        self.settings = candidate
+        else:
+            self._configure_hooks_from(staged["hooks_section"], staged["plugins"])
+        self.settings = staged["settings"]
+        self._declared = staged["declared"]
+        self.strict_config = staged["strict"]
+        self.config_version = staged["version"]
+        self.users = staged["users"]
+        self.default_user = staged["default_user"]
 
     def _configure_hooks_from(self, hooks: HooksSection, plugins: Dict[str, Dict[str, Any]]) -> None:
         """Replace the settings.yaml-sourced hooks/plugins with the file's
@@ -277,11 +312,9 @@ class ConfigManager:
         when the error propagates; YamlWriter reloads before re-raising."""
         self.hooks.run_config_saved(path, kind)
 
-    def _set_default_settings(self) -> None:
-        """Set default settings with demo client."""
-        # Model defaults (the same the loader applies to a sparse file) plus
-        # the demo client and prefixes a fresh install gets.
-        self.settings = SettingsDocument(
+    def _default_settings(self) -> Settings:
+        """The Settings a directory without settings.yaml gets."""
+        return SettingsDocument(
             authority_prefixes={
                 "roles": "ROLE_",
                 "groups": "GROUP_",
@@ -290,50 +323,10 @@ class ConfigManager:
             },
             allowed_identity_classes=["INTERNAL", "EXTERNAL", "PARTNER", "SERVICE"],
         ).to_settings()
-        self.settings.clients = [OAuthClient(
-            client_id="demo-client",
-            client_secret="demo-secret",
-            description="Default demo client",
-        )]
 
-    def _load_users(self) -> None:
-        """Load users from users.yaml."""
-        users_file = self.config_dir / "users.yaml"
-
-        if not users_file.exists():
-            logger.warning(f"Users file not found: {users_file}, using defaults")
-            self._set_default_users()
-            return
-
-        with open(users_file, "r") as f:
-            data = yaml.safe_load(f) or {}
-
-        # config_version is checked BEFORE placeholder expansion on purpose:
-        # it must be a literal integer, never ${VAR} (#175 review).
-        users_version = check_config_version(data, users_file)
-        # One contract for the whole directory (#175 review): both files must
-        # declare the same version. Impossible to violate while only v1 exists
-        # (the check above already refused anything else), enforced now so
-        # the rule is real before the first bump makes it matter.
-        if users_version != self.config_version:
-            raise ValueError(
-                f"{users_file}: config_version {users_version} does not match "
-                f"settings.yaml's config_version {self.config_version}; the "
-                f"configuration directory follows one contract version"
-            )
-        # users.yaml takes the same ${VAR} / ${VAR:default} placeholders as
-        # settings.yaml (passwords, emails, attributes); until #175 only the
-        # settings loader expanded them.
-        data = _expand_env_vars(data)
-        # Same document-model path as settings (#175 piece 2); unknown keys
-        # inside a user entry keep folding into its attributes, as always.
-        self.users, self.default_user = load_users_document(
-            data, users_file, strict=self.strict_config
-        ).to_users()
-
-    def _set_default_users(self) -> None:
-        """Set default users."""
-        self.users = {
+    def _default_users(self) -> Dict[str, User]:
+        """The users a directory without users.yaml gets."""
+        return {
             "admin": User(
                 username="admin",
                 password="admin",
@@ -443,8 +436,7 @@ class ConfigManager:
         (or whose push just failed) would silently roll the write back
         (#185 review). Only an explicit reload() consults the mirror.
         """
-        self._load_settings()
-        self._load_users()
+        self._load_config(run_before_load=False)
         logger.info("Configuration refreshed from local files")
 
     def save(self) -> None:

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -314,7 +314,7 @@ class ConfigManager:
 
     def _default_settings(self) -> Settings:
         """The Settings a directory without settings.yaml gets."""
-        return SettingsDocument(
+        settings = SettingsDocument(
             authority_prefixes={
                 "roles": "ROLE_",
                 "groups": "GROUP_",
@@ -323,6 +323,17 @@ class ConfigManager:
             },
             allowed_identity_classes=["INTERNAL", "EXTERNAL", "PARTNER", "SERVICE"],
         ).to_settings()
+        # The demo client the old fallback always shipped (#204 review: the
+        # transactional refactor must not change what a directory without
+        # settings.yaml gets).
+        settings.clients = [
+            OAuthClient(
+                client_id="demo-client",
+                client_secret="demo-secret",
+                description="Default demo client",
+            )
+        ]
+        return settings
 
     def _default_users(self) -> Dict[str, User]:
         """The users a directory without users.yaml gets."""

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -17,6 +17,7 @@ import yaml
 from .config_documents import (
     HooksSection,
     SettingsDocument,
+    declared_validation_mode,
     document_defaults,
     load_settings_document,
     load_users_document,
@@ -47,7 +48,10 @@ class ConfigManager:
     """Manages configuration loading and access."""
 
     def __init__(
-        self, config_dir: Optional[str] = None, profile_override: Optional[str] = None
+        self,
+        config_dir: Optional[str] = None,
+        profile_override: Optional[str] = None,
+        strict_config: Optional[bool] = None,
     ) -> None:
         self.config_dir = Path(config_dir or self._find_config_dir())
         # A transient CLI/programmatic `--profile` (#172). Kept here, not on
@@ -59,6 +63,13 @@ class ConfigManager:
                 f"expected one of {', '.join(SECURITY_PROFILES)}"
             )
         self.profile_override: Optional[str] = profile_override
+        # The transient CLI --strict-config (#175 piece 4), same contract as
+        # profile_override: True wins over settings.yaml's config_validation
+        # for the life of the process and is never written back. None means
+        # "whatever the file declares".
+        self.strict_config_override: Optional[bool] = strict_config
+        # Effective strictness, re-derived from the file on every load.
+        self.strict_config: bool = self._effective_strict(self._peek_validation_mode())
         self._declared: Dict[str, Any] = {}
         self.settings: Settings = Settings()
         self.users: Dict[str, User] = {}
@@ -70,7 +81,12 @@ class ConfigManager:
         # the config dir, NANOIDP_BOOTSTRAP_HOOK / _PLUGIN) is read before
         # the first load because settings.yaml may be what a hook renders;
         # settings.yaml's own hooks: / plugins: are merged in after each load.
-        self.hooks: HookRegistry = bootstrap_registry(self.config_dir)
+        # bootstrap.yaml is read before settings.yaml (it may be what renders
+        # it), so the strictness it follows comes from a raw peek at
+        # settings.yaml's config_validation above: one contract per directory.
+        self.hooks: HookRegistry = bootstrap_registry(
+            self.config_dir, strict_config=self.strict_config
+        )
         # Last settings.yaml hooks:/plugins: declaration applied to the
         # registry; an unchanged declaration is not re-applied on the next
         # load, so a post-write refresh does not drop and re-instantiate
@@ -97,6 +113,30 @@ class ConfigManager:
 
         # Default to ./config
         return "./config"
+
+    def _effective_strict(self, declared_mode: str) -> bool:
+        """--strict-config wins over the file, as --profile does (#172)."""
+        if self.strict_config_override is not None:
+            return self.strict_config_override
+        return declared_mode == "strict"
+
+    def _peek_validation_mode(self) -> str:
+        """``config_validation`` as declared by settings.yaml, read raw.
+
+        Needed before the document loader runs (it decides how that loader
+        reports) and before bootstrap.yaml is read. A file that cannot be
+        parsed at all returns the default here and fails with its real error
+        a moment later, in _read_settings, where the message belongs.
+        """
+        settings_file = self.config_dir / "settings.yaml"
+        if not settings_file.exists():
+            return "warn"
+        try:
+            with open(settings_file, "r") as f:
+                data = yaml.safe_load(f) or {}
+        except Exception:  # noqa: BLE001 - reported by _read_settings
+            return "warn"
+        return declared_validation_mode(data) if isinstance(data, dict) else "warn"
 
     def _load_config(self) -> None:
         """Load all configuration files."""
@@ -183,6 +223,10 @@ class ConfigManager:
         with open(settings_file, "r") as f:
             data = yaml.safe_load(f) or {}
 
+        # Re-derived on every load: an edited config_validation takes effect
+        # on the next reload, an explicit --strict-config keeps winning.
+        self.strict_config = self._effective_strict(declared_validation_mode(data))
+
         # Refuse files written for a newer contract before reading any key
         # (#175): a silently half-understood file is worse than a clear stop.
         self.config_version = check_config_version(data, settings_file)
@@ -193,7 +237,7 @@ class ConfigManager:
         # reported with their path, defaults live on the model, and the
         # domain Settings is built from it with every validator it already
         # had. ${VAR} expansion and config_version stay at the edge, above.
-        document = load_settings_document(data, settings_file)
+        document = load_settings_document(data, settings_file, strict=self.strict_config)
         # Fail without commit (#200 review): build the candidate, apply the
         # file's hooks/plugins (which may raise under strict and then rolls
         # the registry back), and only then promote the candidate. A reload
@@ -283,7 +327,9 @@ class ConfigManager:
         data = _expand_env_vars(data)
         # Same document-model path as settings (#175 piece 2); unknown keys
         # inside a user entry keep folding into its attributes, as always.
-        self.users, self.default_user = load_users_document(data, users_file).to_users()
+        self.users, self.default_user = load_users_document(
+            data, users_file, strict=self.strict_config
+        ).to_users()
 
     def _set_default_users(self) -> None:
         """Set default users."""
@@ -455,14 +501,19 @@ def get_config() -> ConfigManager:
 
 
 def init_config(
-    config_dir: Optional[str] = None, profile_override: Optional[str] = None
+    config_dir: Optional[str] = None,
+    profile_override: Optional[str] = None,
+    strict_config: Optional[bool] = None,
 ) -> ConfigManager:
     """Initialize the global config instance.
 
     profile_override is the CLI --profile: it wins over settings.yaml's
     security_profile for the life of the process and is re-applied on every
-    reload() without ever being persisted (#172).
+    reload() without ever being persisted (#172). strict_config is the CLI
+    --strict-config, with the same contract over config_validation (#175).
     """
     global _config
-    _config = ConfigManager(config_dir, profile_override=profile_override)
+    _config = ConfigManager(
+        config_dir, profile_override=profile_override, strict_config=strict_config
+    )
     return _config

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import copy
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
@@ -50,6 +50,9 @@ logger = logging.getLogger(__name__)
 DocumentT = TypeVar("DocumentT", bound=BaseModel)
 
 _FORBID = ConfigDict(extra="forbid")
+
+# Accepted values of the top-level ``config_validation`` key (#175 piece 4).
+VALIDATION_MODES = ("warn", "strict")
 
 
 class ServerSection(BaseModel):
@@ -241,6 +244,14 @@ class SettingsDocument(BaseModel):
     logging: LoggingSection = Field(default_factory=LoggingSection)
     login: LoginSection = Field(default_factory=LoginSection)
     security_profile: str = "dev"
+    # How the loader reacts to an unknown key in this configuration directory
+    # (#175 piece 4). "warn" (default) logs it with its dotted path and
+    # ignores it; "strict" refuses to load. The server's --strict-config flag
+    # wins over this value for that run and is never written back. The value
+    # is read from the raw YAML before the document is validated, because it
+    # decides how this very validation reports; it applies to users.yaml and
+    # bootstrap.yaml too, one contract per directory.
+    config_validation: str = "warn"
     authority_prefixes: Dict[str, str] = Field(default_factory=dict)
     allowed_identity_classes: List[str] = Field(default_factory=list)
     # Accepted for compatibility, not consumed (module docstring).
@@ -259,6 +270,15 @@ class SettingsDocument(BaseModel):
     @classmethod
     def _plugins_shape(cls, value: Any) -> Dict[str, Dict[str, Any]]:
         return _validate_plugins_mapping(value)
+
+    @field_validator("config_validation")
+    @classmethod
+    def _known_validation_mode(cls, value: str) -> str:
+        if value not in VALIDATION_MODES:
+            raise ValueError(
+                f"config_validation must be one of {', '.join(VALIDATION_MODES)}"
+            )
+        return value
 
     @model_validator(mode="before")
     @classmethod
@@ -459,14 +479,34 @@ def _drop_path(data: Any, loc: Tuple[Any, ...]) -> None:
         target.pop(loc[-1], None)
 
 
-def _load_document(model: Type[DocumentT], data: Dict[str, Any], file_path: Path) -> DocumentT:
+def unknown_key_message(file_path: Path, loc: Tuple[Any, ...]) -> str:
+    """The one wording of an unknown-key finding, shared by the warning, the
+    strict error and ``nanoidp validate-config`` (#175 piece 4)."""
+    return f"{file_path}: unknown key {_dotted(loc)}"
+
+
+def _load_document(
+    model: Type[DocumentT],
+    data: Dict[str, Any],
+    file_path: Path,
+    *,
+    strict: bool = False,
+    on_unknown: Optional[Callable[[str], None]] = None,
+) -> DocumentT:
     """Validate ``data`` against ``model``.
 
-    Unknown keys (``extra_forbidden``) are reported as a WARNING with their
-    dotted path, removed, and validation is retried, so a typo such as
-    ``oauth.isuer`` no longer vanishes silently (#175) while files that load
-    today keep loading. Any other error (wrong type, invalid value) raises a
-    ``ValueError`` naming the file and the path; stricter handling is piece 4.
+    Unknown keys (``extra_forbidden``) are reported with their dotted path,
+    removed, and validation is retried, so a typo such as ``oauth.isuer`` no
+    longer vanishes silently (#175) while files that load today keep loading.
+    Any other error (wrong type, invalid value) raises a ``ValueError``
+    naming the file and the path.
+
+    ``strict`` (``config_validation: strict`` or ``--strict-config``, #175
+    piece 4) turns the unknown key into that same ``ValueError`` instead:
+    same text, no ``(ignored)`` suffix, raised at load and at every reload.
+    ``on_unknown`` receives the message instead of the logger when a caller
+    collects findings rather than starting the server
+    (``nanoidp validate-config``).
     """
     working = data
     for _attempt in range(2):
@@ -481,27 +521,69 @@ def _load_document(model: Type[DocumentT], data: Dict[str, Any], file_path: Path
                     f"{file_path}: invalid value at {_dotted(first['loc']) or '<root>'}: "
                     f"{first['msg']}"
                 ) from exc
+            if strict:
+                raise ValueError(unknown_key_message(file_path, unknown[0]["loc"])) from exc
             working = copy.deepcopy(working) if working is data else working
             for error in unknown:
-                logger.warning(
-                    f"{file_path}: unknown key {_dotted(error['loc'])} (ignored)"
-                )
+                message = unknown_key_message(file_path, error["loc"])
+                if on_unknown is not None:
+                    on_unknown(message)
+                else:
+                    logger.warning(f"{message} (ignored)")
                 _drop_path(working, error["loc"])
     return model.model_validate(working)  # pragma: no cover - second pass raised
 
 
-def load_settings_document(data: Dict[str, Any], file_path: Path) -> SettingsDocument:
-    return _load_document(SettingsDocument, data, file_path)
+def load_settings_document(
+    data: Dict[str, Any],
+    file_path: Path,
+    *,
+    strict: bool = False,
+    on_unknown: Optional[Callable[[str], None]] = None,
+) -> SettingsDocument:
+    return _load_document(
+        SettingsDocument, data, file_path, strict=strict, on_unknown=on_unknown
+    )
 
 
-def load_users_document(data: Dict[str, Any], file_path: Path) -> UsersDocument:
-    return _load_document(UsersDocument, data, file_path)
+def load_users_document(
+    data: Dict[str, Any],
+    file_path: Path,
+    *,
+    strict: bool = False,
+    on_unknown: Optional[Callable[[str], None]] = None,
+) -> UsersDocument:
+    return _load_document(
+        UsersDocument, data, file_path, strict=strict, on_unknown=on_unknown
+    )
 
 
-def load_bootstrap_document(data: Dict[str, Any], file_path: Path) -> BootstrapDocument:
+def load_bootstrap_document(
+    data: Dict[str, Any],
+    file_path: Path,
+    *,
+    strict: bool = False,
+    on_unknown: Optional[Callable[[str], None]] = None,
+) -> BootstrapDocument:
     """``bootstrap.yaml`` goes through the same unknown-key / wrong-type
-    reporting as ``settings.yaml`` (review before 2.7.0rc4)."""
-    return _load_document(BootstrapDocument, data, file_path)
+    reporting as ``settings.yaml`` (review before 2.7.0rc4), and the same
+    strictness: it is declared in settings.yaml, one contract per directory."""
+    return _load_document(
+        BootstrapDocument, data, file_path, strict=strict, on_unknown=on_unknown
+    )
+
+
+def declared_validation_mode(data: Mapping[str, Any]) -> str:
+    """The ``config_validation`` a raw settings.yaml mapping declares.
+
+    Read from the raw YAML, before the document is built, because it decides
+    how that build reports an unknown key - and before the registry reads
+    ``bootstrap.yaml``, which is loaded first but follows settings.yaml's
+    choice. An unrecognized value returns the default and is left to the
+    document validator, which reports it with its path like any bad value.
+    """
+    value = data.get("config_validation")
+    return value if value in VALIDATION_MODES else "warn"
 
 
 def document_defaults() -> Dict[str, Any]:

--- a/src/nanoidp/config_schema.py
+++ b/src/nanoidp/config_schema.py
@@ -1,0 +1,125 @@
+"""
+The JSON Schema of the configuration files, derived from the document models.
+
+``nanoidp config-schema`` renders it; ``docs/schema/config.v1.json`` is the
+committed artifact and a test fails when the two diverge (#175 piece 3). The
+point of generating it is that it cannot become a seventh restatement of the
+contract (see #174): the schema has no content of its own, it is
+``SettingsDocument`` / ``UsersDocument`` / ``BootstrapDocument`` rendered by
+pydantic, so a field added to a model is in the schema on the next run and a
+field invented in the schema is impossible.
+
+The artifact is a container, not itself a schema: it holds the three
+schemas under ``settings``, ``users`` and ``bootstrap``, next to the
+``config_version`` they describe. Each one is a complete, standalone JSON
+Schema with its own ``$schema``, ``$id`` and ``$defs``, so a consumer picks
+the one it wants (``.settings`` for ``settings.yaml``) and validates with it
+directly, no reference resolution across the container needed. Three
+separate files would work too; one file keeps the version and the three
+shapes together, which is the whole point of the contract.
+
+One thing the schema cannot express: a ``${VAR}`` placeholder is a string
+until it is expanded, and the expansion produces a string too, which
+pydantic then coerces to the field's type. A generic JSON Schema tool has
+no such coercion, so it reports ``port: ${PORT:8000}`` (and its expansion,
+``"8000"``) as a type error against ``"type": "integer"``. Editor
+completion and typo detection - what the artifact is for - work either way;
+the type check of a placeholder-fed non-string field is what
+``nanoidp validate-config`` is for, since it runs the real loader.
+
+Output is deterministic (``sort_keys``, two-space indent, trailing newline):
+the artifact is meant to be diffed in review and regenerated in a pre-commit
+hook, so a rerun must produce a byte-identical file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Type
+
+from pydantic import BaseModel
+
+from .config_documents import BootstrapDocument, SettingsDocument, UsersDocument
+from .serialization import CONFIG_VERSION
+
+# YAML file name (without extension) -> the model that describes it.
+SCHEMA_MODELS: Dict[str, Type[BaseModel]] = {
+    "settings": SettingsDocument,
+    "users": UsersDocument,
+    "bootstrap": BootstrapDocument,
+}
+
+JSON_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+# Identity of the artifact and of the three resources embedded in it. Not a
+# URL anything fetches: a JSON Schema $id is a name, and this one is stable
+# per config_version so a tool can pin it.
+SCHEMA_ID_BASE = f"https://cdelmonte-zg.github.io/nanoidp/schema/config.v{CONFIG_VERSION}"
+
+# Where `--write` puts the artifact, relative to the repository root.
+SCHEMA_ARTIFACT = Path("docs") / "schema" / f"config.v{CONFIG_VERSION}.json"
+
+
+def file_schema(name: str) -> Dict[str, Any]:
+    """The complete, standalone JSON Schema of one configuration file."""
+    model = SCHEMA_MODELS[name]
+    schema = model.model_json_schema(ref_template="#/$defs/{model}")
+    return {
+        "$schema": JSON_SCHEMA_DIALECT,
+        "$id": f"{SCHEMA_ID_BASE}-{name}.json",
+        **schema,
+    }
+
+
+def build_schema_document() -> Dict[str, Any]:
+    """The full artifact: one schema per file plus the contract version."""
+    document: Dict[str, Any] = {
+        "title": "NanoIDP configuration directory",
+        "description": (
+            "One JSON Schema per configuration file, generated from the "
+            "document models in nanoidp.config_documents by "
+            "`nanoidp config-schema --write`. Do not edit by hand. Each of "
+            "settings, users and bootstrap is a standalone schema; validate "
+            "a file against the entry of the same name."
+        ),
+        "config_version": CONFIG_VERSION,
+    }
+    for name in SCHEMA_MODELS:
+        document[name] = file_schema(name)
+    return document
+
+
+def render(document: Dict[str, Any]) -> str:
+    """Deterministic JSON text, with the trailing newline a file wants."""
+    return json.dumps(document, sort_keys=True, indent=2) + "\n"
+
+
+def repo_root() -> Path:
+    """The checkout this package is running from.
+
+    ``--write`` targets a path inside the repository, so it only makes sense
+    from a source checkout: an installed wheel has no ``docs/`` to write to,
+    and this returns the directory that would have to contain it.
+    """
+    return Path(__file__).resolve().parents[2]
+
+
+def artifact_path() -> Path:
+    """Absolute path of the committed schema artifact in this checkout."""
+    return repo_root() / SCHEMA_ARTIFACT
+
+
+def write_artifact() -> Path:
+    """Regenerate ``docs/schema/config.v1.json``; raises outside a checkout."""
+    root = repo_root()
+    if not (root / "pyproject.toml").exists():
+        raise RuntimeError(
+            f"{root} is not a nanoidp source checkout: config-schema --write "
+            "regenerates a file tracked in the repository and works from a "
+            "checkout only. Redirect the output instead: "
+            "nanoidp config-schema > config.v1.json"
+        )
+    target = root / SCHEMA_ARTIFACT
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(render(build_schema_document()))
+    return target

--- a/src/nanoidp/config_validation.py
+++ b/src/nanoidp/config_validation.py
@@ -86,6 +86,7 @@ def _validate_file(
     model_loader: Any,
     findings: List[Finding],
     expected_version: Optional[int] = None,
+    check_version: bool = True,
 ) -> Tuple[Optional[Any], Optional[int]]:
     """Run one file through the real loader, collecting instead of raising.
 
@@ -99,11 +100,13 @@ def _validate_file(
     if data is None:
         return None, None
 
-    try:
-        version = check_config_version(data, path)
-    except ValueError as exc:
-        findings.append(Finding(ERROR, str(exc), path.name))
-        return None, None
+    version: Optional[int] = None
+    if check_version:
+        try:
+            version = check_config_version(data, path)
+        except ValueError as exc:
+            findings.append(Finding(ERROR, str(exc), path.name))
+            return None, None
 
     if expected_version is not None and version != expected_version:
         findings.append(
@@ -178,7 +181,11 @@ def validate_config_dir(config_dir: Path | str) -> List[Finding]:
     if bootstrap_path.exists():
         # Shape only: hooks and plugins declared here are never dispatched
         # or imported by a validation run (see the module docstring).
-        _validate_file(bootstrap_path, load_bootstrap_document, findings)
+        # bootstrap.yaml has no config_version in its schema and the real
+        # startup path (bootstrap_registry) never version-checks it: a
+        # config_version key there is an unknown key, same as at startup
+        # (#204 review: same semantics as the loader, not stricter ones).
+        _validate_file(bootstrap_path, load_bootstrap_document, findings, check_version=False)
 
     return findings
 

--- a/src/nanoidp/config_validation.py
+++ b/src/nanoidp/config_validation.py
@@ -1,0 +1,266 @@
+"""
+Validating a configuration directory without starting anything (#175 piece 4).
+
+``nanoidp validate-config`` and the MCP ``validate_config`` tool both call
+``validate_config_dir()``. It reads ``settings.yaml``, ``users.yaml`` and
+``bootstrap.yaml`` through the very loaders the server uses, so a finding
+here is a finding there, and it deliberately does NOT:
+
+- construct a ``ConfigManager`` or touch the global config singleton,
+- build a ``HookRegistry``, dispatch ``on_before_load`` or any other hook,
+- import an entry point or instantiate a plugin.
+
+``bootstrap.yaml`` is validated for its SHAPE only (``BootstrapDocument``):
+the file's whole purpose is to name commands and plugins, and a lint step
+that ran them would be a remote-execution primitive triggered by looking at
+a directory. That is why this module imports ``config_documents`` and
+``serialization`` but never ``config`` or ``hooks``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from .config_documents import (
+    SettingsDocument,
+    UsersDocument,
+    declared_validation_mode,
+    load_bootstrap_document,
+    load_settings_document,
+    load_users_document,
+)
+from .serialization import check_config_version
+from .serialization import expand_env_vars as _expand_env_vars
+
+ERROR = "error"
+WARNING = "warning"
+
+# The three files of a configuration directory. bootstrap.yaml is optional
+# and absent by default; the other two fall back to built-in defaults, which
+# is worth saying out loud in a lint step.
+SETTINGS_FILE = "settings.yaml"
+USERS_FILE = "users.yaml"
+BOOTSTRAP_FILE = "bootstrap.yaml"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One line of a validation report."""
+
+    level: str
+    message: str
+    file: Optional[str] = None
+
+    def format(self) -> str:
+        return f"{self.level}: {self.message}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"level": self.level, "message": self.message, "file": self.file}
+
+
+def _read_yaml(path: Path, findings: List[Finding]) -> Optional[Dict[str, Any]]:
+    """Parse one YAML file into a mapping, recording what went wrong."""
+    try:
+        with open(path, "r") as handle:
+            data = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:
+        findings.append(Finding(ERROR, f"{path}: not valid YAML: {exc}", path.name))
+        return None
+    except OSError as exc:
+        findings.append(Finding(ERROR, f"{path}: cannot be read: {exc}", path.name))
+        return None
+    if not isinstance(data, dict):
+        findings.append(
+            Finding(ERROR, f"{path}: top level must be a mapping, found {type(data).__name__}", path.name)
+        )
+        return None
+    return data
+
+
+def _validate_file(
+    path: Path,
+    model_loader: Any,
+    findings: List[Finding],
+    expected_version: Optional[int] = None,
+) -> Tuple[Optional[Any], Optional[int]]:
+    """Run one file through the real loader, collecting instead of raising.
+
+    Returns the built document (or None) and the file's effective
+    ``config_version``. Unknown keys always arrive as warnings: ``--strict``
+    is a decision about the exit code, made once over the whole report, not
+    a second code path (and it is what lets the report list every finding
+    instead of stopping at the first).
+    """
+    data = _read_yaml(path, findings)
+    if data is None:
+        return None, None
+
+    try:
+        version = check_config_version(data, path)
+    except ValueError as exc:
+        findings.append(Finding(ERROR, str(exc), path.name))
+        return None, None
+
+    if expected_version is not None and version != expected_version:
+        findings.append(
+            Finding(
+                ERROR,
+                f"{path}: config_version {version} does not match settings.yaml's "
+                f"config_version {expected_version}; the configuration directory "
+                f"follows one contract version",
+                path.name,
+            )
+        )
+
+    expanded = _expand_env_vars(data)
+    unknown: List[str] = []
+    document = None
+    try:
+        document = model_loader(expanded, path, on_unknown=unknown.append)
+    except ValueError as exc:
+        findings.append(Finding(ERROR, str(exc), path.name))
+    findings.extend(Finding(WARNING, message, path.name) for message in unknown)
+    return document, version
+
+
+def validate_config_dir(config_dir: Path | str) -> List[Finding]:
+    """Validate a configuration directory; never starts or runs anything.
+
+    Every finding carries its own file, so the report reads the same whether
+    it is printed by the CLI or returned to an MCP agent.
+    """
+    directory = Path(config_dir)
+    findings: List[Finding] = []
+
+    if not directory.is_dir():
+        return [Finding(ERROR, f"{directory}: not a configuration directory", None)]
+
+    settings_path = directory / SETTINGS_FILE
+    users_path = directory / USERS_FILE
+    bootstrap_path = directory / BOOTSTRAP_FILE
+
+    settings_version: Optional[int] = None
+    settings_document: Optional[SettingsDocument] = None
+    if settings_path.exists():
+        settings_document, settings_version = _validate_file(
+            settings_path, load_settings_document, findings
+        )
+        if settings_document is not None:
+            try:
+                settings_document.to_settings()
+            except (ValueError, TypeError) as exc:
+                # Domain-model validators and the duplicate-client_id rule:
+                # a file whose shape is fine can still be refused at startup.
+                findings.append(Finding(ERROR, f"{settings_path}: {exc}", SETTINGS_FILE))
+    else:
+        findings.append(
+            Finding(WARNING, f"{settings_path}: not found, built-in defaults would be used", SETTINGS_FILE)
+        )
+
+    if users_path.exists():
+        users_document, _ = _validate_file(
+            users_path, load_users_document, findings, expected_version=settings_version
+        )
+        if isinstance(users_document, UsersDocument):
+            try:
+                users_document.to_users()
+            except (ValueError, TypeError) as exc:
+                findings.append(Finding(ERROR, f"{users_path}: {exc}", USERS_FILE))
+    else:
+        findings.append(
+            Finding(WARNING, f"{users_path}: not found, the default admin user would be used", USERS_FILE)
+        )
+
+    if bootstrap_path.exists():
+        # Shape only: hooks and plugins declared here are never dispatched
+        # or imported by a validation run (see the module docstring).
+        _validate_file(bootstrap_path, load_bootstrap_document, findings)
+
+    return findings
+
+
+def declared_mode(config_dir: Path | str) -> str:
+    """``config_validation`` as settings.yaml declares it, for the report
+    header. Unreadable files return the default; validate_config_dir reports
+    what is actually wrong with them."""
+    settings_path = Path(config_dir) / SETTINGS_FILE
+    if not settings_path.exists():
+        return "warn"
+    try:
+        with open(settings_path, "r") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (yaml.YAMLError, OSError):
+        return "warn"
+    return declared_validation_mode(data) if isinstance(data, dict) else "warn"
+
+
+def effective_strict(config_dir: Path | str, strict_flag: bool = False) -> bool:
+    """``--strict`` on the command line, or the directory declaring it.
+
+    A directory whose settings.yaml says ``config_validation: strict`` is one
+    the server refuses to start on: a lint step that returned 0 for it would
+    be lying, so the declaration counts here too. The flag can only add
+    strictness, never remove it, exactly as it does for the server.
+    """
+    return bool(strict_flag) or declared_mode(config_dir) == "strict"
+
+
+def report(findings: List[Finding], strict: bool) -> Tuple[List[str], int]:
+    """Render the findings and decide the exit code.
+
+    Exit 0 when clean, or when only warnings were found and ``--strict`` was
+    not asked for; 1 on any error, and on any warning under ``--strict`` -
+    the same rule the server applies at startup, so CI and the server agree
+    about what the directory is worth.
+    """
+    lines = [finding.format() for finding in findings]
+    errors = [f for f in findings if f.level == ERROR]
+    warnings = [f for f in findings if f.level == WARNING]
+    if errors:
+        code = 1
+    elif warnings and strict:
+        code = 1
+    else:
+        code = 0
+    if not findings:
+        lines.append("ok: no findings")
+    else:
+        lines.append(
+            f"{len(errors)} error(s), {len(warnings)} warning(s)"
+            + (" (strict: warnings fail)" if strict and warnings else "")
+        )
+    return lines, code
+
+
+def validate_config_result(config_dir: Path | str, strict: bool = False) -> Dict[str, Any]:
+    """``{valid, findings, ...}`` for the MCP ``validate_config`` tool.
+
+    ``valid`` follows the exit code of ``validate-config``: errors always
+    invalidate, warnings only when the run is strict.
+    """
+    findings = validate_config_dir(config_dir)
+    strict_run = effective_strict(config_dir, strict)
+    _lines, code = report(findings, strict_run)
+    return {
+        "config_dir": str(config_dir),
+        "config_validation": declared_mode(config_dir),
+        "strict": strict_run,
+        "valid": code == 0,
+        "findings": [finding.to_dict() for finding in findings],
+    }
+
+
+__all__ = [
+    "ERROR",
+    "Finding",
+    "WARNING",
+    "declared_mode",
+    "effective_strict",
+    "report",
+    "validate_config_dir",
+    "validate_config_result",
+]

--- a/src/nanoidp/hooks.py
+++ b/src/nanoidp/hooks.py
@@ -598,7 +598,11 @@ class HookRegistry:
 # ------------------------------------------------------------------ bootstrap
 
 
-def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = None) -> HookRegistry:
+def bootstrap_registry(
+    config_dir: Path,
+    environ: Optional[Mapping[str, str]] = None,
+    strict_config: bool = False,
+) -> HookRegistry:
     """Build the registry from the bootstrap surface, before settings.yaml exists.
 
     Sources, in order: ``bootstrap.yaml`` in the config directory (``hooks:``
@@ -610,6 +614,10 @@ def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = 
     as ``_``, keys lower-cased). A bootstrap plugin is a plugin like any
     other: loaded once, it takes part in every hook for the life of the
     process.
+
+    ``strict_config`` is settings.yaml's effective ``config_validation``
+    (#175 piece 4): under strict an unknown key in ``bootstrap.yaml`` refuses
+    to start instead of warning, one contract for the whole directory.
     """
     env = os.environ if environ is None else environ
     registry = HookRegistry(config_dir=config_dir)
@@ -622,7 +630,7 @@ def bootstrap_registry(config_dir: Path, environ: Optional[Mapping[str, str]] = 
         with open(bootstrap_file, "r") as f:
             raw = yaml.safe_load(f) or {}
         raw = expand_env_vars(raw)
-        document = load_bootstrap_document(raw, bootstrap_file)
+        document = load_bootstrap_document(raw, bootstrap_file, strict=strict_config)
         registry.configure_from_sections(document.hooks, document.plugins, SOURCE_BOOTSTRAP_FILE)
         # bootstrap.yaml's on_before_load runs before the first load only,
         # like the env hook: settings.yaml owns reloads.

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -691,8 +691,9 @@ _TOOLS: list[Tool] = [
         "a startup or the next reload would hit; bootstrap.yaml findings are what "
         "would stop the NEXT startup (the bootstrap surface loads at startup only). Read-only and inert: it re-reads the files through the same "
         "loaders, runs no hook and loads no plugin. 'valid' is false on any error, "
-        "and on a warning too when the directory declares config_validation: strict "
-        "(or 'strict' is passed), which is when a start would refuse.",
+        "and on a warning too under strict mode, which is when a start would refuse. "
+        "'strict' defaults to this server's effective validation mode; pass it "
+        "explicitly to override.",
         input_schema={
             "type": "object",
             "properties": {
@@ -1344,7 +1345,12 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         # The CLI's code path exactly (nanoidp.config_validation): no
         # ConfigManager is built, no hook runs, no plugin is imported, and
         # the running configuration is not touched or reloaded.
-        return validate_config_result(config.config_dir, bool(arguments.get("strict", False)))
+        # strict defaults to the manager's effective mode, so "what the next
+        # reload would hit" stays true for a ConfigManager started with
+        # --strict-config (#204 review); an explicit argument still wins.
+        strict_arg = arguments.get("strict")
+        effective = config.strict_config if strict_arg is None else bool(strict_arg)
+        return validate_config_result(config.config_dir, effective)
 
     elif name == "update_settings":
         settings = config.settings

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -686,9 +686,10 @@ _TOOLS: list[Tool] = [
     Tool(
         name="validate_config",
         description="Validate the running configuration directory (settings.yaml, "
-        "users.yaml, bootstrap.yaml) and report what a start or reload would "
-        "complain about: unknown keys as warnings, wrong types and refused values "
-        "as errors. Read-only and inert: it re-reads the files through the same "
+        "users.yaml, bootstrap.yaml): unknown keys as warnings, wrong types and "
+        "refused values as errors. settings.yaml and users.yaml findings are what "
+        "a startup or the next reload would hit; bootstrap.yaml findings are what "
+        "would stop the NEXT startup (the bootstrap surface loads at startup only). Read-only and inert: it re-reads the files through the same "
         "loaders, runs no hook and loads no plugin. 'valid' is false on any error, "
         "and on a warning too when the directory declares config_validation: strict "
         "(or 'strict' is passed), which is when a start would refuse.",

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -1281,6 +1281,7 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         return {
             # Same key as GET /api/config (#175): the contract an agent targets.
             "config_version": config.config_version,
+            "config_validation": "strict" if config.strict_config else "warn",
             "issuer": settings.issuer,
             "issuer_from_request": settings.issuer_from_request,
             "issuer_allowlist": settings.issuer_allowlist,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -58,6 +58,7 @@ from mcp.types import (
 
 from . import __version__
 from .config import ConfigManager, OAuthClient, User, init_config
+from .config_validation import validate_config_result
 from .hooks import HookError
 from .models import HEX_COLOR_PATTERN, normalize_saml_attr_name
 from .services import (
@@ -679,6 +680,28 @@ _TOOLS: list[Tool] = [
         input_schema={
             "type": "object",
             "properties": {},
+            "required": [],
+        },
+    ),
+    Tool(
+        name="validate_config",
+        description="Validate the running configuration directory (settings.yaml, "
+        "users.yaml, bootstrap.yaml) and report what a start or reload would "
+        "complain about: unknown keys as warnings, wrong types and refused values "
+        "as errors. Read-only and inert: it re-reads the files through the same "
+        "loaders, runs no hook and loads no plugin. 'valid' is false on any error, "
+        "and on a warning too when the directory declares config_validation: strict "
+        "(or 'strict' is passed), which is when a start would refuse.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "strict": {
+                    "type": "boolean",
+                    "description": "Treat warnings as failures, like the server's "
+                    "--strict-config. A directory declaring config_validation: "
+                    "strict is strict regardless.",
+                },
+            },
             "required": [],
         },
     ),
@@ -1314,6 +1337,12 @@ async def _execute_tool(name: str, arguments: dict[str, Any], config: ConfigMana
         except HookError as exc:
             return {"success": False, "error": f"Reload failed: {exc.message}", "kind": exc.kind}
         return {"success": True, "message": "Configuration reloaded"}
+
+    elif name == "validate_config":
+        # The CLI's code path exactly (nanoidp.config_validation): no
+        # ConfigManager is built, no hook runs, no plugin is imported, and
+        # the running configuration is not touched or reloaded.
+        return validate_config_result(config.config_dir, bool(arguments.get("strict", False)))
 
     elif name == "update_settings":
         settings = config.settings

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -131,6 +131,10 @@ def get_configuration() -> ResponseReturnValue:
     return jsonify({
         # Config schema version the loaded files follow (#175); absent = 1.
         "config_version": config.config_version,
+        # Effective validation mode (#175 piece 4): strict from the CLI flag
+        # or settings.yaml's config_validation; reported like security_profile
+        # so the contract is observable.
+        "config_validation": "strict" if config.strict_config else "warn",
         "server": {
             "host": settings.host,
             "port": settings.port,

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -371,3 +371,62 @@ class TestDirectoryLoadIsTransactional:
             get_config().reload()
         assert get_config().settings.security_profile == "stricter-dev"
         assert get_config().settings.require_pkce is True
+
+
+class TestRegressionRound2:
+    def test_directory_without_settings_still_gets_the_demo_client(self, tmp_path):
+        """#204 review round 2: the transactional refactor dropped the
+        demo-client from the missing-settings fallback."""
+        import yaml as _yaml
+
+        from nanoidp.config import ConfigManager
+
+        (tmp_path / "users.yaml").write_text(_yaml.safe_dump({"users": {}}))
+        manager = ConfigManager(str(tmp_path))
+        assert [c.client_id for c in manager.settings.clients] == ["demo-client"]
+        assert manager.check_client("demo-client", "demo-secret")
+
+    def test_bootstrap_config_version_is_an_unknown_key_not_an_error(self, tmp_path):
+        """validate-config must mirror the startup semantics: the bootstrap
+        loader never version-checks, so config_version there is an unknown
+        key (warning), not a version error."""
+        import yaml as _yaml
+
+        from nanoidp.config_validation import ERROR, WARNING, validate_config_dir
+
+        (tmp_path / "settings.yaml").write_text(_yaml.safe_dump({"server": {"host": "127.0.0.1", "port": 8000}}))
+        (tmp_path / "users.yaml").write_text(_yaml.safe_dump({"users": {}}))
+        (tmp_path / "bootstrap.yaml").write_text(_yaml.safe_dump({"config_version": 2, "hooks": {}}))
+        findings = validate_config_dir(tmp_path)
+        bootstrap = [f for f in findings if f.file == "bootstrap.yaml"]
+        assert bootstrap and all(f.level == WARNING for f in bootstrap)
+        assert any("unknown key config_version" in f.message for f in bootstrap)
+        assert not [f for f in findings if f.level == ERROR]
+
+    def test_mcp_validate_config_defaults_to_the_managers_mode(self, tmp_path):
+        import asyncio
+
+        import yaml as _yaml
+
+        from nanoidp import mcp_server
+        from nanoidp.config import init_config
+
+        (tmp_path / "settings.yaml").write_text(
+            _yaml.safe_dump({"server": {"host": "127.0.0.1", "port": 8000}})
+        )
+        (tmp_path / "users.yaml").write_text(_yaml.safe_dump({"users": {}}))
+        # A strict manager refuses to LOAD a typo, so build it on a clean
+        # directory first, then put the typo on disk: validate_config reads
+        # the files, not the runtime.
+        manager = init_config(str(tmp_path), strict_config=True)
+        mcp_server._config = manager
+        (tmp_path / "settings.yaml").write_text(
+            _yaml.safe_dump({"server": {"host": "127.0.0.1", "port": 8000}, "oauth": {"isuer": "x"}})
+        )
+        try:
+            result = asyncio.run(mcp_server._execute_tool("validate_config", {}, manager))
+            assert result["valid"] is False  # warnings fail under the manager's strict mode
+            result = asyncio.run(mcp_server._execute_tool("validate_config", {"strict": False}, manager))
+            assert result["valid"] is True  # explicit argument still wins
+        finally:
+            mcp_server._config = None

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,227 @@
+"""
+The generated config schema and the surface-parity tests (#175 piece 3).
+
+Two different guarantees:
+
+- **Drift**: ``docs/schema/config.v1.json`` is committed, so it must be what
+  ``nanoidp config-schema`` produces right now. Change a document model
+  without regenerating and this fails with the command to run.
+- **Parity**: every knob the MCP ``update_settings`` tool and the web UI's
+  settings form offer must reach a field of the document models, and the
+  YAML-only fields must not be offered by either. Adding a knob to one
+  surface only, or to a surface but not to the contract, fails here.
+
+The parity tests read the surfaces themselves (the tool's input schema, the
+template's ``name=`` attributes), not a list of names kept next to them,
+which is what makes them notice an addition nobody told them about.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from nanoidp.config_documents import SettingsDocument
+from nanoidp.config_schema import (
+    SCHEMA_MODELS,
+    artifact_path,
+    build_schema_document,
+    file_schema,
+    render,
+)
+from nanoidp.mcp_server import _TOOL_SCHEMAS
+
+REPO = Path(__file__).resolve().parent.parent
+SETTINGS_TEMPLATE = REPO / "src" / "nanoidp" / "templates" / "settings.html"
+
+# Fields of settings.yaml that are deliberately NOT editable through the MCP
+# server or the web UI: secrets and switches an operator owns, and the two
+# extension sections whose values are commands (#185). A knob that appears on
+# a remote surface for one of these is a security regression, not a feature.
+YAML_ONLY_FIELDS = {
+    "secret_key",
+    "require_ui_login",
+    "hooks",
+    "plugins",
+}
+
+# Flat name used by the MCP tool / the UI form -> dotted path in the document
+# models. Only the names that are not already a section field of the same
+# name: the domain Settings is flat, the YAML is nested, and this table is
+# where that translation is written down once.
+FLAT_TO_DOCUMENT_PATH = {
+    "saml_entity_id": "saml.entity_id",
+    "saml_sso_url": "saml.sso_url",
+    "saml_sign_responses": "saml.sign_responses",
+    "saml_export_roles": "saml.export_roles",
+    "saml_export_groups": "saml.export_groups",
+    "saml_roles_attr_name": "saml.roles_attr_name",
+    "saml_groups_attr_name": "saml.groups_attr_name",
+    "saml_c14n_algorithm": "saml.c14n_algorithm",
+    "saml_want_authn_requests_signed": "saml.want_authn_requests_signed",
+    "saml_sp_certificates": "saml.sp_certificates",
+    "strict_saml_binding": "saml.strict_binding",
+    "default_acs_url": "saml.default_acs_url",
+    "login_mode": "login.mode",
+    "verbose_logging": "logging.verbose_logging",
+    "log_token_requests": "logging.log_token_requests",
+    "log_saml_requests": "logging.log_saml_requests",
+    "log_level": "logging.level",
+    "jwt_algorithm": "jwt.algorithm",
+    "keys_dir": "jwt.keys_dir",
+    "host": "server.host",
+    "port": "server.port",
+    "debug": "server.debug",
+    "secret_key": "session.secret_key",
+    "require_ui_login": "session.require_ui_login",
+    "enforce_password_check": "session.enforce_password_check",
+}
+
+
+def document_paths() -> set:
+    """Every dotted path a settings.yaml key can have."""
+    paths = set()
+    for name, field in SettingsDocument.model_fields.items():
+        paths.add(name)
+        annotation = field.annotation
+        section_fields = getattr(annotation, "model_fields", None)
+        if section_fields:
+            paths.update(f"{name}.{sub}" for sub in section_fields)
+    return paths
+
+
+def resolve(flat_name: str) -> str | None:
+    """The document path a surface's field name maps to, or None.
+
+    An unprefixed name that is a field of exactly one section resolves on its
+    own (``issuer`` -> ``oauth.issuer``); everything else goes through the
+    rename table above. Ambiguity is refused rather than guessed.
+    """
+    if flat_name in FLAT_TO_DOCUMENT_PATH:
+        return FLAT_TO_DOCUMENT_PATH[flat_name]
+    paths = document_paths()
+    if flat_name in paths:
+        return flat_name
+    matches = [p for p in paths if p.endswith(f".{flat_name}")]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def template_field_names() -> set:
+    """The names the settings form actually posts.
+
+    ``<name>__on_form`` markers are the checkbox contract (#131), not knobs,
+    and the per-checkbox hidden marker is derived from the real field.
+    """
+    html = SETTINGS_TEMPLATE.read_text()
+    names = set(re.findall(r'name="([^"]+)"', html))
+    return {name for name in names if not name.endswith("__on_form")}
+
+
+class TestGeneratedSchema:
+    def test_committed_artifact_matches_the_models(self):
+        """The one test that keeps the artifact honest."""
+        committed = artifact_path()
+        assert committed.exists(), f"missing {committed}: run nanoidp config-schema --write"
+        assert committed.read_text() == render(build_schema_document()), (
+            "schema drifted: run nanoidp config-schema --write"
+        )
+
+    def test_render_is_deterministic(self):
+        assert render(build_schema_document()) == render(build_schema_document())
+
+    def test_document_carries_the_three_files_and_the_version(self):
+        document = build_schema_document()
+        assert document["config_version"] == 1
+        for name in ("settings", "users", "bootstrap"):
+            assert name in document
+            jsonschema.Draft202012Validator.check_schema(document[name])
+
+    def test_each_file_schema_is_standalone(self):
+        """A consumer picks one entry and validates with it, no cross-file
+        reference resolution: the $defs a sub-schema refers to are its own."""
+        for name in SCHEMA_MODELS:
+            schema = file_schema(name)
+            refs = re.findall(r'"\$ref": "([^"]+)"', json.dumps(schema))
+            defs = schema.get("$defs", {})
+            for ref in refs:
+                assert ref.startswith("#/$defs/"), ref
+                assert ref.rsplit("/", 1)[1] in defs, ref
+
+    def test_schema_rejects_the_typo_the_loader_warns_about(self):
+        schema = file_schema("settings")
+        jsonschema.validate({"oauth": {"issuer": "http://localhost:8000"}}, schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"oauth": {"isuer": "http://localhost:8000"}}, schema)
+
+    def test_config_validation_is_in_the_contract(self):
+        """Piece 4's key is part of the published contract, not a hidden knob."""
+        assert "config_validation" in file_schema("settings")["properties"]
+
+
+class TestMcpUpdateSettingsParity:
+    """Every MCP knob is a real key of the contract, and no YAML-only one is."""
+
+    def test_every_property_maps_to_a_document_field(self):
+        paths = document_paths()
+        unmapped = {}
+        for name in _TOOL_SCHEMAS["update_settings"]["properties"]:
+            resolved = resolve(name)
+            if resolved is None or resolved not in paths:
+                unmapped[name] = resolved
+        assert not unmapped, (
+            "MCP update_settings offers knobs that are not settings.yaml keys "
+            f"(or are not in the rename table): {unmapped}"
+        )
+
+    def test_yaml_only_fields_are_not_offered(self):
+        offered = set(_TOOL_SCHEMAS["update_settings"]["properties"])
+        assert not (offered & YAML_ONLY_FIELDS), (
+            "these are operator-owned YAML-only fields and must not be settable "
+            f"over MCP: {sorted(offered & YAML_ONLY_FIELDS)}"
+        )
+
+    def test_validate_config_tool_is_read_only(self):
+        from nanoidp.mcp_server import MUTATING_TOOLS
+
+        assert "validate_config" in _TOOL_SCHEMAS
+        assert "validate_config" not in MUTATING_TOOLS
+
+
+class TestSettingsFormParity:
+    """Same contract for the web UI's settings form."""
+
+    def test_every_form_field_maps_to_a_document_field(self):
+        paths = document_paths()
+        unmapped = {}
+        for name in template_field_names():
+            resolved = resolve(name)
+            if resolved is None or resolved not in paths:
+                unmapped[name] = resolved
+        assert not unmapped, (
+            "the settings form posts fields that are not settings.yaml keys "
+            f"(or are not in the rename table): {unmapped}"
+        )
+
+    def test_yaml_only_fields_are_not_editable(self):
+        posted = template_field_names()
+        assert not (posted & YAML_ONLY_FIELDS), (
+            f"YAML-only fields must not be form-editable: {sorted(posted & YAML_ONLY_FIELDS)}"
+        )
+
+    def test_rename_table_has_no_stale_entries(self):
+        """A rename that no surface uses any more is a lie waiting to happen."""
+        paths = document_paths()
+        used = set(_TOOL_SCHEMAS["update_settings"]["properties"]) | template_field_names()
+        # Names that document the flat domain model without being on a surface
+        # are allowed; what is not allowed is a target that does not exist.
+        broken = {
+            flat: target
+            for flat, target in FLAT_TO_DOCUMENT_PATH.items()
+            if target not in paths
+        }
+        assert not broken, f"rename table points at non-existent keys: {broken}"
+        assert used, "no surface fields found: the parity test would pass vacuously"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -225,3 +225,27 @@ class TestSettingsFormParity:
         }
         assert not broken, f"rename table points at non-existent keys: {broken}"
         assert used, "no surface fields found: the parity test would pass vacuously"
+
+
+class TestConfigValidationIsObservable:
+    """#175 piece 4 follow-up: the effective validation mode is reported like
+    security_profile, on both surfaces (the MCP side is covered by the
+    api/mcp equality test in test_hooks.py)."""
+
+    def test_api_config_reports_the_effective_mode(self, tmp_path):
+        import yaml
+
+        from nanoidp.app import create_app
+
+        settings = {"server": {"host": "127.0.0.1", "port": 8000}}
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(settings))
+        (tmp_path / "users.yaml").write_text(yaml.safe_dump({"users": {}}))
+        app = create_app(config_dir=str(tmp_path))
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            assert client.get("/api/config").get_json()["config_validation"] == "warn"
+
+        app = create_app(config_dir=str(tmp_path), strict_config=True)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            assert client.get("/api/config").get_json()["config_validation"] == "strict"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -249,3 +249,125 @@ class TestConfigValidationIsObservable:
         app.config["TESTING"] = True
         with app.test_client() as client:
             assert client.get("/api/config").get_json()["config_validation"] == "strict"
+
+
+class TestDirectoryLoadIsTransactional:
+    """#204 review: the transactional boundary is the whole configuration
+    directory. A reload that fails while validating users.yaml (or anywhere)
+    must not have committed the new settings, strictness or hooks."""
+
+    def _write(self, tmp_path, settings, users):
+        import yaml as _yaml
+
+        (tmp_path / "settings.yaml").write_text(_yaml.safe_dump(settings))
+        (tmp_path / "users.yaml").write_text(_yaml.safe_dump(users))
+
+    def test_invalid_users_under_strict_commits_nothing(self, tmp_path):
+        from nanoidp.config import ConfigManager
+
+        log = tmp_path / "hooks.log"
+        self._write(
+            tmp_path,
+            {
+                "server": {"host": "127.0.0.1", "port": 8000},
+                "oauth": {"audience": "old"},
+                "hooks": {"on_config_saved": f"echo saved >> {log}"},
+            },
+            {"users": {"alice": {"password": "x"}}},
+        )
+        manager = ConfigManager(str(tmp_path))
+        old_settings = manager.settings
+        old_users = manager.users
+        old_default = manager.default_user
+        old_strict = manager.strict_config
+        old_registry = manager.hooks.snapshot()
+        old_marker = manager._hooks_snapshot
+        # disk: changed settings + hooks, strict on, users.yaml typo
+        self._write(
+            tmp_path,
+            {
+                "server": {"host": "127.0.0.1", "port": 8000},
+                "oauth": {"audience": "new"},
+                "config_validation": "strict",
+                "hooks": {"on_config_saved": f"echo saved2 >> {log}"},
+            },
+            {"users": {"alice": {"password": "x"}}, "defualt_user": "alice"},
+        )
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="unknown key defualt_user"):
+            manager.reload()
+        assert manager.settings is old_settings
+        assert manager.settings.audience == "old"
+        assert manager.users is old_users
+        assert manager.default_user == old_default
+        assert manager.strict_config is old_strict
+        assert manager.hooks.snapshot() == old_registry
+        assert manager._hooks_snapshot is old_marker
+        # fixing users commits everything at once
+        self._write(
+            tmp_path,
+            {
+                "server": {"host": "127.0.0.1", "port": 8000},
+                "oauth": {"audience": "new"},
+                "config_validation": "strict",
+                "hooks": {"on_config_saved": f"echo saved2 >> {log}"},
+            },
+            {"users": {"alice": {"password": "x"}}},
+        )
+        manager.reload()
+        assert manager.settings.audience == "new"
+        assert manager.strict_config is True
+
+    def test_failed_strict_flip_does_not_change_the_running_mode(self, tmp_path):
+        """config_validation: strict plus a typo in the same file: the load
+        fails AND the running mode stays warn (#204 review: the mode used to
+        flip before validation ran)."""
+        from nanoidp.app import create_app
+        from nanoidp.config import get_config
+
+        self._write(
+            tmp_path,
+            {"server": {"host": "127.0.0.1", "port": 8000}},
+            {"users": {"alice": {"password": "x"}}},
+        )
+        app = create_app(config_dir=str(tmp_path))
+        app.config["TESTING"] = True
+        self._write(
+            tmp_path,
+            {
+                "server": {"host": "127.0.0.1", "port": 8000},
+                "config_validation": "strict",
+                "oauth": {"isuer": "x"},
+            },
+            {"users": {"alice": {"password": "x"}}},
+        )
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="unknown key oauth.isuer"):
+            get_config().reload()
+        assert get_config().strict_config is False
+        with app.test_client() as client:
+            assert client.get("/api/config").get_json()["config_validation"] == "warn"
+
+    def test_profile_hardening_survives_a_failed_users_load(self, tmp_path):
+        from nanoidp.config import get_config, init_config
+
+        self._write(
+            tmp_path,
+            {"server": {"host": "127.0.0.1", "port": 8000}, "config_validation": "strict"},
+            {"users": {"alice": {"password": "x"}}},
+        )
+        init_config(str(tmp_path), profile_override="stricter-dev")
+        assert get_config().settings.require_pkce is True
+        self._write(
+            tmp_path,
+            {"server": {"host": "127.0.0.1", "port": 8000}, "config_validation": "strict"},
+            {"users": {"alice": {"password": "x"}}, "defualt_user": "alice"},
+        )
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError):
+            get_config().reload()
+        assert get_config().settings.security_profile == "stricter-dev"
+        assert get_config().settings.require_pkce is True

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,385 @@
+"""
+Strict validation and ``nanoidp validate-config`` (#175 piece 4).
+
+Covers: the ``--strict-config`` flag, ``config_validation: strict`` in
+settings.yaml and the precedence between them; the CLI's exit codes on
+clean / warning / error directories including a bootstrap.yaml finding; the
+guarantee that validating a directory never executes what its hooks declare;
+and the MCP ``validate_config`` tool.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nanoidp.config import ConfigManager
+from nanoidp.config_validation import (
+    ERROR,
+    WARNING,
+    validate_config_dir,
+    validate_config_result,
+)
+
+
+def write_config(directory: Path, settings=None, users=None, bootstrap=None) -> str:
+    """A minimal but complete config directory."""
+    doc = {"oauth": {"issuer": "http://localhost:8000"}}
+    doc.update(settings or {})
+    (directory / "settings.yaml").write_text(yaml.safe_dump(doc))
+    (directory / "users.yaml").write_text(
+        yaml.safe_dump(users or {"users": {"alice": {"password": "x"}}})
+    )
+    if bootstrap is not None:
+        (directory / "bootstrap.yaml").write_text(yaml.safe_dump(bootstrap))
+    return str(directory)
+
+
+def levels(findings):
+    return [f.level for f in findings]
+
+
+class TestStrictLoading:
+    def test_unknown_key_warns_by_default(self, tmp_path, caplog):
+        config_dir = write_config(tmp_path, {"oauth": {"isuer": "x"}})
+        with caplog.at_level("WARNING"):
+            manager = ConfigManager(config_dir)
+        assert manager.strict_config is False
+        assert any("unknown key oauth.isuer" in r.message for r in caplog.records)
+
+    def test_strict_flag_refuses_to_load(self, tmp_path):
+        config_dir = write_config(tmp_path, {"oauth": {"isuer": "x"}})
+        with pytest.raises(ValueError) as exc:
+            ConfigManager(config_dir, strict_config=True)
+        assert "unknown key oauth.isuer" in str(exc.value)
+        assert "settings.yaml" in str(exc.value)
+
+    def test_strict_from_yaml_refuses_to_load(self, tmp_path):
+        config_dir = write_config(
+            tmp_path, {"config_validation": "strict", "oauth": {"isuer": "x"}}
+        )
+        with pytest.raises(ValueError, match="unknown key oauth.isuer"):
+            ConfigManager(config_dir)
+
+    def test_flag_wins_over_yaml(self, tmp_path):
+        """--strict-config is an override in both directions, like --profile."""
+        config_dir = write_config(
+            tmp_path, {"config_validation": "strict", "oauth": {"isuer": "x"}}
+        )
+        manager = ConfigManager(config_dir, strict_config=False)
+        assert manager.strict_config is False
+        assert manager.settings.issuer == "http://localhost:8000"
+
+        # ... and the other way round: warn in the file, strict on the flag.
+        clean = tmp_path / "clean"
+        clean.mkdir()
+        strict_manager = ConfigManager(write_config(clean), strict_config=True)
+        assert strict_manager.strict_config is True
+
+    def test_strict_is_never_persisted(self, tmp_path):
+        """The flag is transient: a save must not write config_validation."""
+        config_dir = write_config(tmp_path)
+        manager = ConfigManager(config_dir, strict_config=True)
+        manager.save()
+        written = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert "config_validation" not in written
+
+    def test_yaml_value_survives_a_save(self, tmp_path):
+        config_dir = write_config(tmp_path, {"config_validation": "strict"})
+        manager = ConfigManager(config_dir)
+        assert manager.strict_config is True
+        manager.save()
+        written = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        assert written["config_validation"] == "strict"
+
+    def test_strict_applies_to_users_yaml(self, tmp_path):
+        config_dir = write_config(
+            tmp_path,
+            {"config_validation": "strict"},
+            users={"users": {"alice": {"password": "x"}}, "defualt_user": "alice"},
+        )
+        with pytest.raises(ValueError) as exc:
+            ConfigManager(config_dir)
+        assert "unknown key defualt_user" in str(exc.value)
+        assert "users.yaml" in str(exc.value)
+
+    def test_strict_applies_to_bootstrap_yaml(self, tmp_path):
+        """bootstrap.yaml is read before settings.yaml but follows its
+        declaration: one contract for the directory."""
+        config_dir = write_config(
+            tmp_path,
+            {"config_validation": "strict"},
+            bootstrap={"hooks": {"on_before_load": "true"}, "plugns": {}},
+        )
+        with pytest.raises(ValueError) as exc:
+            ConfigManager(config_dir)
+        assert "unknown key plugns" in str(exc.value)
+        assert "bootstrap.yaml" in str(exc.value)
+
+    def test_wrong_type_is_an_error_either_way(self, tmp_path):
+        config_dir = write_config(tmp_path, {"oauth": {"token_expiry_minutes": "soon"}})
+        with pytest.raises(ValueError, match="invalid value at oauth.token_expiry_minutes"):
+            ConfigManager(config_dir)
+
+    def test_unknown_validation_mode_is_reported_with_its_path(self, tmp_path):
+        config_dir = write_config(tmp_path, {"config_validation": "paranoid"})
+        with pytest.raises(ValueError, match="invalid value at config_validation"):
+            ConfigManager(config_dir)
+
+    def test_strict_survives_a_reload(self, tmp_path):
+        config_dir = write_config(tmp_path)
+        manager = ConfigManager(config_dir, strict_config=True)
+        (tmp_path / "settings.yaml").write_text(
+            yaml.safe_dump({"oauth": {"issuer": "http://localhost:8000", "isuer": "x"}})
+        )
+        with pytest.raises(ValueError, match="unknown key oauth.isuer"):
+            manager.reload()
+
+    def test_yaml_strict_takes_effect_on_the_next_reload(self, tmp_path):
+        config_dir = write_config(tmp_path)
+        manager = ConfigManager(config_dir)
+        assert manager.strict_config is False
+        (tmp_path / "settings.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "config_validation": "strict",
+                    "oauth": {"issuer": "http://localhost:8000", "isuer": "x"},
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="unknown key oauth.isuer"):
+            manager.reload()
+
+
+class TestValidateConfigDir:
+    def test_clean_directory_has_no_findings(self, tmp_path):
+        assert validate_config_dir(write_config(tmp_path)) == []
+
+    def test_unknown_key_is_a_warning(self, tmp_path):
+        findings = validate_config_dir(write_config(tmp_path, {"oauth": {"isuer": "x"}}))
+        assert levels(findings) == [WARNING]
+        assert "unknown key oauth.isuer" in findings[0].message
+
+    def test_wrong_type_is_an_error(self, tmp_path):
+        findings = validate_config_dir(
+            write_config(tmp_path, {"oauth": {"token_expiry_minutes": "soon"}})
+        )
+        assert levels(findings) == [ERROR]
+        assert "invalid value at oauth.token_expiry_minutes" in findings[0].message
+
+    def test_bootstrap_finding_is_reported(self, tmp_path):
+        findings = validate_config_dir(
+            write_config(tmp_path, bootstrap={"hooks": {"stric": True}})
+        )
+        assert levels(findings) == [WARNING]
+        assert "bootstrap.yaml" in findings[0].message
+        assert "unknown key hooks.stric" in findings[0].message
+
+    def test_every_file_is_reported_not_just_the_first(self, tmp_path):
+        findings = validate_config_dir(
+            write_config(
+                tmp_path,
+                {"oauth": {"isuer": "x"}},
+                users={"users": {"alice": {"password": "x"}}, "defualt_user": "a"},
+                bootstrap={"plugns": {}},
+            )
+        )
+        assert {f.file for f in findings} == {"settings.yaml", "users.yaml", "bootstrap.yaml"}
+
+    def test_domain_validators_run(self, tmp_path):
+        """A file whose shape is fine can still be refused at startup: the
+        duplicate client_id rule is not expressible in the document model."""
+        findings = validate_config_dir(
+            write_config(
+                tmp_path,
+                {
+                    "oauth": {
+                        "clients": [
+                            {"client_id": "a", "client_secret": "s"},
+                            {"client_id": "a", "client_secret": "t"},
+                        ]
+                    }
+                },
+            )
+        )
+        assert levels(findings) == [ERROR]
+        assert "Duplicate OAuth client_id" in findings[0].message
+
+    def test_broken_yaml_is_an_error(self, tmp_path):
+        write_config(tmp_path)
+        (tmp_path / "settings.yaml").write_text("oauth: [unclosed\n")
+        findings = validate_config_dir(tmp_path)
+        assert levels(findings) == [ERROR]
+        assert "not valid YAML" in findings[0].message
+
+    def test_missing_files_are_warnings(self, tmp_path):
+        findings = validate_config_dir(tmp_path)
+        assert levels(findings) == [WARNING, WARNING]
+
+    def test_missing_directory_is_an_error(self, tmp_path):
+        findings = validate_config_dir(tmp_path / "nope")
+        assert levels(findings) == [ERROR]
+
+    def test_placeholders_are_expanded_before_validation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NANOIDP_TEST_EXPIRY", "45")
+        config_dir = write_config(
+            tmp_path, {"oauth": {"token_expiry_minutes": "${NANOIDP_TEST_EXPIRY}"}}
+        )
+        assert validate_config_dir(config_dir) == []
+
+    def test_version_mismatch_between_files(self, tmp_path):
+        write_config(tmp_path, {"config_version": 1}, users={"config_version": 2, "users": {}})
+        findings = validate_config_dir(tmp_path)
+        assert ERROR in levels(findings)
+        assert any("config_version" in f.message for f in findings)
+
+
+class TestValidateConfigNeverRunsHooks:
+    def test_bootstrap_hook_command_is_not_executed(self, tmp_path):
+        """The point of validating instead of starting: a directory whose
+        bootstrap.yaml names a command must be safe to look at."""
+        marker = tmp_path / "hook-ran.txt"
+        config_dir = write_config(
+            tmp_path,
+            bootstrap={"hooks": {"on_before_load": f"touch {marker}"}},
+        )
+        findings = validate_config_dir(config_dir)
+        assert findings == []
+        assert not marker.exists(), "validate-config executed a bootstrap hook"
+
+    def test_settings_hook_command_is_not_executed(self, tmp_path):
+        marker = tmp_path / "settings-hook-ran.txt"
+        config_dir = write_config(
+            tmp_path, {"hooks": {"on_before_load": f"touch {marker}"}}
+        )
+        assert validate_config_dir(config_dir) == []
+        assert not marker.exists()
+
+    def test_plugin_is_not_loaded(self, tmp_path):
+        """An unknown plugin name is a load failure at startup; validating
+        must not even look it up, so it produces no finding."""
+        config_dir = write_config(
+            tmp_path, {"plugins": {"definitely-not-installed": {"a": 1}}}
+        )
+        assert validate_config_dir(config_dir) == []
+
+    def test_the_hook_does_run_when_the_server_starts(self, tmp_path):
+        """Control for the two tests above: the same file, actually loaded."""
+        marker = tmp_path / "hook-ran.txt"
+        config_dir = write_config(
+            tmp_path, bootstrap={"hooks": {"on_before_load": f"touch {marker}"}}
+        )
+        ConfigManager(config_dir)
+        assert marker.exists()
+
+
+class TestValidateConfigCli:
+    def run(self, capsys, config_dir, strict=False):
+        from nanoidp.__main__ import validate_config_command
+
+        code = validate_config_command(str(config_dir), strict)
+        return code, capsys.readouterr().out
+
+    def test_clean_exits_zero(self, tmp_path, capsys):
+        code, out = self.run(capsys, write_config(tmp_path))
+        assert code == 0
+        assert "ok: no findings" in out
+
+    def test_warning_exits_zero_without_strict(self, tmp_path, capsys):
+        code, out = self.run(capsys, write_config(tmp_path, {"oauth": {"isuer": "x"}}))
+        assert code == 0
+        assert "warning: " in out
+        assert "unknown key oauth.isuer" in out
+
+    def test_warning_exits_one_with_strict(self, tmp_path, capsys):
+        code, out = self.run(
+            capsys, write_config(tmp_path, {"oauth": {"isuer": "x"}}), strict=True
+        )
+        assert code == 1
+        assert "unknown key oauth.isuer" in out
+
+    def test_error_exits_one(self, tmp_path, capsys):
+        code, out = self.run(
+            capsys, write_config(tmp_path, {"oauth": {"token_expiry_minutes": "soon"}})
+        )
+        assert code == 1
+        assert "error: " in out
+
+    def test_bootstrap_finding_exits_one_under_strict(self, tmp_path, capsys):
+        code, out = self.run(
+            capsys, write_config(tmp_path, bootstrap={"hooks": {"stric": True}}), strict=True
+        )
+        assert code == 1
+        assert "bootstrap.yaml" in out
+
+    def test_declared_strict_fails_without_the_flag(self, tmp_path, capsys):
+        """A directory the server would refuse to start on cannot lint clean."""
+        code, out = self.run(
+            capsys,
+            write_config(tmp_path, {"config_validation": "strict", "oauth": {"isuer": "x"}}),
+        )
+        assert code == 1
+        assert "(strict)" in out
+
+    def test_one_line_per_finding(self, tmp_path, capsys):
+        code, out = self.run(
+            capsys,
+            write_config(
+                tmp_path,
+                {"oauth": {"isuer": "x", "audiense": "y"}},
+            ),
+        )
+        assert code == 0
+        assert out.count("warning: ") == 2
+
+
+class TestValidateConfigMcpTool:
+    def test_result_shape(self, tmp_path):
+        result = validate_config_result(write_config(tmp_path))
+        assert result["valid"] is True
+        assert result["findings"] == []
+        assert result["config_validation"] == "warn"
+
+    def test_warning_is_reported_but_still_valid(self, tmp_path):
+        result = validate_config_result(write_config(tmp_path, {"oauth": {"isuer": "x"}}))
+        assert result["valid"] is True
+        assert result["findings"][0]["level"] == WARNING
+
+    def test_strict_argument_invalidates_a_warning(self, tmp_path):
+        result = validate_config_result(
+            write_config(tmp_path, {"oauth": {"isuer": "x"}}), strict=True
+        )
+        assert result["valid"] is False
+
+    @pytest.mark.asyncio
+    async def test_tool_call(self, tmp_path, monkeypatch, mcp_call_tool):
+        marker = tmp_path / "hook-ran.txt"
+        config_dir = write_config(
+            tmp_path,
+            {"oauth": {"isuer": "x"}},
+            bootstrap={"hooks": {"on_config_saved": f"touch {marker}"}},
+        )
+        monkeypatch.setenv("NANOIDP_CONFIG_DIR", config_dir)
+        result = await mcp_call_tool("validate_config", {})
+        payload = json.loads(result.content[0].text)
+        assert payload["valid"] is True
+        assert payload["findings"][0]["level"] == WARNING
+        assert "unknown key oauth.isuer" in payload["findings"][0]["message"]
+        assert result.is_error is False
+        assert not marker.exists()
+
+    @pytest.mark.asyncio
+    async def test_tool_call_strict(self, tmp_path, monkeypatch, mcp_call_tool):
+        config_dir = write_config(tmp_path, {"oauth": {"isuer": "x"}})
+        monkeypatch.setenv("NANOIDP_CONFIG_DIR", config_dir)
+        result = await mcp_call_tool("validate_config", {"strict": True})
+        payload = json.loads(result.content[0].text)
+        assert payload["valid"] is False
+        # An invalid config is a truthful answer, not a failed call (#122).
+        assert result.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_tool_is_listed(self, mcp_list_tools):
+        names = {tool.name for tool in await mcp_list_tools()}
+        assert "validate_config" in names

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -807,7 +807,7 @@ class TestReviewBeforeRc4:
         mcp._config = ConfigManager(str(tmp_path), profile_override="stricter-dev")
         result = asyncio.run(mcp_call_tool("get_settings", {}))
         payload = yaml.safe_load(result.content[0].text)
-        for key in ("security_profile", "profile_override", "effective", "config_version", "hooks"):
+        for key in ("security_profile", "profile_override", "effective", "config_version", "config_validation", "hooks"):
             assert payload[key] == api[key], key
         assert payload["effective"]["require_pkce"] is True
 


### PR DESCRIPTION
Pieces 3 and 4 of #175, closing the issue: the contract that rc4 shipped (config_version + document models) gets its published artifact, its lint entry point and its opt-in strict mode. Agreed exception to the 2.7 freeze: it completes the release's own theme and the runtime surface is opt-in only.

## Piece 3: generated schema + parity

- `nanoidp config-schema [--file settings|users|bootstrap] [--write]`: JSON Schema derived from the document models (deterministic output). Committed artifact `docs/schema/config.v1.json` (20 KB): `config_version: 1` plus three standalone schemas under `settings`/`users`/`bootstrap`, each directly usable with jsonschema (nested-resource refs do not resolve under non-schema keys, so the container is plainly a container). Documented caveat: `${VAR}` placeholders are strings, so a plain JSON Schema check flags `port: ${PORT:8000}`; `validate-config` is the check that runs the real loader.
- A test regenerates the document and fails with "schema drifted: run nanoidp config-schema --write" on divergence.
- Parity tests (`tests/test_config_schema.py`): every MCP `update_settings` property and every `settings.html` form field must map to a document-model field (explicit rename table); the YAML-only set (`secret_key`, `require_ui_login`, `hooks`, `plugins`) must NOT appear on either surface; stale rename entries fail. Verified by simulation: an injected `new_shiny_knob` on either surface fails a test.

## Piece 4: strict validation + CLI

- `config_validation: warn|strict` (document field, default `warn`) and server flag `--strict-config` (transient, wins over YAML, never persisted, same pattern as `--profile`). Under strict an unknown key in any of the three files refuses startup/reload with the same `"<file>: unknown key <path>"` text; warnings unchanged otherwise. One contract per directory: users.yaml/bootstrap.yaml follow settings.yaml's declared mode.
- `nanoidp validate-config [--config DIR] [--strict]`: same loaders, no server, and **no hook execution guaranteed by construction**: `config_validation.py` imports only `config_documents` + `serialization`, never `config` or `hooks`; tests assert a `touch`-ing `on_before_load` does not run (with a control test proving ConfigManager would run it). Exit 0 clean/warnings, 1 on errors or (with `--strict`) warnings; also honours `config_validation: strict` from the file (a directory the server refuses to boot cannot lint green).
- MCP parity: read-only `validate_config` tool (`{valid, findings}`), tool count 25 -> 26, exercised in `mcp_smoke_test.py`; the effective mode is reported as `config_validation` on `GET /api/config` and MCP `get_settings` (pinned by the existing api/mcp equality test).
- Docs: schema artifact linked from the configuration reference, "Validating your configuration" subsection with a pre-commit example; CHANGELOG.

## Verification

- 1379 passed (1326 on main, +53), ruff/mypy clean, `lint-imports` 2 kept.
- Live (scratch config with `oauth.isuer: x`): non-strict boot warns and serves (`test_agent` 54/54); `--strict-config` refuses with the message, port never opens; `validate-config` exit 0 with the finding printed, `--strict` exit 1; `config-schema` renders; `mcp_smoke_test` 26 tools, `validate_config: valid` plus the finding on the scratch dir.

Implementation notes worth review: strictness for the bootstrap registry is peeked from settings.yaml's raw `config_validation` at init (re-derived on every reload); strict fails fast on the first unknown key while `validate-config` lists everything; a strict refusal surfaces like every existing config error at startup (traceback ending in the clear message).
