### PR TITLE
chore: bump to 2.7.0 and consolidate the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.7.0] - 2026-08-25
 
 ### Changed
 - **Configuration files load through document models** (#175, piece 2).
@@ -924,6 +924,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Key rotation with JWKS support for multiple keys
 - External key import support
 
+[2.7.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.3.0...v2.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.7.0rc5"
+version = "2.7.0"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Final release bump: `pyproject.toml` to `2.7.0`, CHANGELOG `[Unreleased]` consolidated into `[2.7.0] - 2026-08-25` with the compare link added, per docs/RELEASING.md.

Soak summary: rc5 (the intended-final candidate) has been out since 2026-08-24 with no issues reported; the code delta between rc5 and main is docs-only (#206, #207). Pre-flight on main: 1385 tests, ruff, mypy, import-linter and `validate-config` all green locally.

After merge: tag `v2.7.0` (hyphen-less, so `:latest` moves to it), GitHub release without `--prerelease`, then the full artifact verification from RELEASING.md steps 5-7.