### PR TITLE
Per-client allowed scopes and `invalid_scop. `oauth.scop…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `additional_audiences` in #32. The route now copies the client and
   changes only the secret, so every field (present and future) is carried.
 
+### Added
+- **Per-client allowed scopes and `invalid_scope`** (#186). `oauth.scopes_supported`
+  is the global scope vocabulary (default `openid`, `profile`, `email`,
+  `offline_access`, also what discovery's `scopes_supported` now advertises
+  instead of a hardcoded list); a client's new `allowed_scopes` is an
+  optional subset of it. A requested scope outside the vocabulary is
+  `invalid_scope` for every client - a small behavior change, since any
+  scope string used to be accepted unchecked; a scope outside a client's own
+  `allowed_scopes`, when set, is `invalid_scope` for that client
+  specifically. Enforced at `/authorize`, every `/token` grant (including
+  `client_credentials`, RFC 6749 §4.4, which previously dropped any
+  requested scope entirely) and `/device_authorization`; an omitted `scope`
+  defaults to the client's full allowed set, or today's default when
+  unrestricted. Every `/token` rejection - including the pre-existing
+  refresh-token scope-narrowing check - now returns the RFC 6749 §5.2 JSON
+  error shape (`{"error": "invalid_scope", ...}`) instead of a bare 400.
+  `oauth.scope_enforcement: false` is a dev-only escape hatch back to the
+  pre-#186 behavior (any scope string accepted, unchecked); refused outside
+  the `dev` profile. `allowed_scopes` is settable from the clients UI form
+  and the MCP `create_client`/`update_client` tools, same as
+  `additional_audiences`/`redirect_uris`.
+
 ### Security
 - **Opt-in `management_secret` mutation gate** (#163): one shared secret that
   gates state-changing calls across all three management surfaces - the MCP

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -271,7 +271,21 @@ oauth:
       footer_color: "#e8f4f8"      # optional; hex only, the card's footer band
       show_client_id: true         # optional; default true
       show_description: true       # optional; default false
+    - client_id: "scoped-client"
+      client_secret: "secret"
+      description: "Client restricted to a scope subset"
+      allowed_scopes:           # optional; see "Registered scopes" below
+        - "openid"
+        - "profile"
   # logos_dir: "./static/logos"    # optional; defaults to src/nanoidp/static/logos
+  # scopes_supported:               # optional; the global scope vocabulary
+  #   - openid                      # (default: openid, profile, email, offline_access)
+  #   - profile
+  #   - email
+  #   - offline_access
+  # scope_enforcement: true          # optional; false is a dev-only escape
+                                      # hatch back to "any scope string is
+                                      # accepted" - see "Registered scopes"
 
 saml:
   # Both optional: when absent they are derived from the effective issuer as
@@ -328,6 +342,21 @@ OAuth 2.1 §4.1.1): no prefix, host or path normalization, and a mismatch
 is answered with `400 invalid_request` directly, never by redirecting to
 the unvalidated URI (§3.1.2.4). Clients without the field keep accepting
 any absolute URI, the permissive dev default.
+
+**Registered scopes** (issue #186): `oauth.scopes_supported` is the global
+scope vocabulary (default: `openid`, `profile`, `email`, `offline_access`,
+also what discovery's `scopes_supported` advertises); a client's
+`allowed_scopes` is an optional subset of it. A requested scope outside the
+vocabulary is `invalid_scope` for every client (RFC 6749 §3.3, §4.1.2.1,
+§5.2) - `scopes_supported` is a contract, not a suggestion. A requested
+scope outside a client's own `allowed_scopes`, when set, is `invalid_scope`
+for that client specifically; a client without the field may obtain any
+vocabulary scope, the permissive dev default (same "empty = unrestricted"
+convention as `redirect_uris` above). Enforced at `/authorize`, every
+`/token` grant (including `client_credentials`, RFC 6749 §4.4), and
+`/device_authorization`. `oauth.scope_enforcement: false` is a dev-only
+escape hatch back to the pre-#186 behavior - any scope string accepted,
+unchecked; refused outside the `dev` profile.
 
 **Native apps (RFC 8252)**: two things a native client needs are built
 in. A private-use scheme URI such as `com.example.app:/oauth2redirect`

--- a/book/src/reference/tokens.md
+++ b/book/src/reference/tokens.md
@@ -92,10 +92,11 @@ That is expected. The **standard OpenID Connect profile/email claims**
 custom claims where configured) are **not embedded in the tokens**. For the
 authorization code flow they are served from the **UserInfo endpoint**,
 using the access token (OpenID Connect Core 1.0 §5.4). The discovery
-document advertises what is available - `scopes_supported` (`openid`,
-`profile`, `email`, `offline_access`) and `claims_supported` - but those
-scope-based claims are returned from `GET /userinfo`, not from the tokens
-themselves.
+document advertises what is available - `scopes_supported` (configurable,
+default `openid`, `profile`, `email`, `offline_access` - see "Registered
+scopes" in the [configuration reference](configuration.md)) and
+`claims_supported` - but those scope-based claims are returned from
+`GET /userinfo`, not from the tokens themselves.
 
 ```bash
 curl 'http://localhost:8000/userinfo' \
@@ -125,6 +126,13 @@ standard OIDC claims are gated by the granted scope (OIDC Core §5.4):
 carried on the access token as the `scope` claim (RFC 9068 §2.2.3).
 NanoIDP-specific claims (`roles`, `groups`, `tenant`, `identity_class`,
 `attributes`) have no standard scope and are always returned.
+
+This is a distinct mechanism from per-client scope *enforcement* (see the
+configuration reference), issue #186: scope gating decides which claims an
+already-granted scope unlocks at `/userinfo`; enforcement decides whether a
+client may be granted that scope at all, at `/authorize` and `/token`. A
+scope that fails enforcement is rejected outright (`invalid_scope`) long
+before this gating would ever see it.
 
 ## Requesting claims in the ID Token (`claims` parameter)
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -39,6 +39,12 @@ oauth:
     redirect_uris:
     - com.example.app:/oauth2redirect
     - http://127.0.0.1:0/callback
+  - client_id: scoped-client
+    client_secret: scoped-secret
+    description: 'Client restricted to a scope subset (issue #186)'
+    allowed_scopes:
+    - openid
+    - profile
   issuer_from_request: false
   issuer_from_proxy_headers: false
   # logos_dir: ./static/logos  # optional override; defaults to src/nanoidp/static/logos

--- a/docs/schema/config.v1.json
+++ b/docs/schema/config.v1.json
@@ -89,6 +89,10 @@
             "default": null,
             "title": "Additional Audiences"
           },
+          "allowed_scopes": {
+            "default": null,
+            "title": "Allowed Scopes"
+          },
           "background_color": {
             "anyOf": [
               {
@@ -355,6 +359,26 @@
             "default": false,
             "title": "Require Pkce",
             "type": "boolean"
+          },
+          "scope_enforcement": {
+            "default": true,
+            "title": "Scope Enforcement",
+            "type": "boolean"
+          },
+          "scopes_supported": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scopes Supported"
           },
           "token_expiry_minutes": {
             "default": 60,

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -972,6 +972,128 @@ class NanoIDPTestAgent:
                 f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
             )
 
+    def test_scope_enforcement(self) -> TestResult:
+        """Per-client allowed scopes and invalid_scope (issue #186).
+
+        Registers a client restricted to ['openid', 'profile'] (clients UI
+        form), then checks /authorize, /token (client_credentials) and
+        /device_authorization all reject a scope outside that set with
+        invalid_scope, and accept one inside it.
+        """
+        test_client_id = f"scope-test-{secrets.token_hex(4)}"
+        test_client_secret = "scope-test-secret"
+        redirect_uri = "http://localhost:3000/callback"
+        try:
+            create = self.session.post(
+                f"{self.base_url}/clients/create",
+                data={
+                    "client_id": test_client_id,
+                    "client_secret": test_client_secret,
+                    "description": "Scope enforcement e2e test client",
+                    "allowed_scopes": "openid\nprofile",
+                },
+                allow_redirects=False,
+                timeout=5,
+            )
+            if create.status_code not in (302, 303):
+                return self._add_result(
+                    "Scope Enforcement", TestCategory.OAUTH, False,
+                    f"Client creation failed: status={create.status_code}",
+                )
+
+            def authorize(scope: str) -> requests.Response:
+                return requests.get(
+                    f"{self.base_url}/authorize",
+                    params={
+                        "response_type": "code",
+                        "client_id": test_client_id,
+                        "redirect_uri": redirect_uri,
+                        "scope": scope,
+                    },
+                    allow_redirects=False,
+                    timeout=5,
+                )
+
+            def is_invalid_scope(resp: requests.Response) -> bool:
+                if resp.status_code != 400:
+                    return False
+                try:
+                    return resp.json().get("error") == "invalid_scope"
+                except ValueError:
+                    return False
+
+            authorize_disallowed = authorize("email")
+            authorize_allowed = authorize("openid")
+
+            client_credentials_disallowed = self.session.post(
+                f"{self.base_url}/token",
+                data={"grant_type": "client_credentials", "scope": "email"},
+                auth=(test_client_id, test_client_secret),
+                timeout=5,
+            )
+            client_credentials_allowed = self.session.post(
+                f"{self.base_url}/token",
+                data={"grant_type": "client_credentials", "scope": "profile"},
+                auth=(test_client_id, test_client_secret),
+                timeout=5,
+            )
+
+            device_disallowed = self.session.post(
+                f"{self.base_url}/device_authorization",
+                data={"scope": "email"},
+                auth=(test_client_id, test_client_secret),
+                timeout=5,
+            )
+            device_allowed = self.session.post(
+                f"{self.base_url}/device_authorization",
+                data={"scope": "profile"},
+                auth=(test_client_id, test_client_secret),
+                timeout=5,
+            )
+
+            checks = {
+                "authorize_disallowed_scope_rejected": is_invalid_scope(authorize_disallowed),
+                "authorize_allowed_scope_accepted": authorize_allowed.status_code == 200,
+                "client_credentials_disallowed_scope_rejected": (
+                    client_credentials_disallowed.status_code == 400
+                    and client_credentials_disallowed.json().get("error") == "invalid_scope"
+                ),
+                "client_credentials_allowed_scope_accepted": (
+                    client_credentials_allowed.status_code == 200
+                    and client_credentials_allowed.json().get("scope") == "profile"
+                ),
+                "device_authorization_disallowed_scope_rejected": (
+                    device_disallowed.status_code == 400
+                    and device_disallowed.json().get("error") == "invalid_scope"
+                ),
+                "device_authorization_allowed_scope_accepted": device_allowed.status_code == 200,
+            }
+
+            success = all(checks.values())
+            return self._add_result(
+                "Scope Enforcement",
+                TestCategory.OAUTH,
+                success,
+                "issue #186: a scope outside allowed_scopes is invalid_scope at "
+                "/authorize, /token and /device_authorization; one inside it is granted",
+                {**checks, "statuses": {
+                    "authorize_disallowed": authorize_disallowed.status_code,
+                    "authorize_allowed": authorize_allowed.status_code,
+                    "client_credentials_disallowed": client_credentials_disallowed.status_code,
+                    "client_credentials_allowed": client_credentials_allowed.status_code,
+                    "device_disallowed": device_disallowed.status_code,
+                    "device_allowed": device_allowed.status_code,
+                }},
+            )
+        except Exception as e:
+            return self._add_result(
+                "Scope Enforcement", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+        finally:
+            self.session.post(
+                f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
+            )
+
     def test_client_branding(self) -> TestResult:
         """Per-client login page branding is created and rendered end-to-end (#150).
 
@@ -4018,6 +4140,7 @@ class NanoIDPTestAgent:
                 self.test_authorization_code_pkce,
                 self.test_redirect_uri_exact_matching,
                 self.test_native_app_redirect_uris,
+                self.test_scope_enforcement,
                 self.test_client_branding,
                 self.test_id_token_audience,
                 self.test_id_token_time_claims,

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -39,6 +39,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Ty
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from .models import (
+    DEFAULT_SCOPES_SUPPORTED,
     OAuthClient,
     Settings,
     User,
@@ -82,6 +83,7 @@ class ClientEntry(BaseModel):
     show_description: bool = False
     additional_audiences: Any = None
     redirect_uris: Any = None
+    allowed_scopes: Any = None
 
     def to_client(self) -> OAuthClient:
         return OAuthClient(
@@ -98,6 +100,9 @@ class ClientEntry(BaseModel):
             ),
             redirect_uris=_coerce_client_str_list(
                 self.redirect_uris, self.client_id, "redirect_uris"
+            ),
+            allowed_scopes=_coerce_client_str_list(
+                self.allowed_scopes, self.client_id, "allowed_scopes"
             ),
         )
 
@@ -117,6 +122,11 @@ class OAuthSection(BaseModel):
     # Absent = no clients; an explicit `clients:` (null) is a type error, as
     # it was for the old loader (#197 review: null and missing differ).
     clients: List[ClientEntry] = Field(default_factory=list)
+    # Absent = the DEFAULT_SCOPES_SUPPORTED vocabulary (#186); None here (not
+    # a default_factory of the tuple) so to_settings() can tell "declared
+    # empty list" from "not declared" the same way issuer_allowlist does.
+    scopes_supported: Optional[List[str]] = None
+    scope_enforcement: bool = True
     logos_dir: Optional[str] = None
     # Present in shipped presets, never consumed by the loader (accepted for
     # compatibility; see the module docstring).
@@ -330,6 +340,12 @@ class SettingsDocument(BaseModel):
             refresh_token_rotation=self.oauth.refresh_token_rotation,
             require_pkce=self.oauth.require_pkce,
             clients=clients,
+            scopes_supported=(
+                self.oauth.scopes_supported
+                if self.oauth.scopes_supported is not None
+                else list(DEFAULT_SCOPES_SUPPORTED)
+            ),
+            scope_enforcement=self.oauth.scope_enforcement,
             logos_dir=self.oauth.logos_dir,
             saml_entity_id=self.saml.entity_id or None,
             saml_sso_url=self.saml.sso_url or None,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -241,6 +241,7 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
         "show_description": client.show_description,
         "additional_audiences": client.additional_audiences,
         "redirect_uris": client.redirect_uris,
+        "allowed_scopes": client.allowed_scopes,
     }
 
 
@@ -615,6 +616,11 @@ _TOOLS: list[Tool] = [
                     "items": {"type": "string"},
                     "description": "Registered redirect URIs; when non-empty, /authorize enforces exact matching, except a registered loopback URI (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any port per RFC 8252 section 7.3; reverse-domain private-use schemes like com.example.app:/cb are accepted, schemes without a period such as myapp:// are rejected per section 7.1 (optional)",
                 },
+                "allowed_scopes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Per-client scope allow-list (#186); when non-empty, /authorize and /token reject a requested scope outside this set with invalid_scope (RFC 6749 4.1.2.1/5.2). Empty = any scope in the global oauth.scopes_supported vocabulary is allowed (optional)",
+                },
             },
             "required": ["client_id", "client_secret"],
         },
@@ -666,6 +672,11 @@ _TOOLS: list[Tool] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Replace the client's registered redirect URIs (loopback URIs match any port per RFC 8252 section 7.3, reverse-domain private-use schemes accepted, myapp:// rejected per section 7.1); empty list removes the restriction (optional)",
+                },
+                "allowed_scopes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Replace the client's scope allow-list (#186); empty list removes the restriction (optional)",
                 },
             },
             "required": ["client_id"],
@@ -1229,6 +1240,7 @@ def _tool_create_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         show_description=arguments.get("show_description", False),
         additional_audiences=_normalize_audiences(arguments.get("additional_audiences")),
         redirect_uris=_normalize_str_list(arguments.get("redirect_uris"), "redirect_uris"),
+        allowed_scopes=_normalize_str_list(arguments.get("allowed_scopes"), "allowed_scopes"),
     )
     config.settings.clients.append(new_client)
     return {"success": True, "client": _client_to_dict(new_client)}
@@ -1251,6 +1263,11 @@ def _tool_update_client(arguments: dict[str, Any], config: ConfigManager) -> dic
     new_redirect_uris = (
         _normalize_str_list(arguments["redirect_uris"], "redirect_uris")
         if "redirect_uris" in arguments
+        else None
+    )
+    new_allowed_scopes = (
+        _normalize_str_list(arguments["allowed_scopes"], "allowed_scopes")
+        if "allowed_scopes" in arguments
         else None
     )
     new_background_color = (
@@ -1287,6 +1304,8 @@ def _tool_update_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         client.additional_audiences = new_audiences
     if new_redirect_uris is not None:
         client.redirect_uris = new_redirect_uris
+    if new_allowed_scopes is not None:
+        client.allowed_scopes = new_allowed_scopes
 
     return {"success": True, "client": _client_to_dict(client)}
 
@@ -1315,6 +1334,11 @@ def _tool_get_settings(arguments: dict[str, Any], config: ConfigManager) -> dict
         "issuer_from_proxy_headers": settings.issuer_from_proxy_headers,
         "audience": settings.audience,
         "token_expiry_minutes": settings.token_expiry_minutes,
+        # YAML-only (oauth.scopes_supported / oauth.scope_enforcement, #186)
+        # - reported for visibility, like secret_key and require_ui_login,
+        # but not in update_settings' input_schema below.
+        "scopes_supported": settings.scopes_supported,
+        "scope_enforcement": settings.scope_enforcement_active,
         "security_profile": settings.security_profile,
         # Same as GET /api/config (#172): whether the profile comes from
         # the CLI, and the values the effective profile forces.

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -63,6 +63,12 @@ def _coerce_additional_audiences(raw: Any, client_id: str) -> List[str]:
 # read this tuple (#172).
 SECURITY_PROFILES: tuple[str, ...] = ("dev", "stricter-dev", "oauth21")
 
+# Today's fixed scope list (#186), now Settings.scopes_supported's default
+# instead of being hardcoded in discovery.py - so discovery keeps advertising
+# the same four scopes out of the box, but an operator can grow the
+# vocabulary without patching code.
+DEFAULT_SCOPES_SUPPORTED: tuple[str, ...] = ("openid", "profile", "email", "offline_access")
+
 
 class User(BaseModel):
     """Represents a user in the system."""
@@ -154,6 +160,20 @@ class OAuthClient(BaseModel):
             "acceptable scheme is accepted (dev default)."
         ),
     )
+    allowed_scopes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Per-client scope allow-list (issue #186). When non-empty, "
+            "/authorize and /token (every grant) reject a requested scope "
+            "outside this set with invalid_scope (RFC 6749 4.1.2.1/5.2); an "
+            "omitted 'scope' parameter defaults to this client's full set. "
+            "Empty = this client may obtain any scope in the global "
+            "'oauth.scopes_supported' vocabulary (dev default) - the same "
+            "'empty allow-list = unrestricted' convention as redirect_uris "
+            "above. A scope outside 'oauth.scopes_supported' is always "
+            "invalid_scope, for every client, regardless of this field."
+        ),
+    )
 
 
 class Settings(BaseModel):
@@ -222,6 +242,27 @@ class Settings(BaseModel):
         "refresh token, so its reuse fails (lets clients test rotation handling, #46)",
     )
     clients: List[OAuthClient] = Field(default_factory=list, description="OAuth clients")
+    scopes_supported: List[str] = Field(
+        default_factory=lambda: list(DEFAULT_SCOPES_SUPPORTED),
+        description=(
+            "The global scope vocabulary (issue #186): a requested scope "
+            "outside this list is invalid_scope for every client, regardless "
+            "of that client's own 'allowed_scopes'. Also what discovery's "
+            "'scopes_supported' advertises, so metadata never lies about what "
+            "/authorize and /token will actually grant. YAML-only "
+            "(oauth.scopes_supported) - like secret_key and require_ui_login, "
+            "not on the Settings page or the MCP update_settings tool."
+        ),
+    )
+    scope_enforcement: bool = Field(
+        default=True,
+        description=(
+            "The declared value; combined with security_profile via the "
+            "'scope_enforcement_active' property below - false only actually "
+            "disables enforcement under the 'dev' profile (issue #186). "
+            "YAML-only (oauth.scope_enforcement), like scopes_supported above."
+        ),
+    )
     logos_dir: Optional[str] = Field(
         default=None,
         description="Directory path where per-client logo files are stored for the "
@@ -481,6 +522,18 @@ class Settings(BaseModel):
         (local dev/testing convenience only; unrelated to 'security_profile'
         and to the OAuth password grant - see 'login_mode' above)."""
         return self.login_mode == "persona"
+
+    @property
+    def scope_enforcement_active(self) -> bool:
+        """Effective scope enforcement (#186): the same 'raw field OR profile
+        decides' shape as pkce_required/rotation_enabled above, just with the
+        opposite polarity - this one force-ENABLES rather than force-relaxes.
+        The raw scope_enforcement flag may turn enforcement off, but only
+        under 'dev'; stricter-dev and oauth21 always enforce regardless of
+        the raw value, exactly like a --profile override that mutates
+        security_profile after construction (bypassing field validation)
+        still can't be used to silently smuggle enforcement off."""
+        return self.scope_enforcement or self.security_profile != "dev"
 
     @field_validator("issuer")
     @classmethod

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -153,6 +153,10 @@ def get_configuration() -> ResponseReturnValue:
             "audience": settings.audience,
             "token_expiry_minutes": settings.token_expiry_minutes,
             "clients_count": len(settings.clients),
+            # YAML-only (#186) - reported for visibility like the rest of
+            # this block, never settable through this endpoint.
+            "scopes_supported": settings.scopes_supported,
+            "scope_enforcement": settings.scope_enforcement_active,
         },
         "saml": {
             # Effective values for THIS request (#181): explicit YAML value,

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -595,6 +595,11 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
     # (issue #186): both may have changed since the original grant, so
     # narrowing alone (above) isn't enough to guarantee the refreshed token
     # still only carries scopes this client may currently have.
+    # validate_only=True: an absent scope here means the ORIGINAL grant had
+    # none (a legacy refresh token predating this setting, or one issued
+    # before allowed_scopes was set) - it must stay absent, not be defaulted
+    # to the client's current full allowed set, or a refresh could silently
+    # GRANT MORE than the original authorization ever did (#186 review, B1).
     client = ctx.config.get_client(ctx.client_id)
     if client is not None:
         scope_result = resolve_scope(
@@ -602,6 +607,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
             client,
             ctx.config.settings.scopes_supported,
             ctx.config.settings.scope_enforcement_active,
+            validate_only=True,
         )
         if not scope_result.ok:
             audit_event(
@@ -837,6 +843,10 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
     # code and this exchange, so the check at issuance time isn't enough to
     # guarantee the token still only carries scopes this client may
     # currently have.
+    # validate_only=True: an absent scope here means /authorize granted none
+    # (not reachable today - it always resolves a non-empty scope before
+    # minting a code - but kept safe against a future refactor, same
+    # reasoning as the refresh grant's re-check, #186 review B1).
     code_scope: Optional[str] = auth_code.scope if auth_code.scope is not None else None
     client = ctx.config.get_client(ctx.client_id)
     if client is not None:
@@ -845,6 +855,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
             client,
             ctx.config.settings.scopes_supported,
             ctx.config.settings.scope_enforcement_active,
+            validate_only=True,
         )
         if not scope_result.ok:
             audit_event(

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -38,6 +38,7 @@ from ..services import (
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
 from ..services.redirect_uri import redirect_uri_is_registered, redirect_uri_rejection_reason
+from ..services.scope import resolve_scope
 from ..services.token import resolve_user_claim, sanitize_claim_names
 from ._audit import audit_event
 from ._issuer import effective_issuer
@@ -136,7 +137,7 @@ def authorize() -> ResponseReturnValue:
     response_type = params.get("response_type", session.get("oauth_response_type", ""))
     client_id = params.get("client_id", session.get("oauth_client_id", ""))
     redirect_uri = params.get("redirect_uri", session.get("oauth_redirect_uri", ""))
-    scope = params.get("scope", session.get("oauth_scope", "openid"))
+    scope = params.get("scope", session.get("oauth_scope", ""))
     state = params.get("state", session.get("oauth_state", ""))
     code_challenge = params.get("code_challenge", session.get("oauth_code_challenge", ""))
     code_challenge_method = params.get("code_challenge_method", session.get("oauth_code_challenge_method", ""))
@@ -188,6 +189,33 @@ def authorize() -> ResponseReturnValue:
             "error": "invalid_client",
             "error_description": "Unknown client_id"
         }), 400
+
+    # Scope validation (issue #186): a requested scope outside the global
+    # vocabulary, or outside this client's own allowed_scopes when set, is
+    # invalid_scope (RFC 6749 §4.1.2.1). An omitted scope defaults to the
+    # client's full allowed set when restricted, or "openid" as before
+    # (#186). Checked before redirect_uri so an invalid_scope on an
+    # unregistered client reports the more specific problem first.
+    scope_result = resolve_scope(
+        scope,
+        client,
+        config.settings.scopes_supported,
+        config.settings.scope_enforcement_active,
+        default_when_omitted="openid",
+    )
+    if not scope_result.ok:
+        audit_event(
+            "authorization_request",
+            "failed",
+            endpoint="/authorize",
+            client_id=client_id,
+            details={"reason": scope_result.error_description},
+        )
+        return jsonify({
+            "error": "invalid_scope",
+            "error_description": scope_result.error_description
+        }), 400
+    scope = scope_result.granted or ""
 
     # Syntactic validation (RFC 6749 §3.1.2): an absolute URI with no
     # fragment. A scheme is required; an authority is not, so native-app
@@ -555,12 +583,43 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
                     "rejected_scopes": rejected,
                 },
             )
-            return abort(
-                400, description="Requested scope exceeds originally granted scope"
-            )
+            return jsonify({
+                "error": "invalid_scope",
+                "error_description": "Requested scope exceeds originally granted scope"
+            }), 400
         scope = requested_scope
     else:
         scope = original_scope or None
+
+    # Re-validate against the vocabulary and this client's allowed_scopes
+    # (issue #186): both may have changed since the original grant, so
+    # narrowing alone (above) isn't enough to guarantee the refreshed token
+    # still only carries scopes this client may currently have.
+    client = ctx.config.get_client(ctx.client_id)
+    if client is not None:
+        scope_result = resolve_scope(
+            scope,
+            client,
+            ctx.config.settings.scopes_supported,
+            ctx.config.settings.scope_enforcement_active,
+        )
+        if not scope_result.ok:
+            audit_event(
+                "token_request",
+                "failed",
+                endpoint="/token",
+                username=username,
+                client_id=ctx.client_id,
+                details={
+                    "reason": scope_result.error_description,
+                    "grant_type": ctx.grant_type,
+                },
+            )
+            return jsonify({
+                "error": "invalid_scope",
+                "error_description": scope_result.error_description
+            }), 400
+        scope = scope_result.granted
 
     # A refreshed ID Token must carry the ORIGINAL authentication time
     # (OIDC Core §12.2), persisted in the refresh token claims (#42).
@@ -674,6 +733,34 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
         )
         return abort(401, description="Invalid credentials")
 
+    # Scope validation (issue #186), same rule as every other grant.
+    client = ctx.config.get_client(ctx.client_id)
+    requested_scope = request.form.get("scope")
+    if client is not None:
+        scope_result = resolve_scope(
+            requested_scope,
+            client,
+            ctx.config.settings.scopes_supported,
+            ctx.config.settings.scope_enforcement_active,
+        )
+        if not scope_result.ok:
+            audit_event(
+                "token_request",
+                "failed",
+                endpoint="/token",
+                username=username,
+                client_id=ctx.client_id,
+                details={
+                    "reason": scope_result.error_description,
+                    "grant_type": ctx.grant_type,
+                },
+            )
+            return jsonify({
+                "error": "invalid_scope",
+                "error_description": scope_result.error_description
+            }), 400
+        requested_scope = scope_result.granted
+
     # An authenticated end-user is present, so honour an openid scope and
     # emit an ID Token (issue #36). nonce is non-standard for this grant but
     # accepted as a dev convenience; normalize an empty field to None so we
@@ -682,7 +769,7 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
         user=user,
         username=username,
         nonce=request.form.get("nonce") or None,
-        scope=request.form.get("scope"),
+        scope=requested_scope,
     )
 
 
@@ -745,12 +832,44 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
         )
         return abort(401, description="User not found")
 
+    # Re-validate against the vocabulary and this client's allowed_scopes
+    # (issue #186): both may have changed between /authorize issuing the
+    # code and this exchange, so the check at issuance time isn't enough to
+    # guarantee the token still only carries scopes this client may
+    # currently have.
+    code_scope: Optional[str] = auth_code.scope if auth_code.scope is not None else None
+    client = ctx.config.get_client(ctx.client_id)
+    if client is not None:
+        scope_result = resolve_scope(
+            code_scope,
+            client,
+            ctx.config.settings.scopes_supported,
+            ctx.config.settings.scope_enforcement_active,
+        )
+        if not scope_result.ok:
+            audit_event(
+                "token_request",
+                "failed",
+                endpoint="/token",
+                username=username,
+                client_id=ctx.client_id,
+                details={
+                    "reason": scope_result.error_description,
+                    "grant_type": ctx.grant_type,
+                },
+            )
+            return jsonify({
+                "error": "invalid_scope",
+                "error_description": scope_result.error_description
+            }), 400
+        code_scope = scope_result.granted
+
     requested_claims = auth_code.claims or {}
     return _GrantOutcome(
         user=user,
         username=username,
         nonce=auth_code.nonce if auth_code.nonce is not None else None,
-        scope=auth_code.scope if auth_code.scope is not None else None,
+        scope=code_scope,
         # The user authenticated at the login page when the code was created,
         # not at this token exchange - use that moment as auth_time (#42).
         auth_time=int(auth_code.created_at.timestamp()),
@@ -761,7 +880,48 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
 
 
 def _grant_client_credentials(ctx: _GrantContext) -> GrantResult:
-    """client_credentials grant (RFC 6749 §4.4)."""
+    """client_credentials grant (RFC 6749 §4.4).
+
+    §4.4 makes the 'scope' parameter optional for this grant; before #186 it
+    was read nowhere, so a requested scope was silently dropped rather than
+    granted or rejected. Validated the same as every other grant now.
+    """
+    requested_scope = request.form.get("scope")
+    client = ctx.config.get_client(ctx.client_id)
+    if client is not None:
+        scope_result = resolve_scope(
+            requested_scope,
+            client,
+            ctx.config.settings.scopes_supported,
+            ctx.config.settings.scope_enforcement_active,
+        )
+        if not scope_result.ok:
+            audit_event(
+                "token_request",
+                "failed",
+                endpoint="/token",
+                client_id=ctx.client_id,
+                details={
+                    "reason": scope_result.error_description,
+                    "grant_type": ctx.grant_type,
+                },
+            )
+            return jsonify({
+                "error": "invalid_scope",
+                "error_description": scope_result.error_description
+            }), 400
+        requested_scope = scope_result.granted
+        if requested_scope:
+            # client_credentials has no end-user context (RFC 6749 §4.4 has
+            # no ID Token concept), but create_token()'s id_token issuance is
+            # grant-agnostic - it mints one whenever 'openid' is in scope, no
+            # matter the grant. Accepted at validation (it's a real,
+            # vocabulary-listed scope) but silently dropped from what's
+            # actually granted, rather than rejected, matching this grant's
+            # pre-#186 behavior of never producing an ID Token.
+            remaining = [t for t in requested_scope.split() if t != "openid"]
+            requested_scope = " ".join(remaining) or None
+
     # Use default user for client credentials
     default_username = ctx.config.default_user
     user = ctx.config.get_user(default_username)
@@ -773,7 +933,7 @@ def _grant_client_credentials(ctx: _GrantContext) -> GrantResult:
             roles=["user"],
             tenant="default",
         )
-    return _GrantOutcome(user=user, username=user.username)
+    return _GrantOutcome(user=user, username=user.username, scope=requested_scope)
 
 
 def _grant_device_code(ctx: _GrantContext) -> GrantResult:
@@ -1409,7 +1569,33 @@ def device_authorization() -> ResponseReturnValue:
     # check_client fails closed on a missing username, so it is present here;
     # the fallback only narrows the type.
     client_id = auth.username or ""
-    scope = request.form.get("scope", "openid")
+    requested_scope = request.form.get("scope", "")
+
+    # Scope validation (issue #186), same rule as /authorize including the
+    # "openid" default when omitted on an unrestricted client.
+    client = config.get_client(client_id)
+    if client is not None:
+        scope_result = resolve_scope(
+            requested_scope,
+            client,
+            config.settings.scopes_supported,
+            config.settings.scope_enforcement_active,
+            default_when_omitted="openid",
+        )
+        if not scope_result.ok:
+            audit_event(
+                "device_authorization_request",
+                "failed",
+                endpoint="/device_authorization",
+                client_id=client_id,
+                details={"reason": scope_result.error_description},
+            )
+            return jsonify({
+                "error": "invalid_scope",
+                "error_description": scope_result.error_description
+            }), 400
+        requested_scope = scope_result.granted or ""
+    scope = requested_scope
 
     # Create the device authorization; the store prunes stale entries and
     # keeps the user-code index internally (#84, previously module globals).

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -414,6 +414,7 @@ def client_create() -> ResponseReturnValue:
                 request.form.get("additional_audiences", "")
             ),
             redirect_uris=_parse_textarea_list(request.form.get("redirect_uris", "")),
+            allowed_scopes=_parse_textarea_list(request.form.get("allowed_scopes", "")),
         )
 
         yaml_writer = get_yaml_writer()
@@ -479,6 +480,7 @@ def client_edit(client_id: str) -> ResponseReturnValue:
                 request.form.get("additional_audiences", "")
             ),
             redirect_uris=_parse_textarea_list(request.form.get("redirect_uris", "")),
+            allowed_scopes=_parse_textarea_list(request.form.get("allowed_scopes", "")),
         )
 
         yaml_writer = get_yaml_writer()
@@ -535,7 +537,8 @@ def client_regenerate_secret(client_id: str) -> ResponseReturnValue:
         # field by field is how #32 lost additional_audiences here, and how
         # the branding fields (colors, show_* flags) were silently reset
         # until #215's review caught it. model_copy carries every field,
-        # including ones added after this line was written.
+        # including ones added after this line was written (allowed_scopes,
+        # #186, included).
         updated_client = client.model_copy(update={"client_secret": new_secret})
 
         yaml_writer = get_yaml_writer()

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -245,6 +245,8 @@ def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
         entry["additional_audiences"] = client.additional_audiences
     if client.redirect_uris:
         entry["redirect_uris"] = client.redirect_uris
+    if client.allowed_scopes:
+        entry["allowed_scopes"] = client.allowed_scopes
     return entry
 
 
@@ -287,6 +289,7 @@ def merge_client_entry(raw_entry: Dict[str, Any], client: OAuthClient) -> Dict[s
     for field_name, new_list_value in (
         ("additional_audiences", client.additional_audiences),
         ("redirect_uris", client.redirect_uris),
+        ("allowed_scopes", client.allowed_scopes),
     ):
         if not is_unchanged(raw_entry.get(field_name), new_list_value):
             if new_list_value:

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -47,7 +47,8 @@ def build_discovery_document(
         # deprecated by the OAuth 2.0 Security BCP and intentionally absent.
         "response_types_supported": ["code"],
         "id_token_signing_alg_values_supported": ["RS256"],
-        "scopes_supported": ["openid", "profile", "email", "offline_access"],
+        # Settings-driven (#186), default unchanged - see Settings.scopes_supported.
+        "scopes_supported": settings.scopes_supported,
         "claims_supported": [
             "sub", "iss", "aud", "azp", "exp", "iat", "nbf",
             "auth_time", "nonce", "at_hash",

--- a/src/nanoidp/services/scope.py
+++ b/src/nanoidp/services/scope.py
@@ -1,0 +1,97 @@
+"""
+Per-client scope validation and invalid_scope rejection (issue #186).
+
+/authorize, every /token grant, and /device_authorization all ask the same
+question of a requested ``scope`` string: is every token in it something
+this client may have? This module answers that once so those call sites in
+``routes/oauth.py`` cannot drift on what ``invalid_scope`` means (RFC 6749
+§4.1.2.1 for the authorization endpoint, §5.2 for the token endpoint).
+
+Enforcement is opt-out (``Settings.scope_enforcement_active``, dev profile
+only, #186): off restores exactly the pre-#186 behavior - any scope string
+is accepted unchecked, and a client's ``allowed_scopes`` is not even
+consulted for defaulting, only the endpoint's own historical default (if
+any) applies.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from ..models import OAuthClient
+
+
+@dataclass
+class ScopeResult:
+    """The outcome of validating a requested scope against a client.
+
+    ``granted`` is the scope string to actually issue (already resolved from
+    an omitted request); ``error_description`` is set, and ``granted`` is
+    None, exactly when the request must be rejected as invalid_scope.
+    """
+
+    granted: Optional[str]
+    error_description: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error_description is None
+
+
+def resolve_scope(
+    requested: Optional[str],
+    client: OAuthClient,
+    vocabulary: Iterable[str],
+    enforcement_active: bool,
+    *,
+    default_when_omitted: Optional[str] = None,
+) -> ScopeResult:
+    """Validate (and default) one requested scope string for one client.
+
+    - Enforcement off: ``requested`` (or ``default_when_omitted`` if it was
+      omitted) passes through untouched - no vocabulary check, no per-client
+      check, and ``client.allowed_scopes`` is not consulted at all, so a
+      client's allow-list has no effect while enforcement is off.
+    - Enforcement on, omitted (falsy ``requested``): a client with a
+      non-empty ``allowed_scopes`` defaults to its full allowed set (space
+      joined); an unrestricted client falls back to ``default_when_omitted``,
+      same as when enforcement is off.
+    - Enforcement on, present: every space-separated token must be in
+      ``vocabulary`` - a scope outside the global vocabulary is
+      ``invalid_scope`` for every client, the "small behaviour change" #186
+      calls out - and, when ``client.allowed_scopes`` is non-empty, every
+      token must ALSO be in it.
+    """
+    if not enforcement_active:
+        return ScopeResult(granted=requested or default_when_omitted)
+
+    effective = requested or (
+        " ".join(client.allowed_scopes) if client.allowed_scopes else default_when_omitted
+    )
+    if not effective:
+        return ScopeResult(granted=effective)
+
+    tokens = effective.split()
+    vocabulary_set = set(vocabulary)
+    outside_vocabulary = sorted({t for t in tokens if t not in vocabulary_set})
+    if outside_vocabulary:
+        return ScopeResult(
+            granted=None,
+            error_description=(
+                "Requested scope contains values outside the supported "
+                f"vocabulary: {', '.join(outside_vocabulary)}"
+            ),
+        )
+
+    if client.allowed_scopes:
+        allowed = set(client.allowed_scopes)
+        disallowed = sorted({t for t in tokens if t not in allowed})
+        if disallowed:
+            return ScopeResult(
+                granted=None,
+                error_description=(
+                    f"Requested scope is not allowed for client "
+                    f"'{client.client_id}': {', '.join(disallowed)}"
+                ),
+            )
+
+    return ScopeResult(granted=effective)

--- a/src/nanoidp/services/scope.py
+++ b/src/nanoidp/services/scope.py
@@ -44,29 +44,46 @@ def resolve_scope(
     enforcement_active: bool,
     *,
     default_when_omitted: Optional[str] = None,
+    validate_only: bool = False,
 ) -> ScopeResult:
-    """Validate (and default) one requested scope string for one client.
+    """Validate (and, at a request surface, default) one scope string.
 
     - Enforcement off: ``requested`` (or ``default_when_omitted`` if it was
-      omitted) passes through untouched - no vocabulary check, no per-client
-      check, and ``client.allowed_scopes`` is not consulted at all, so a
-      client's allow-list has no effect while enforcement is off.
-    - Enforcement on, omitted (falsy ``requested``): a client with a
-      non-empty ``allowed_scopes`` defaults to its full allowed set (space
-      joined); an unrestricted client falls back to ``default_when_omitted``,
-      same as when enforcement is off.
-    - Enforcement on, present: every space-separated token must be in
+      omitted and ``validate_only`` is not set) passes through untouched - no
+      vocabulary check, no per-client check, and ``client.allowed_scopes`` is
+      not consulted at all, so a client's allow-list has no effect while
+      enforcement is off.
+    - Enforcement on, omitted (falsy ``requested``), ``validate_only=False``
+      (the default - use at a request surface: /authorize,
+      /device_authorization, and the password/client_credentials grants): a
+      client with a non-empty ``allowed_scopes`` defaults to its full allowed
+      set (space joined); an unrestricted client falls back to
+      ``default_when_omitted``, same as when enforcement is off.
+    - Enforcement on, omitted, ``validate_only=True`` (use at a RE-check of an
+      already-granted scope: the refresh grant and authorization_code
+      redemption): omitted stays omitted, unchecked and undefaulted. A grant
+      minted with no scope at all - a legacy refresh token predating this
+      setting, or one issued before ``allowed_scopes`` was set - has nothing
+      to validate and must not have one manufactured for it; defaulting an
+      absent *original* scope to the client's current full allowed set would
+      let a refresh silently GRANT MORE than the original authorization ever
+      did (#186 review, B1) - the opposite of the narrowing this grant is
+      supposed to enforce.
+    - Present (either mode): every space-separated token must be in
       ``vocabulary`` - a scope outside the global vocabulary is
       ``invalid_scope`` for every client, the "small behaviour change" #186
       calls out - and, when ``client.allowed_scopes`` is non-empty, every
       token must ALSO be in it.
     """
     if not enforcement_active:
-        return ScopeResult(granted=requested or default_when_omitted)
+        return ScopeResult(granted=requested if validate_only else requested or default_when_omitted)
 
-    effective = requested or (
-        " ".join(client.allowed_scopes) if client.allowed_scopes else default_when_omitted
-    )
+    if validate_only:
+        effective = requested
+    else:
+        effective = requested or (
+            " ".join(client.allowed_scopes) if client.allowed_scopes else default_when_omitted
+        )
     if not effective:
         return ScopeResult(granted=effective)
 

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -79,6 +79,17 @@
                         </div>
                     </div>
 
+                    <div class="mb-3">
+                        <label for="allowed_scopes" class="form-label">Allowed Scopes</label>
+                        <textarea class="form-control" id="allowed_scopes" name="allowed_scopes"
+                                  rows="3" placeholder="One scope per line, e.g.&#10;openid&#10;profile">{{ client.allowed_scopes | join('\n') if client else '' }}</textarea>
+                        <div class="form-text">
+                            When set, a requested <code>scope</code> outside this list is <code>invalid_scope</code>
+                            at <code>/authorize</code> and <code>/token</code> (RFC 6749 §4.1.2.1/§5.2). Leave empty to
+                            allow any scope in the global vocabulary (<code>oauth.scopes_supported</code>, dev default).
+                        </div>
+                    </div>
+
                     <hr class="my-4">
                     <h6 class="mb-3">
                         <i class="bi bi-palette me-2"></i>Login Page Branding (Optional)

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -136,6 +136,36 @@ class TestResolveScopeHelper:
         assert result.ok
         assert result.granted is None
 
+    def test_validate_only_does_not_default_omitted_scope_for_restricted_client(self):
+        """#186 review B1: at a RE-check (refresh, auth-code redemption), an
+        absent original scope must stay absent, never widened to the
+        client's current allowed_scopes."""
+        result = resolve_scope(None, self._client(["openid", "profile"]), self.VOCAB, True, validate_only=True)
+        assert result.ok
+        assert result.granted is None
+
+    def test_validate_only_ignores_default_when_omitted_too(self):
+        result = resolve_scope(
+            None, self._client(), self.VOCAB, True,
+            default_when_omitted="openid", validate_only=True,
+        )
+        assert result.ok
+        assert result.granted is None
+
+    def test_validate_only_still_validates_a_present_scope(self):
+        result = resolve_scope("email", self._client(["openid"]), self.VOCAB, True, validate_only=True)
+        assert not result.ok
+
+    def test_validate_only_accepts_a_present_allowed_scope(self):
+        result = resolve_scope("openid", self._client(["openid"]), self.VOCAB, True, validate_only=True)
+        assert result.ok
+        assert result.granted == "openid"
+
+    def test_validate_only_enforcement_off_passes_through(self):
+        result = resolve_scope(None, self._client(["openid"]), self.VOCAB, False, validate_only=True)
+        assert result.ok
+        assert result.granted is None
+
 
 class TestDiscoveryScopesSupported:
     def test_reflects_settings(self):
@@ -362,3 +392,94 @@ class TestScopeEnforcementOffEscapeHatch:
         )
         assert response.status_code == 200
         assert json.loads(response.data)["scope"] == "anything-goes"
+
+
+class TestRefreshTokenScopeReValidation:
+    """The refresh grant's own coverage (#186 review: previously untested).
+
+    resolve_scope() is called twice on this path: the existing
+    narrow-only-never-widen check (unchanged logic, now RFC-shaped errors),
+    then a re-validation against the CURRENT vocabulary/allowed_scopes via
+    validate_only=True (B1 fix) - an absent original scope must stay absent
+    rather than being defaulted to the client's current allowed set.
+    """
+
+    def _password_grant(self, client, scope=None):
+        data = {"grant_type": "password", "username": "admin", "password": "admin"}
+        if scope is not None:
+            data["scope"] = scope
+        resp = client.post("/token", data=data, headers=SCOPED_AUTH)
+        assert resp.status_code == 200
+        return json.loads(resp.data)
+
+    def test_legacy_no_scope_refresh_token_does_not_widen(self, client, app):
+        """B1 repro: a refresh token minted with no scope at all (enforcement
+        off at issuance - the pre-#186 world, or any token minted before
+        allowed_scopes was set) must refresh to another no-scope token, not
+        the client's current full allowed set - and must never mint an
+        ID Token that the original (scopeless) grant never had."""
+        with app.app_context():
+            get_config().settings.scope_enforcement = False
+        minted = self._password_grant(client)
+        assert "scope" not in minted
+        assert "id_token" not in minted
+        refresh_token = minted["refresh_token"]
+
+        with app.app_context():
+            get_config().settings.scope_enforcement = True
+
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+            headers=SCOPED_AUTH,
+        )
+        assert resp.status_code == 200
+        refreshed = json.loads(resp.data)
+        assert "scope" not in refreshed
+        assert "id_token" not in refreshed
+
+    def test_narrowing_rejection_is_rfc_shaped_invalid_scope(self, client):
+        """The pre-#186 narrowing check ('exceeds originally granted scope')
+        now answers with the RFC 6749 5.2 JSON error body, not a bare 400."""
+        minted = self._password_grant(client, scope="openid")
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": minted["refresh_token"],
+                "scope": "openid profile",
+            },
+            headers=SCOPED_AUTH,
+        )
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data["error"] == "invalid_scope"
+        assert "error_description" in data
+
+    def test_revalidation_rejects_scope_no_longer_allowed(self, client, app):
+        """The original grant was valid at the time; allowed_scopes shrank
+        since (an operator edit) - the re-check must catch it on refresh,
+        even though the client didn't request anything new."""
+        minted = self._password_grant(client, scope="openid")
+
+        with app.app_context():
+            get_config().get_client("scoped-client").allowed_scopes = ["profile"]
+
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": minted["refresh_token"]},
+            headers=SCOPED_AUTH,
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_scope"
+
+    def test_revalidation_accepts_still_allowed_scope(self, client):
+        """Sanity: the re-check doesn't reject a refresh that's still fine."""
+        minted = self._password_grant(client, scope="openid")
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": minted["refresh_token"]},
+            headers=SCOPED_AUTH,
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.data)["scope"] == "openid"

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -1,0 +1,364 @@
+"""
+Tests for per-client allowed scopes and invalid_scope enforcement (issue #186).
+
+Before this, /authorize and /token accepted any scope string unchecked: a
+client could obtain 'admin' just by asking. oauth.scopes_supported is the
+global vocabulary; OAuthClient.allowed_scopes is an optional per-client
+subset of it. A requested scope outside the vocabulary is invalid_scope for
+every client; outside a client's own allowed_scopes (when set) it is
+invalid_scope for that client specifically. scope_enforcement (dev-only) is
+the escape hatch back to the old, unchecked behavior.
+
+The shipped config/settings.yaml carries a 'scoped-client' restricted to
+['openid', 'profile'] and the pre-existing 'demo-client' (unrestricted),
+used throughout via the `client`/`app` fixtures (isolated_repo_config copies
+config/ per test, so mutating either client's YAML entry never touches the
+real one).
+"""
+
+import base64
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from nanoidp.config import ConfigManager, OAuthClient, Settings, get_config
+from nanoidp.services.discovery import build_discovery_document
+from nanoidp.services.scope import resolve_scope
+
+
+def _basic_auth(client_id: str, secret: str) -> dict:
+    credentials = base64.b64encode(f"{client_id}:{secret}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+SCOPED_AUTH = _basic_auth("scoped-client", "scoped-secret")
+
+
+class TestOAuthClientAllowedScopes:
+    def test_default_is_empty_unrestricted(self):
+        assert OAuthClient(client_id="c", client_secret="s").allowed_scopes == []
+
+    def test_explicit_list_is_kept(self):
+        client = OAuthClient(client_id="c", client_secret="s", allowed_scopes=["openid", "profile"])
+        assert client.allowed_scopes == ["openid", "profile"]
+
+
+class TestSettingsScopeFields:
+    def test_scopes_supported_default(self):
+        assert Settings().scopes_supported == ["openid", "profile", "email", "offline_access"]
+
+    def test_scope_enforcement_default_on(self):
+        assert Settings().scope_enforcement_active is True
+
+    def test_scope_enforcement_off_in_dev(self):
+        s = Settings(security_profile="dev", scope_enforcement=False)
+        assert s.scope_enforcement_active is False
+
+    def test_scope_enforcement_off_forced_on_under_stricter_dev(self):
+        """The raw flag can say off, but stricter-dev/oauth21 always enforce -
+        the same 'raw field OR profile decides' shape as pkce_required, just
+        force-ENABLING instead of force-relaxing."""
+        s = Settings(security_profile="stricter-dev", scope_enforcement=False)
+        assert s.scope_enforcement_active is True
+
+    def test_scope_enforcement_off_forced_on_under_oauth21(self):
+        s = Settings(security_profile="oauth21", scope_enforcement=False)
+        assert s.scope_enforcement_active is True
+
+    def test_unknown_security_profile_still_rejected(self):
+        """Sanity: adding scope_enforcement_active didn't disturb the existing validator."""
+        with pytest.raises(ValidationError):
+            Settings(security_profile="not-a-profile")
+
+
+class TestResolveScopeHelper:
+    """Direct unit tests of services.scope.resolve_scope - the shared logic
+    behind every /authorize, /token and /device_authorization check."""
+
+    VOCAB = ["openid", "profile", "email"]
+
+    def _client(self, allowed=None):
+        return OAuthClient(client_id="c", client_secret="s", allowed_scopes=allowed or [])
+
+    def test_enforcement_off_passes_anything_through(self):
+        result = resolve_scope("admin nonsense", self._client(), self.VOCAB, False)
+        assert result.ok
+        assert result.granted == "admin nonsense"
+
+    def test_enforcement_off_ignores_allowed_scopes_even_when_set(self):
+        result = resolve_scope("admin", self._client(["openid"]), self.VOCAB, False)
+        assert result.ok
+        assert result.granted == "admin"
+
+    def test_enforcement_off_omitted_uses_default(self):
+        result = resolve_scope(None, self._client(), self.VOCAB, False, default_when_omitted="openid")
+        assert result.granted == "openid"
+
+    def test_unrestricted_client_any_vocabulary_scope_allowed(self):
+        result = resolve_scope("openid email", self._client(), self.VOCAB, True)
+        assert result.ok
+        assert result.granted == "openid email"
+
+    def test_scope_outside_global_vocabulary_rejected_for_every_client(self):
+        result = resolve_scope("admin", self._client(), self.VOCAB, True)
+        assert not result.ok
+        assert "admin" in result.error_description
+        assert result.granted is None
+
+    def test_scope_outside_global_vocabulary_rejected_even_when_client_allows_it(self):
+        """A client's own allow-list can never widen the global vocabulary."""
+        result = resolve_scope("admin", self._client(["admin"]), self.VOCAB, True)
+        assert not result.ok
+
+    def test_scope_outside_client_allowed_scopes_rejected(self):
+        result = resolve_scope("email", self._client(["openid"]), self.VOCAB, True)
+        assert not result.ok
+        assert "email" in result.error_description
+
+    def test_scope_within_client_allowed_scopes_accepted(self):
+        result = resolve_scope("openid", self._client(["openid", "profile"]), self.VOCAB, True)
+        assert result.ok
+        assert result.granted == "openid"
+
+    def test_omitted_scope_restricted_client_defaults_to_full_allowed_set(self):
+        result = resolve_scope(None, self._client(["openid", "profile"]), self.VOCAB, True)
+        assert result.ok
+        assert result.granted == "openid profile"
+
+    def test_omitted_scope_unrestricted_client_uses_default_when_omitted(self):
+        result = resolve_scope(None, self._client(), self.VOCAB, True, default_when_omitted="openid")
+        assert result.ok
+        assert result.granted == "openid"
+
+    def test_omitted_scope_unrestricted_client_no_default_is_none(self):
+        result = resolve_scope(None, self._client(), self.VOCAB, True)
+        assert result.ok
+        assert result.granted is None
+
+
+class TestDiscoveryScopesSupported:
+    def test_reflects_settings(self):
+        settings = Settings(scopes_supported=["openid", "custom"])
+        doc = build_discovery_document(settings)
+        assert doc["scopes_supported"] == ["openid", "custom"]
+
+    def test_default_matches_prior_hardcoded_list(self):
+        doc = build_discovery_document(Settings())
+        assert doc["scopes_supported"] == ["openid", "profile", "email", "offline_access"]
+
+
+class TestYamlLoadAllowedScopes:
+    def test_scoped_client_loads_from_shipped_config(self, app):
+        with app.app_context():
+            client = get_config().get_client("scoped-client")
+        assert client is not None
+        assert client.allowed_scopes == ["openid", "profile"]
+
+    def test_scalar_allowed_scopes_coerced_to_list(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "settings.yaml").write_text(
+            'oauth:\n'
+            '  issuer: "http://localhost:8000"\n'
+            '  audience: "my-app"\n'
+            '  clients:\n'
+            '    - client_id: "c1"\n'
+            '      client_secret: "s1"\n'
+            '      allowed_scopes: "openid"\n'
+        )
+        (config_dir / "users.yaml").write_text(
+            'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+        )
+        config = ConfigManager(str(config_dir))
+        assert config.get_client("c1").allowed_scopes == ["openid"]
+
+
+class TestAuthorizeScopeEnforcement:
+    REGISTERED_URI = "http://localhost:3000/callback"
+
+    def _authorize(self, client, client_id, **extra):
+        params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": self.REGISTERED_URI,
+            **extra,
+        }
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return client.get(f"/authorize?{query}")
+
+    def test_disallowed_scope_is_invalid_scope(self, client):
+        response = self._authorize(client, "scoped-client", scope="email")
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data["error"] == "invalid_scope"
+
+    def test_allowed_scope_gets_login_page(self, client):
+        response = self._authorize(client, "scoped-client", scope="openid")
+        assert response.status_code == 200
+
+    def test_unrestricted_client_any_vocabulary_scope_allowed(self, client):
+        response = self._authorize(client, "demo-client", scope="offline_access")
+        assert response.status_code == 200
+
+    def test_scope_outside_global_vocabulary_rejected_for_unrestricted_client(self, client):
+        response = self._authorize(client, "demo-client", scope="admin")
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data["error"] == "invalid_scope"
+
+    def test_omitted_scope_on_restricted_client_defaults_to_full_allowed_set(self, client):
+        """No 'scope' param at all - a bare login page, not an error."""
+        response = client.get(
+            f"/authorize?response_type=code&client_id=scoped-client"
+            f"&redirect_uri={self.REGISTERED_URI}"
+        )
+        assert response.status_code == 200
+
+
+class TestTokenScopeEnforcement:
+    def test_client_credentials_disallowed_scope_rejected(self, client):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "email"},
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 400
+        assert json.loads(response.data)["error"] == "invalid_scope"
+
+    def test_client_credentials_allowed_scope_accepted(self, client):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "profile"},
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["scope"] == "profile"
+
+    def test_client_credentials_unrestricted_client_vocabulary_scope_accepted(self, client, auth_header):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "email"},
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["scope"] == "email"
+
+    def test_client_credentials_scope_outside_vocabulary_rejected(self, client, auth_header):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "admin"},
+            headers=auth_header,
+        )
+        assert response.status_code == 400
+        assert json.loads(response.data)["error"] == "invalid_scope"
+
+    def test_password_grant_disallowed_scope_rejected(self, client):
+        response = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "email",
+            },
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 400
+        assert json.loads(response.data)["error"] == "invalid_scope"
+
+    def test_password_grant_allowed_scope_accepted(self, client):
+        response = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "openid profile",
+            },
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["scope"] == "openid profile"
+
+
+class TestDeviceAuthorizationScopeEnforcement:
+    def test_disallowed_scope_rejected(self, client):
+        response = client.post(
+            "/device_authorization",
+            data={"scope": "email"},
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 400
+        assert json.loads(response.data)["error"] == "invalid_scope"
+
+    def test_allowed_scope_accepted(self, client):
+        response = client.post(
+            "/device_authorization",
+            data={"scope": "profile"},
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 200
+        assert "device_code" in json.loads(response.data)
+
+
+class TestClientCredentialsOpenidNeverMintsIdToken:
+    """#186 review: create_token()'s ID Token issuance is grant-agnostic
+    (any grant with 'openid' in scope gets one), but client_credentials has
+    no end-user context. 'openid' is accepted (it's vocabulary-listed) but
+    silently dropped from what's actually granted, preserving this grant's
+    pre-#186 behavior (see tests/test_id_token_grants.py)."""
+
+    def test_openid_accepted_but_no_id_token(self, client, auth_header):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "openid"},
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "id_token" not in data
+
+    def test_openid_stripped_but_siblings_kept(self, client, auth_header):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "openid profile"},
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "id_token" not in data
+        assert data["scope"] == "profile"
+
+
+class TestScopeEnforcementOffEscapeHatch:
+    """oauth.scope_enforcement: false (dev-only) restores pre-#186 behavior:
+    any scope string is accepted, unchecked."""
+
+    @pytest.fixture
+    def enforcement_off(self, app):
+        with app.app_context():
+            settings = get_config().settings
+            settings.scope_enforcement = False
+        yield settings
+        settings.scope_enforcement = True
+
+    def test_previously_invalid_scope_now_accepted(self, client, enforcement_off, auth_header):
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "admin nonsense"},
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["scope"] == "admin nonsense"
+
+    def test_restricted_client_allow_list_not_consulted(self, client, enforcement_off):
+        """scoped-client's allowed_scopes (['openid', 'profile']) has no effect
+        while enforcement is off - not even for defaulting an omitted scope."""
+        response = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "scope": "anything-goes"},
+            headers=SCOPED_AUTH,
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["scope"] == "anything-goes"


### PR DESCRIPTION
…es_supported`

  is the global scope vocabulary (default `openid`, `profile`, `email`,
  `offline_access`, also what discovery's `scopes_supported` now advertises
  instead of a hardcoded list); a client's new `allowed_scopes` is an
  optional subset of it. A requested scope outside the vocabulary is
  `invalid_scope` for every client - a small behavior change, since any
  scope string used to be accepted unchecked; a scope outside a client's own
  `allowed_scopes`, when set, is `invalid_scope` for that client
  specifically. Enforced at `/authorize`, every `/token` grant (including
  `client_credentials`, RFC 6749 §4.4, which previously dropped any
  requested scope entirely) and `/device_authorization`; an omitted `scope`
  defaults to the client's full allowed set, or today's default when
  unrestricted. Every `/token` rejection - including the pre-existing
  refresh-token scope-narrowing check - now returns the RFC 6749 §5.2 JSON
  error shape (`{"error": "invalid_scope", ...}`) instead of a bare 400.
  `oauth.scope_enforcement: false` is a dev-only escape hatch back to the
  pre-#186 behavior (any scope string accepted, unchecked); refused outside
  the `dev` profile. `allowed_scopes` is settable from the clients UI form
  and the MCP `create_client`/`update_client` tools, same as
  `additional_audiences`/`redirect_uris`.