### PR TITLE
chore: bump to 2.7.0rc5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.7.0rc4"
+version = "2.7.0rc5"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Fifth and intended-final release candidate for 2.7.0. Since rc4:

- #204 (#175 pieces 3-4): generated config schema (`docs/schema/config.v1.json`, `nanoidp config-schema`), `nanoidp validate-config` CLI and MCP `validate_config` tool, `config_validation: warn|strict` + `--strict-config`, MCP/UI parity tests, and configuration loads made transactional across the whole directory (a failed reload commits nothing).
- #203 (#198): the react-spa-pkce preset loads again.

This closes #175 and completes the 2.7.0 scope; the freeze continues through the soak window (regression/security/packaging/doc fixes only). CHANGELOG stays [Unreleased] per the pre-release policy.