### PR TITLE
refactor: extract the /authorize and SAML /sso pipelines into named steps (#212)

### DIFF
--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 import jwt as pyjwt
@@ -25,7 +25,7 @@ from flask import (
 from flask.typing import ResponseReturnValue
 
 from ..branding import effective_logos_dir, resolve_client_logo
-from ..config import ConfigManager, User, get_config
+from ..config import ConfigManager, OAuthClient, User, get_config
 from ..services import (
     DevicePollOutcome,
     DeviceVerifyOutcome,
@@ -80,16 +80,12 @@ def _parse_claims_parameter(raw: Optional[str]) -> Optional[Dict[str, list]]:
     return result or None
 
 
-
-
 @oauth_bp.route("/.well-known/openid-configuration")
 def oidc_config() -> ResponseReturnValue:
     """OIDC Discovery endpoint."""
     config = get_config()
     return jsonify(
-        build_discovery_document(
-            config.settings, issuer=effective_issuer(config.settings)
-        )
+        build_discovery_document(config.settings, issuer=effective_issuer(config.settings))
     )
 
 
@@ -102,6 +98,346 @@ def jwks() -> ResponseReturnValue:
     config = get_config()
     crypto = get_crypto_service(config.settings.keys_dir)
     return jsonify(crypto.get_jwks())
+
+
+@dataclass
+class _AuthorizeParams:
+    """The nine /authorize request parameters, read once per request.
+
+    On GET they come from the query string; on the login-form POST leg they
+    come from the form with the session as fallback (the GET leg stored them
+    there). ``scope`` starts as the raw request value and is replaced by the
+    resolved/granted value once _validate_authorize_scope has run.
+    """
+
+    response_type: str
+    client_id: str
+    redirect_uri: str
+    scope: str
+    state: str
+    code_challenge: str
+    code_challenge_method: str
+    nonce: str
+    claims_param: str
+
+
+def _read_authorize_params() -> _AuthorizeParams:
+    """Extract the request parameters and persist them for the POST leg.
+
+    Storing on GET happens before any validation, exactly as it always has:
+    an invalid request still leaves its parameters in the session, and the
+    login POST leg re-validates everything from scratch.
+    """
+    params = request.args if request.method == "GET" else request.form
+
+    p = _AuthorizeParams(
+        response_type=params.get("response_type", session.get("oauth_response_type", "")),
+        client_id=params.get("client_id", session.get("oauth_client_id", "")),
+        redirect_uri=params.get("redirect_uri", session.get("oauth_redirect_uri", "")),
+        scope=params.get("scope", session.get("oauth_scope", "")),
+        state=params.get("state", session.get("oauth_state", "")),
+        code_challenge=params.get("code_challenge", session.get("oauth_code_challenge", "")),
+        code_challenge_method=params.get(
+            "code_challenge_method", session.get("oauth_code_challenge_method", "")
+        ),
+        nonce=params.get("nonce", session.get("oauth_nonce", "")),
+        claims_param=params.get("claims", session.get("oauth_claims", "")),
+    )
+
+    if request.method == "GET":
+        session["oauth_response_type"] = p.response_type
+        session["oauth_client_id"] = p.client_id
+        session["oauth_redirect_uri"] = p.redirect_uri
+        session["oauth_scope"] = p.scope
+        session["oauth_state"] = p.state
+        session["oauth_code_challenge"] = p.code_challenge
+        session["oauth_code_challenge_method"] = p.code_challenge_method
+        session["oauth_nonce"] = p.nonce
+        session["oauth_claims"] = p.claims_param
+
+    return p
+
+
+def _authorize_reject(
+    client_id: str, reason: str, error: str, description: str
+) -> ResponseReturnValue:
+    """Audit-then-reject, the shape every post-client-lookup check shares.
+
+    The pre-lookup checks (response_type, missing client_id/redirect_uri,
+    redirect_uri syntax) intentionally do NOT audit - they never have - so
+    they build their responses directly instead of calling this.
+    """
+    audit_event(
+        "authorization_request",
+        "failed",
+        endpoint="/authorize",
+        client_id=client_id,
+        details={"reason": reason},
+    )
+    return jsonify({"error": error, "error_description": description}), 400
+
+
+def _validate_authorize_client(
+    config: ConfigManager, p: _AuthorizeParams
+) -> Tuple[Optional[OAuthClient], Optional[ResponseReturnValue]]:
+    """Required-parameter checks and client lookup: (client, None) or (None, error)."""
+    if p.response_type != "code":
+        return None, (
+            jsonify(
+                {
+                    "error": "unsupported_response_type",
+                    "error_description": "Only 'code' response_type is supported",
+                }
+            ),
+            400,
+        )
+
+    if not p.client_id:
+        return None, (
+            jsonify({"error": "invalid_request", "error_description": "client_id is required"}),
+            400,
+        )
+
+    if not p.redirect_uri:
+        return None, (
+            jsonify({"error": "invalid_request", "error_description": "redirect_uri is required"}),
+            400,
+        )
+
+    client = config.get_client(p.client_id)
+    if not client:
+        return None, _authorize_reject(
+            p.client_id, "Unknown client", "invalid_client", "Unknown client_id"
+        )
+    return client, None
+
+
+def _validate_authorize_scope(
+    config: ConfigManager, p: _AuthorizeParams, client: OAuthClient
+) -> Optional[ResponseReturnValue]:
+    """Scope validation (issue #186): a requested scope outside the global
+    vocabulary, or outside this client's own allowed_scopes when set, is
+    invalid_scope (RFC 6749 §4.1.2.1). An omitted scope defaults to the
+    client's full allowed set when restricted, or "openid" as before (#186).
+    Checked before redirect_uri so an invalid_scope on an unregistered client
+    reports the more specific problem first. Mutates p.scope to the granted
+    value on success."""
+    scope_result = resolve_scope(
+        p.scope,
+        client,
+        config.settings.scopes_supported,
+        config.settings.scope_enforcement_active,
+        default_when_omitted="openid",
+    )
+    if not scope_result.ok:
+        return _authorize_reject(
+            p.client_id,
+            scope_result.error_description or "invalid scope",
+            "invalid_scope",
+            scope_result.error_description or "invalid scope",
+        )
+    p.scope = scope_result.granted or ""
+    return None
+
+
+def _validate_authorize_redirect_uri(
+    config: ConfigManager, p: _AuthorizeParams, client: OAuthClient
+) -> Optional[ResponseReturnValue]:
+    """The three redirect_uri checks, in their historical order.
+
+    Syntactic validation (RFC 6749 §3.1.2): an absolute URI with no
+    fragment. A scheme is required; an authority is not, so native-app
+    private-use scheme URIs like com.example.app:/oauth2redirect (RFC 8252
+    §7.1) pass (#81), while a private-use scheme without a period (myapp://)
+    is rejected per §7.1's minimum rule. See services/redirect_uri.py.
+
+    Matching against registered redirect URIs (issue #67). RFC 6749
+    §3.1.2.3 / OAuth 2.1 §4.1.1 require simple string comparison - no
+    prefix, host or path normalization - with the single exception RFC
+    8252 §7.3 mandates for native apps: a registered loopback URI
+    (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any
+    port (#81). Clients without registered URIs keep the permissive dev
+    behavior (hardening is opt-in, principle 3). A mismatch MUST NOT
+    redirect (§3.1.2.4): the error is returned directly, never sent to
+    the unvalidated URI.
+
+    Under the oauth21 profile, registration is not optional: a client used
+    at /authorize must have redirect_uris pinned (#68; OAuth 2.1 §2.3
+    requires the AS to compare against registered values, which presumes
+    they exist). Enforced here, not at config load, so other grants keep
+    working for unregistered clients.
+    """
+    rejection = redirect_uri_rejection_reason(p.redirect_uri)
+    if rejection is not None:
+        return jsonify({"error": "invalid_request", "error_description": rejection}), 400
+
+    if client.redirect_uris and not redirect_uri_is_registered(
+        p.redirect_uri, client.redirect_uris
+    ):
+        return _authorize_reject(
+            p.client_id,
+            "redirect_uri not registered for client",
+            "invalid_request",
+            "redirect_uri is not registered for this client",
+        )
+
+    if config.settings.security_profile == "oauth21" and not client.redirect_uris:
+        return _authorize_reject(
+            p.client_id,
+            "oauth21 profile requires registered redirect_uris",
+            "invalid_request",
+            "the oauth21 profile requires this client to have " "registered redirect_uris",
+        )
+    return None
+
+
+def _validate_authorize_pkce(
+    config: ConfigManager, p: _AuthorizeParams
+) -> Optional[ResponseReturnValue]:
+    """PKCE enforcement (issues #47, #68). Via the require_pkce setting (on by
+    default in the stricter-dev profile) or implied by the oauth21 profile
+    (OAuth 2.1 §4.1.1 makes PKCE mandatory), an authorization request
+    without a code_challenge is rejected, so developers can verify their
+    client actually sends PKCE."""
+    if config.settings.pkce_required and not p.code_challenge:
+        return _authorize_reject(
+            p.client_id,
+            "PKCE code_challenge required (require_pkce or oauth21)",
+            "invalid_request",
+            "PKCE code_challenge is required " "(require_pkce setting or oauth21 profile)",
+        )
+
+    if not p.code_challenge:
+        return None
+
+    # RFC 7636 §4.3: an omitted code_challenge_method defaults to 'plain',
+    # and the verifier honors that - so the method must be normalized
+    # BEFORE validation or the stricter-dev rejection could be bypassed by
+    # simply omitting the parameter (#56). Unsupported methods are
+    # rejected at the authorization endpoint per §4.4.1.
+    effective_method = p.code_challenge_method or "plain"
+    if effective_method not in ("plain", "S256"):
+        return _authorize_reject(
+            p.client_id,
+            f"Unsupported code_challenge_method: {effective_method}",
+            "invalid_request",
+            f"Unsupported code_challenge_method " f"'{effective_method}'; use S256 or plain",
+        )
+
+    # The 'plain' method is only acceptable when S256 is unavailable
+    # (RFC 7636 §4.2); the stricter-dev (#47) and oauth21 (#68, OAuth 2.1
+    # §7.5.2) profiles reject it outright, whether requested explicitly
+    # or via the implicit default.
+    if effective_method == "plain" and not config.settings.pkce_plain_allowed:
+        return _authorize_reject(
+            p.client_id,
+            "PKCE method 'plain' rejected by " f"{config.settings.security_profile} profile",
+            "invalid_request",
+            "code_challenge_method 'plain' (including the "
+            "implicit default when the parameter is omitted) "
+            f"is not allowed by the {config.settings.security_profile} "
+            "profile; use S256",
+        )
+    return None
+
+
+def _handle_authorize_login(
+    config: ConfigManager, p: _AuthorizeParams
+) -> Tuple[Optional[str], Optional[ResponseReturnValue]]:
+    """The POST login leg: (None, redirect) on success, (error_msg, None) to
+    fall through to the login page (failed or incomplete credentials)."""
+    username = request.form.get("username", "").strip()
+    password = request.form.get("password", "")
+    persona_mode = config.settings.persona_mode_enabled
+
+    user = config.interactive_authenticate(username, password)
+
+    if user:
+        # Authentication successful - generate authorization code
+        auth_code_store = get_auth_code_store()
+        code = auth_code_store.create_code(
+            client_id=p.client_id,
+            redirect_uri=p.redirect_uri,
+            username=user.username,
+            scope=p.scope,
+            code_challenge=p.code_challenge if p.code_challenge else None,
+            code_challenge_method=p.code_challenge_method if p.code_challenge_method else None,
+            nonce=p.nonce if p.nonce else None,
+            state=p.state if p.state else None,
+            claims=_parse_claims_parameter(p.claims_param),
+        )
+
+        # Clear OAuth session data
+        for key in list(session.keys()):
+            if key.startswith("oauth_"):
+                session.pop(key, None)
+
+        # Build redirect URL with code
+        redirect_params = {"code": code}
+        if p.state:
+            redirect_params["state"] = p.state
+
+        callback_url = f"{p.redirect_uri}?{urlencode(redirect_params)}"
+
+        audit_event(
+            "authorization_request",
+            "success",
+            endpoint="/authorize",
+            username=user.username,
+            client_id=p.client_id,
+            details={
+                "scope": p.scope,
+                "pkce": bool(p.code_challenge),
+            },
+        )
+
+        if config.settings.verbose_logging:
+            logger.info(
+                f"Authorization code issued for user '{user.username}', client '{p.client_id}'"
+            )
+        else:
+            logger.info("Authorization code issued")
+
+        return None, redirect(callback_url)
+
+    if (persona_mode and username) or (not persona_mode and username and password):
+        # A real (failed) selection/login attempt, not just missing input
+        audit_event(
+            "authorization_request",
+            "failed",
+            endpoint="/authorize",
+            username=username,
+            client_id=p.client_id,
+            details={"reason": "Invalid credentials"},
+        )
+        return "Invalid username or password", None
+
+    return ("Select a user" if persona_mode else "Username and password are required"), None
+
+
+def _render_authorize_login(
+    config: ConfigManager,
+    p: _AuthorizeParams,
+    client: Optional[OAuthClient],
+    error_msg: Optional[str],
+) -> ResponseReturnValue:
+    """The login page (GET, or a POST that did not authenticate)."""
+    logo_url = None
+    if client:
+        logos_dir = effective_logos_dir(config.settings.logos_dir, current_app.static_folder)
+        if resolve_client_logo(logos_dir, client.client_id):
+            logo_url = url_for("oauth.client_logo", client_id=client.client_id)
+
+    return render_template(
+        "authorize.html",
+        client_id=p.client_id,
+        client=client,
+        logo_url=logo_url,
+        scope=p.scope,
+        error=error_msg,
+        persona_mode=config.settings.persona_mode_enabled,
+        users=list(config.users.keys()),
+    )
 
 
 @oauth_bp.route("/authorize", methods=["GET", "POST"])
@@ -124,306 +460,35 @@ def authorize() -> ResponseReturnValue:
     - code_challenge: PKCE challenge
     - code_challenge_method: "plain" or "S256"
     - nonce: OIDC nonce for ID token
+
+    Each step below is a named helper; every rejection keeps its historical
+    error body and audit behavior (#212).
     """
     config = get_config()
+    p = _read_authorize_params()
 
-    # Get OAuth parameters (from query string for GET, form for POST)
-    if request.method == "GET":
-        params = request.args
-    else:
-        # For POST, check form first, then fall back to session
-        params = request.form
+    client, error = _validate_authorize_client(config, p)
+    if error is not None:
+        return error
+    assert client is not None  # _validate_authorize_client returns one or the other
 
-    response_type = params.get("response_type", session.get("oauth_response_type", ""))
-    client_id = params.get("client_id", session.get("oauth_client_id", ""))
-    redirect_uri = params.get("redirect_uri", session.get("oauth_redirect_uri", ""))
-    scope = params.get("scope", session.get("oauth_scope", ""))
-    state = params.get("state", session.get("oauth_state", ""))
-    code_challenge = params.get("code_challenge", session.get("oauth_code_challenge", ""))
-    code_challenge_method = params.get("code_challenge_method", session.get("oauth_code_challenge_method", ""))
-    nonce = params.get("nonce", session.get("oauth_nonce", ""))
-    claims_param = params.get("claims", session.get("oauth_claims", ""))
-
-    # Store OAuth params in session for POST handling
-    if request.method == "GET":
-        session["oauth_response_type"] = response_type
-        session["oauth_client_id"] = client_id
-        session["oauth_redirect_uri"] = redirect_uri
-        session["oauth_scope"] = scope
-        session["oauth_state"] = state
-        session["oauth_code_challenge"] = code_challenge
-        session["oauth_code_challenge_method"] = code_challenge_method
-        session["oauth_nonce"] = nonce
-        session["oauth_claims"] = claims_param
-
-    # Validate required parameters
-    if response_type != "code":
-        return jsonify({
-            "error": "unsupported_response_type",
-            "error_description": "Only 'code' response_type is supported"
-        }), 400
-
-    if not client_id:
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "client_id is required"
-        }), 400
-
-    if not redirect_uri:
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "redirect_uri is required"
-        }), 400
-
-    # Validate client exists
-    client = config.get_client(client_id)
-    if not client:
-        audit_event(
-            "authorization_request",
-            "failed",
-            endpoint="/authorize",
-            client_id=client_id,
-            details={"reason": "Unknown client"},
-        )
-        return jsonify({
-            "error": "invalid_client",
-            "error_description": "Unknown client_id"
-        }), 400
-
-    # Scope validation (issue #186): a requested scope outside the global
-    # vocabulary, or outside this client's own allowed_scopes when set, is
-    # invalid_scope (RFC 6749 §4.1.2.1). An omitted scope defaults to the
-    # client's full allowed set when restricted, or "openid" as before
-    # (#186). Checked before redirect_uri so an invalid_scope on an
-    # unregistered client reports the more specific problem first.
-    scope_result = resolve_scope(
-        scope,
-        client,
-        config.settings.scopes_supported,
-        config.settings.scope_enforcement_active,
-        default_when_omitted="openid",
-    )
-    if not scope_result.ok:
-        audit_event(
-            "authorization_request",
-            "failed",
-            endpoint="/authorize",
-            client_id=client_id,
-            details={"reason": scope_result.error_description},
-        )
-        return jsonify({
-            "error": "invalid_scope",
-            "error_description": scope_result.error_description
-        }), 400
-    scope = scope_result.granted or ""
-
-    # Syntactic validation (RFC 6749 §3.1.2): an absolute URI with no
-    # fragment. A scheme is required; an authority is not, so native-app
-    # private-use scheme URIs like com.example.app:/oauth2redirect (RFC 8252
-    # §7.1) pass (#81), while a private-use scheme without a period (myapp://)
-    # is rejected per §7.1's minimum rule. See services/redirect_uri.py.
-    rejection = redirect_uri_rejection_reason(redirect_uri)
-    if rejection is not None:
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": rejection
-        }), 400
-
-    # Matching against registered redirect URIs (issue #67). RFC 6749
-    # §3.1.2.3 / OAuth 2.1 §4.1.1 require simple string comparison - no
-    # prefix, host or path normalization - with the single exception RFC
-    # 8252 §7.3 mandates for native apps: a registered loopback URI
-    # (http://127.0.0.1:{port}/..., http://[::1]:{port}/...) matches any
-    # port (#81). Clients without registered URIs keep the permissive dev
-    # behavior (hardening is opt-in, principle 3). A mismatch MUST NOT
-    # redirect (§3.1.2.4): the error is returned directly, never sent to
-    # the unvalidated URI.
-    if client.redirect_uris and not redirect_uri_is_registered(
-        redirect_uri, client.redirect_uris
-    ):
-        audit_event(
-            "authorization_request",
-            "failed",
-            endpoint="/authorize",
-            client_id=client_id,
-            details={"reason": "redirect_uri not registered for client"},
-        )
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "redirect_uri is not registered for this client"
-        }), 400
-
-    # Under the oauth21 profile, registration is not optional: a client used
-    # at /authorize must have redirect_uris pinned (#68; OAuth 2.1 §2.3
-    # requires the AS to compare against registered values, which presumes
-    # they exist). Enforced here, not at config load, so other grants keep
-    # working for unregistered clients.
-    if config.settings.security_profile == "oauth21" and not client.redirect_uris:
-        audit_event(
-            "authorization_request",
-            "failed",
-            endpoint="/authorize",
-            client_id=client_id,
-            details={"reason": "oauth21 profile requires registered redirect_uris"},
-        )
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "the oauth21 profile requires this client to have "
-                                 "registered redirect_uris"
-        }), 400
-
-    # PKCE enforcement (issues #47, #68). Via the require_pkce setting (on by
-    # default in the stricter-dev profile) or implied by the oauth21 profile
-    # (OAuth 2.1 §4.1.1 makes PKCE mandatory), an authorization request
-    # without a code_challenge is rejected, so developers can verify their
-    # client actually sends PKCE.
-    if config.settings.pkce_required and not code_challenge:
-        audit_event(
-            "authorization_request",
-            "failed",
-            endpoint="/authorize",
-            client_id=client_id,
-            details={"reason": "PKCE code_challenge required (require_pkce or oauth21)"},
-        )
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "PKCE code_challenge is required "
-                                 "(require_pkce setting or oauth21 profile)"
-        }), 400
-
-    if code_challenge:
-        # RFC 7636 §4.3: an omitted code_challenge_method defaults to 'plain',
-        # and the verifier honors that - so the method must be normalized
-        # BEFORE validation or the stricter-dev rejection could be bypassed by
-        # simply omitting the parameter (#56). Unsupported methods are
-        # rejected at the authorization endpoint per §4.4.1.
-        effective_method = code_challenge_method or "plain"
-        if effective_method not in ("plain", "S256"):
-            audit_event(
-                "authorization_request",
-                "failed",
-                endpoint="/authorize",
-                client_id=client_id,
-                details={"reason": f"Unsupported code_challenge_method: {effective_method}"},
-            )
-            return jsonify({
-                "error": "invalid_request",
-                "error_description": f"Unsupported code_challenge_method "
-                                     f"'{effective_method}'; use S256 or plain"
-            }), 400
-
-        # The 'plain' method is only acceptable when S256 is unavailable
-        # (RFC 7636 §4.2); the stricter-dev (#47) and oauth21 (#68, OAuth 2.1
-        # §7.5.2) profiles reject it outright, whether requested explicitly
-        # or via the implicit default.
-        if (
-            effective_method == "plain"
-            and not config.settings.pkce_plain_allowed
-        ):
-            audit_event(
-                "authorization_request",
-                "failed",
-                endpoint="/authorize",
-                client_id=client_id,
-                details={
-                    "reason": "PKCE method 'plain' rejected by "
-                    f"{config.settings.security_profile} profile"
-                },
-            )
-            return jsonify({
-                "error": "invalid_request",
-                "error_description": "code_challenge_method 'plain' (including the "
-                                     "implicit default when the parameter is omitted) "
-                                     f"is not allowed by the {config.settings.security_profile} "
-                                     "profile; use S256"
-            }), 400
+    error = _validate_authorize_scope(config, p, client)
+    if error is not None:
+        return error
+    error = _validate_authorize_redirect_uri(config, p, client)
+    if error is not None:
+        return error
+    error = _validate_authorize_pkce(config, p)
+    if error is not None:
+        return error
 
     error_msg = None
-    persona_mode = config.settings.persona_mode_enabled
-
-    # Handle POST (login form submission)
     if request.method == "POST":
-        username = request.form.get("username", "").strip()
-        password = request.form.get("password", "")
+        error_msg, response = _handle_authorize_login(config, p)
+        if response is not None:
+            return response
 
-        user = config.interactive_authenticate(username, password)
-
-        if user:
-            # Authentication successful - generate authorization code
-            auth_code_store = get_auth_code_store()
-            code = auth_code_store.create_code(
-                client_id=client_id,
-                redirect_uri=redirect_uri,
-                username=user.username,
-                scope=scope,
-                code_challenge=code_challenge if code_challenge else None,
-                code_challenge_method=code_challenge_method if code_challenge_method else None,
-                nonce=nonce if nonce else None,
-                state=state if state else None,
-                claims=_parse_claims_parameter(claims_param),
-            )
-
-            # Clear OAuth session data
-            for key in list(session.keys()):
-                if key.startswith("oauth_"):
-                    session.pop(key, None)
-
-            # Build redirect URL with code
-            redirect_params = {"code": code}
-            if state:
-                redirect_params["state"] = state
-
-            callback_url = f"{redirect_uri}?{urlencode(redirect_params)}"
-
-            audit_event(
-                "authorization_request",
-                "success",
-                endpoint="/authorize",
-                username=user.username,
-                client_id=client_id,
-                details={
-                    "scope": scope,
-                    "pkce": bool(code_challenge),
-                },
-            )
-
-            if config.settings.verbose_logging:
-                logger.info(f"Authorization code issued for user '{user.username}', client '{client_id}'")
-            else:
-                logger.info("Authorization code issued")
-
-            return redirect(callback_url)
-        elif (persona_mode and username) or (not persona_mode and username and password):
-            # A real (failed) selection/login attempt, not just missing input
-            error_msg = "Invalid username or password"
-            audit_event(
-                "authorization_request",
-                "failed",
-                endpoint="/authorize",
-                username=username,
-                client_id=client_id,
-                details={"reason": "Invalid credentials"},
-            )
-        else:
-            error_msg = "Select a user" if persona_mode else "Username and password are required"
-
-    # Show login page (GET or failed POST)
-    logo_url = None
-    if client:
-        logos_dir = effective_logos_dir(config.settings.logos_dir, current_app.static_folder)
-        if resolve_client_logo(logos_dir, client.client_id):
-            logo_url = url_for("oauth.client_logo", client_id=client.client_id)
-
-    return render_template(
-        "authorize.html",
-        client_id=client_id,
-        client=client,
-        logo_url=logo_url,
-        scope=scope,
-        error=error_msg,
-        persona_mode=persona_mode,
-        users=list(config.users.keys()),
-    )
+    return _render_authorize_login(config, p, client, error_msg)
 
 
 @oauth_bp.route("/client-logos/<client_id>")
@@ -583,10 +648,15 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
                     "rejected_scopes": rejected,
                 },
             )
-            return jsonify({
-                "error": "invalid_scope",
-                "error_description": "Requested scope exceeds originally granted scope"
-            }), 400
+            return (
+                jsonify(
+                    {
+                        "error": "invalid_scope",
+                        "error_description": "Requested scope exceeds originally granted scope",
+                    }
+                ),
+                400,
+            )
         scope = requested_scope
     else:
         scope = original_scope or None
@@ -621,10 +691,12 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
                     "grant_type": ctx.grant_type,
                 },
             )
-            return jsonify({
-                "error": "invalid_scope",
-                "error_description": scope_result.error_description
-            }), 400
+            return (
+                jsonify(
+                    {"error": "invalid_scope", "error_description": scope_result.error_description}
+                ),
+                400,
+            )
         scope = scope_result.granted
 
     # A refreshed ID Token must carry the ORIGINAL authentication time
@@ -723,9 +795,7 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
                 "grant_type": ctx.grant_type,
             },
         )
-        return abort(
-            400, description="username and password required for password grant"
-        )
+        return abort(400, description="username and password required for password grant")
 
     user = ctx.config.authenticate(username, password)
     if not user:
@@ -761,10 +831,12 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
                     "grant_type": ctx.grant_type,
                 },
             )
-            return jsonify({
-                "error": "invalid_scope",
-                "error_description": scope_result.error_description
-            }), 400
+            return (
+                jsonify(
+                    {"error": "invalid_scope", "error_description": scope_result.error_description}
+                ),
+                400,
+            )
         requested_scope = scope_result.granted
 
     # An authenticated end-user is present, so honour an openid scope and
@@ -820,7 +892,10 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
             "failed",
             endpoint="/token",
             client_id=ctx.client_id,
-            details={"reason": "Invalid or expired authorization code", "grant_type": ctx.grant_type},
+            details={
+                "reason": "Invalid or expired authorization code",
+                "grant_type": ctx.grant_type,
+            },
         )
         return abort(400, description="Invalid or expired authorization code")
 
@@ -869,10 +944,12 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
                     "grant_type": ctx.grant_type,
                 },
             )
-            return jsonify({
-                "error": "invalid_scope",
-                "error_description": scope_result.error_description
-            }), 400
+            return (
+                jsonify(
+                    {"error": "invalid_scope", "error_description": scope_result.error_description}
+                ),
+                400,
+            )
         code_scope = scope_result.granted
 
     requested_claims = auth_code.claims or {}
@@ -917,10 +994,12 @@ def _grant_client_credentials(ctx: _GrantContext) -> GrantResult:
                     "grant_type": ctx.grant_type,
                 },
             )
-            return jsonify({
-                "error": "invalid_scope",
-                "error_description": scope_result.error_description
-            }), 400
+            return (
+                jsonify(
+                    {"error": "invalid_scope", "error_description": scope_result.error_description}
+                ),
+                400,
+            )
         requested_scope = scope_result.granted
         if requested_scope:
             # client_credentials has no end-user context (RFC 6749 §4.4 has
@@ -958,10 +1037,10 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Missing device_code", "grant_type": ctx.grant_type},
         )
-        return jsonify({
-            "error": "invalid_request",
-            "error_description": "device_code is required"
-        }), 400
+        return (
+            jsonify({"error": "invalid_request", "error_description": "device_code is required"}),
+            400,
+        )
 
     # The store runs the whole lookup-check-claim sequence under its lock so
     # two concurrent polls can't both claim the same authorized code
@@ -978,35 +1057,44 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Invalid device_code", "grant_type": ctx.grant_type},
         )
-        return jsonify({
-            "error": "invalid_grant",
-            "error_description": "Invalid device code"
-        }), 400
+        return jsonify({"error": "invalid_grant", "error_description": "Invalid device code"}), 400
     if outcome is DevicePollOutcome.WRONG_CLIENT:
-        return jsonify({
-            "error": "invalid_grant",
-            "error_description": "Device code was not issued to this client"
-        }), 400
+        return (
+            jsonify(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Device code was not issued to this client",
+                }
+            ),
+            400,
+        )
     if outcome is DevicePollOutcome.EXPIRED:
-        return jsonify({
-            "error": "expired_token",
-            "error_description": "Device code has expired"
-        }), 400
+        return (
+            jsonify({"error": "expired_token", "error_description": "Device code has expired"}),
+            400,
+        )
     if outcome is DevicePollOutcome.PENDING:
-        return jsonify({
-            "error": "authorization_pending",
-            "error_description": "User has not yet authorized the device"
-        }), 400
+        return (
+            jsonify(
+                {
+                    "error": "authorization_pending",
+                    "error_description": "User has not yet authorized the device",
+                }
+            ),
+            400,
+        )
     if outcome is DevicePollOutcome.DENIED:
-        return jsonify({
-            "error": "access_denied",
-            "error_description": "User denied the authorization request"
-        }), 400
+        return (
+            jsonify(
+                {
+                    "error": "access_denied",
+                    "error_description": "User denied the authorization request",
+                }
+            ),
+            400,
+        )
     if outcome is DevicePollOutcome.USER_NOT_FOUND:
-        return jsonify({
-            "error": "server_error",
-            "error_description": "User not found"
-        }), 500
+        return jsonify({"error": "server_error", "error_description": "User not found"}), 500
     if outcome is DevicePollOutcome.AUTHORIZED and user and grant:
         # The device flow authenticates an end-user, so honour the requested
         # scope and emit an ID Token when 'openid' was asked for (issue #36).
@@ -1017,10 +1105,10 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
             scope=grant.scope,
             auth_time=grant.auth_time,
         )
-    return jsonify({
-        "error": "server_error",
-        "error_description": "Unknown device code status"
-    }), 500
+    return (
+        jsonify({"error": "server_error", "error_description": "Unknown device code status"}),
+        500,
+    )
 
 
 _GRANT_HANDLERS: Dict[str, Callable[[_GrantContext], GrantResult]] = {
@@ -1062,7 +1150,9 @@ def token() -> ResponseReturnValue:
             client_id=auth.username,
             details={"reason": "client_id mismatch", "body_client_id": body_client_id},
         )
-        return abort(401, description="client_id in request body does not match authenticated client")
+        return abort(
+            401, description="client_id in request body does not match authenticated client"
+        )
 
     # For grant types that require client authentication, enforce it
     if not auth and grant_type != "authorization_code":
@@ -1232,7 +1322,10 @@ def userinfo() -> ResponseReturnValue:
             endpoint="/userinfo",
             details={"reason": str(e)},
         )
-        return jsonify({"error": "invalid_token", "error_description": "Token validation failed"}), 401
+        return (
+            jsonify({"error": "invalid_token", "error_description": "Token validation failed"}),
+            401,
+        )
 
     # UserInfo requires an *access* token (OIDC Core §5.3.1). Reject ID/refresh
     # tokens even if they verify against the resource audience (issue #34).
@@ -1249,12 +1342,18 @@ def userinfo() -> ResponseReturnValue:
             endpoint="/userinfo",
             details={"reason": "Not an access token", "token_use": payload.get("token_use")},
         )
-        return jsonify({"error": "invalid_token", "error_description": "An access token is required"}), 401
+        return (
+            jsonify({"error": "invalid_token", "error_description": "An access token is required"}),
+            401,
+        )
 
     # Check if token is revoked
     jti = payload.get("jti")
     if get_revocation_store().is_revoked(jti):
-        return jsonify({"error": "invalid_token", "error_description": "Token has been revoked"}), 401
+        return (
+            jsonify({"error": "invalid_token", "error_description": "Token has been revoked"}),
+            401,
+        )
 
     # Get user info
     username = payload.get("sub")
@@ -1456,6 +1555,7 @@ def revoke() -> ResponseReturnValue:
         else:
             # If no JTI, add the token hash to blacklist
             import hashlib
+
             token_hash = hashlib.sha256(token.encode()).hexdigest()
             get_revocation_store().revoke(token_hash)
 
@@ -1479,6 +1579,7 @@ def revoke() -> ResponseReturnValue:
 # ============================================================================
 # OIDC End Session / Logout (OpenID Connect RP-Initiated Logout 1.0)
 # ============================================================================
+
 
 @oauth_bp.route("/logout", methods=["GET", "POST"])
 @oauth_bp.route("/end_session", methods=["GET", "POST"])
@@ -1550,6 +1651,7 @@ def end_session() -> ResponseReturnValue:
 # Device Authorization Grant (RFC 8628)
 # ============================================================================
 
+
 @oauth_bp.route("/device_authorization", methods=["POST"])
 @oauth_bp.route("/device/code", methods=["POST"])
 def device_authorization() -> ResponseReturnValue:
@@ -1601,10 +1703,12 @@ def device_authorization() -> ResponseReturnValue:
                 client_id=client_id,
                 details={"reason": scope_result.error_description},
             )
-            return jsonify({
-                "error": "invalid_scope",
-                "error_description": scope_result.error_description
-            }), 400
+            return (
+                jsonify(
+                    {"error": "invalid_scope", "error_description": scope_result.error_description}
+                ),
+                400,
+            )
         requested_scope = scope_result.granted or ""
     scope = requested_scope
 
@@ -1628,21 +1732,20 @@ def device_authorization() -> ResponseReturnValue:
     settings = config.settings
     verification_base = settings.issuer
     if settings.issuer_from_request:
-        verification_base = (
-            settings.device_verification_base_url
-            or effective_issuer(settings)
-        )
+        verification_base = settings.device_verification_base_url or effective_issuer(settings)
     verification_uri = f"{verification_base}/device"
     verification_uri_complete = f"{verification_uri}?user_code={user_code}"
 
-    return jsonify({
-        "device_code": device_code,
-        "user_code": user_code,
-        "verification_uri": verification_uri,
-        "verification_uri_complete": verification_uri_complete,
-        "expires_in": DEVICE_CODE_EXPIRES_IN,
-        "interval": DEVICE_POLL_INTERVAL,
-    })
+    return jsonify(
+        {
+            "device_code": device_code,
+            "user_code": user_code,
+            "verification_uri": verification_uri,
+            "verification_uri_complete": verification_uri_complete,
+            "expires_in": DEVICE_CODE_EXPIRES_IN,
+            "interval": DEVICE_POLL_INTERVAL,
+        }
+    )
 
 
 @oauth_bp.route("/device", methods=["GET", "POST"])

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -8,7 +8,7 @@ import uuid
 import zlib
 from base64 import b64decode, b64encode
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from flask import Blueprint, Response, abort, render_template, request, session
 from flask.typing import ResponseReturnValue
@@ -38,9 +38,11 @@ def secure_fromstring(xml_bytes: bytes) -> etree._Element:
     """Parse XML securely, preventing XXE attacks."""
     return etree.fromstring(xml_bytes, parser=_secure_parser)
 
+
 # Try to import signxml for SAML signing
 try:
     from signxml import CanonicalizationMethod, XMLSigner, methods
+
     SIGNXML_AVAILABLE = True
 except ImportError:
     SIGNXML_AVAILABLE = False
@@ -71,6 +73,7 @@ def _get_c14n_algorithm(config_value: str) -> "CanonicalizationMethod":
         return CanonicalizationMethod.CANONICAL_XML_1_1
     # Default to Exclusive C14N for SAML standard compliance
     return CanonicalizationMethod.EXCLUSIVE_XML_CANONICALIZATION_1_0
+
 
 saml_bp = Blueprint("saml", __name__, url_prefix="/saml")
 
@@ -277,14 +280,20 @@ def _build_saml_response(
     ctxc.text = authn_context
 
     if attributes:
-        attrs = etree.SubElement(assertion, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeStatement")
+        attrs = etree.SubElement(
+            assertion, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeStatement"
+        )
         for k, v in attributes.items():
             if v is None:
                 continue
-            attr = etree.SubElement(attrs, "{urn:oasis:names:tc:SAML:2.0:assertion}Attribute", Name=k)
+            attr = etree.SubElement(
+                attrs, "{urn:oasis:names:tc:SAML:2.0:assertion}Attribute", Name=k
+            )
             if isinstance(v, (list, tuple)):
                 for item in v:
-                    av = etree.SubElement(attr, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue")
+                    av = etree.SubElement(
+                        attr, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue"
+                    )
                     av.text = str(item)
             else:
                 av = etree.SubElement(attr, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue")
@@ -306,8 +315,10 @@ def _build_saml_response(
         )
         signed = signer.sign(
             # signxml's typed API takes the certificate as a PEM string
-            assertion, key=crypto.priv_pem, cert=cert_pem.decode("ascii"),
-            reference_uri=assertion_id
+            assertion,
+            key=crypto.priv_pem,
+            cert=cert_pem.decode("ascii"),
+            reference_uri=assertion_id,
         )
         resp.remove(assertion)
         resp.append(signed)
@@ -344,7 +355,9 @@ def metadata() -> ResponseReturnValue:
         idpsso.set("WantAuthnRequestsSigned", "true")
 
     # KeyDescriptor
-    kd = etree.SubElement(idpsso, "{urn:oasis:names:tc:SAML:2.0:metadata}KeyDescriptor", use="signing")
+    kd = etree.SubElement(
+        idpsso, "{urn:oasis:names:tc:SAML:2.0:metadata}KeyDescriptor", use="signing"
+    )
     ki = etree.SubElement(kd, "{http://www.w3.org/2000/09/xmldsig#}KeyInfo")
     x509d = etree.SubElement(ki, "{http://www.w3.org/2000/09/xmldsig#}X509Data")
     x509c = etree.SubElement(x509d, "{http://www.w3.org/2000/09/xmldsig#}X509Certificate")
@@ -376,186 +389,191 @@ def cert() -> ResponseReturnValue:
     return Response(crypto.cert_pem, mimetype="application/x-pem-file")
 
 
-@saml_bp.route("/sso", methods=["GET", "POST"])
-def sso() -> ResponseReturnValue:
-    """SAML SSO endpoint.
+def _verify_authn_request_signature(
+    config: Any, saml_request_b64: str, relay_state: str
+) -> Optional[ResponseReturnValue]:
+    """AuthnRequest signature verification (#69), opt-in via
+    saml.want_authn_requests_signed. Verified where the request ENTERS:
 
-    Handles both SP-initiated SSO flows:
-    - HTTP-Redirect binding (GET with DEFLATE compressed SAMLRequest)
-    - HTTP-POST binding (POST with uncompressed SAMLRequest)
+    - GET = Redirect binding: query-string signature (Bindings §3.4.4.1).
+      The signature only exists on the original URL and cannot survive the
+      login-form roundtrip, so the verified request is bound SERVER-SIDE in
+      the session; the POST login leg (saml_original_verb=GET) is admitted
+      only for values byte-identical to a request this session already
+      verified, and fails closed otherwise (#69 review: hidden form fields
+      are client-controlled and must not be trusted on their own).
+    - POST without saml_original_verb = POST-binding entry: enveloped XML
+      signature (Core §5).
+    - POST login leg of a POST-binding request (saml_original_verb=POST):
+      the signature still travels inside the XML, so it is re-verified.
 
-    If user is not authenticated, shows login form inline (no redirect)
-    to preserve the original binding context.
+    Returns the rejection response, or None when the request may proceed
+    (verification passed, or the opt-in is off).
     """
-    config = get_config()
+    if not config.settings.saml_want_authn_requests_signed:
+        return None
 
-    saml_request_b64 = request.form.get("SAMLRequest") or request.args.get("SAMLRequest")
-    relay_state = request.form.get("RelayState") or request.args.get("RelayState", "")
-
-    if not saml_request_b64:
-        return abort(400, description="missing SAMLRequest")
-
-    # AuthnRequest signature verification (#69), opt-in via
-    # saml.want_authn_requests_signed. Verified where the request ENTERS:
-    # - GET = Redirect binding: query-string signature (Bindings §3.4.4.1).
-    #   The signature only exists on the original URL and cannot survive the
-    #   login-form roundtrip, so the verified request is bound SERVER-SIDE in
-    #   the session; the POST login leg (saml_original_verb=GET) is admitted
-    #   only for values byte-identical to a request this session already
-    #   verified, and fails closed otherwise (#69 review: hidden form fields
-    #   are client-controlled and must not be trusted on their own).
-    # - POST without saml_original_verb = POST-binding entry: enveloped XML
-    #   signature (Core §5).
-    # - POST login leg of a POST-binding request (saml_original_verb=POST):
-    #   the signature still travels inside the XML, so it is re-verified.
-    if config.settings.saml_want_authn_requests_signed:
-        form_leg_verb = (request.form.get("saml_original_verb") or "").upper()
-        try:
-            if request.method == "GET":
-                verify_redirect_signature(
-                    request.query_string.decode("latin-1"),
-                    load_sp_certificates(config.settings.saml_sp_certificates),
+    form_leg_verb = (request.form.get("saml_original_verb") or "").upper()
+    try:
+        if request.method == "GET":
+            verify_redirect_signature(
+                request.query_string.decode("latin-1"),
+                load_sp_certificates(config.settings.saml_sp_certificates),
+            )
+            # A later Redirect-leg POST may only replay exactly this
+            # verified request. Overwritten by each newly verified GET.
+            session["saml_verified_redirect"] = {
+                "SAMLRequest": saml_request_b64,
+                "RelayState": relay_state,
+            }
+        elif form_leg_verb == "GET":
+            verified = session.get("saml_verified_redirect")
+            if (
+                not isinstance(verified, dict)
+                or verified.get("SAMLRequest") != saml_request_b64
+                or verified.get("RelayState") != relay_state
+            ):
+                raise SAMLSignatureError(
+                    "Redirect-binding login continuation does not match a "
+                    "signature-verified request in this session"
                 )
-                # A later Redirect-leg POST may only replay exactly this
-                # verified request. Overwritten by each newly verified GET.
-                session["saml_verified_redirect"] = {
-                    "SAMLRequest": saml_request_b64,
-                    "RelayState": relay_state,
-                }
-            elif form_leg_verb == "GET":
-                verified = session.get("saml_verified_redirect")
-                if (
-                    not isinstance(verified, dict)
-                    or verified.get("SAMLRequest") != saml_request_b64
-                    or verified.get("RelayState") != relay_state
-                ):
-                    raise SAMLSignatureError(
-                        "Redirect-binding login continuation does not match a "
-                        "signature-verified request in this session"
-                    )
-            else:
-                xml_bytes = _decode_saml_request_bytes(saml_request_b64)
-                verify_post_signature(
-                    xml_bytes,
-                    load_sp_certificates(config.settings.saml_sp_certificates),
-                )
-        except SAMLSignatureError as e:
-            audit_event(
-                "saml_request",
-                "failed",
-                endpoint="/saml/sso",
-                details={"reason": f"AuthnRequest signature rejected: {e}"},
+        else:
+            xml_bytes = _decode_saml_request_bytes(saml_request_b64)
+            verify_post_signature(
+                xml_bytes,
+                load_sp_certificates(config.settings.saml_sp_certificates),
             )
-            return abort(400, description=f"AuthnRequest signature rejected: {e}")
-
-    # Check if user is authenticated
-    username = session.get("user")
-    persona_mode = config.settings.persona_mode_enabled
-
-    # Handle inline login (no redirect to preserve binding)
-    if not username:
-        login_error = None
-
-        # Check if login form was submitted. Persona mode authenticates by
-        # identity selection only; password mode is unchanged.
-        form_username = request.form.get("username", "").strip()
-        form_password = request.form.get("password", "")
-
-        user = config.interactive_authenticate(form_username, form_password)
-
-        if user:
-            session["user"] = form_username
-            # Recorded so the assertion's AuthnContextClassRef below reflects
-            # how this session actually authenticated (#persona login design
-            # contract, point 6) - persona logins must not claim
-            # PasswordProtectedTransport.
-            session["auth_method"] = "persona" if persona_mode else "password"
-            session.permanent = True
-            username = form_username
-            audit_event(
-                "login",
-                "success",
-                endpoint="/saml/sso",
-                username=username,
-            )
-        elif (persona_mode and form_username) or (
-            not persona_mode and form_username and form_password
-        ):
-            # A real (failed) selection/login attempt, not just missing input
-            login_error = "Invalid credentials"
-            audit_event(
-                "login",
-                "failed",
-                endpoint="/saml/sso",
-                username=form_username,
-                details={"reason": "Invalid credentials"},
-            )
-
-        # Still not authenticated - show login form
-        if not username:
-            # Pass original HTTP verb to template for strict mode parsing after inline login
-            # (POST with compressed SAMLRequest from original GET needs to decompress)
-            return render_template(
-                "login.html",
-                error=login_error,
-                saml_request=saml_request_b64,
-                relay_state=relay_state,
-                original_verb=request.method,
-                users=list(config.users.keys()),
-                persona_mode=persona_mode,
-            )
-
-    user = config.get_user(username)
-    if not user:
+    except SAMLSignatureError as e:
         audit_event(
             "saml_request",
             "failed",
             endpoint="/saml/sso",
-            username=username,
-            details={"reason": "User not found"},
+            details={"reason": f"AuthnRequest signature rejected: {e}"},
         )
-        return abort(401, description=f"user '{username}' not found")
+        return abort(400, description=f"AuthnRequest signature rejected: {e}")
+    return None
 
-    # Parse SAMLRequest. Signature verification (when enabled) already
-    # happened at the top of this function (#69); without the opt-in,
-    # Signature/SigAlg query params are accepted and ignored, as before.
-    #
-    # Use original HTTP verb from form if set (inline login case: original GET
-    # compressed SAMLRequest is POSTed back after login form submission).
-    # Normalize to uppercase and validate.
-    form_verb = request.form.get("saml_original_verb")
-    if form_verb and form_verb.upper() not in ("GET", "POST"):
-        return abort(400, description="invalid saml_original_verb")
-    original_verb = (form_verb or request.method or "POST").upper()
-    saml_info = _parse_saml_request(
-        saml_request_b64,
-        http_verb=original_verb,
-        strict=config.settings.strict_saml_binding
+
+def _sso_authenticate_inline(
+    config: Any, saml_request_b64: str, relay_state: str
+) -> tuple[Optional[str], Optional[ResponseReturnValue]]:
+    """The inline-login leg: (username, None) once authenticated, or
+    (None, login-page response) while not.
+
+    Login happens inline (no redirect) to preserve the original binding
+    context. Persona mode authenticates by identity selection only;
+    password mode is unchanged.
+    """
+    username = session.get("user")
+    if username:
+        return username, None
+
+    persona_mode = config.settings.persona_mode_enabled
+    login_error = None
+
+    form_username = request.form.get("username", "").strip()
+    form_password = request.form.get("password", "")
+
+    user = config.interactive_authenticate(form_username, form_password)
+
+    if user:
+        session["user"] = form_username
+        # Recorded so the assertion's AuthnContextClassRef reflects how this
+        # session actually authenticated (#persona login design contract,
+        # point 6) - persona logins must not claim
+        # PasswordProtectedTransport.
+        session["auth_method"] = "persona" if persona_mode else "password"
+        session.permanent = True
+        audit_event(
+            "login",
+            "success",
+            endpoint="/saml/sso",
+            username=form_username,
+        )
+        return form_username, None
+
+    if (persona_mode and form_username) or (not persona_mode and form_username and form_password):
+        # A real (failed) selection/login attempt, not just missing input
+        login_error = "Invalid credentials"
+        audit_event(
+            "login",
+            "failed",
+            endpoint="/saml/sso",
+            username=form_username,
+            details={"reason": "Invalid credentials"},
+        )
+
+    # Still not authenticated - show login form. Pass the original HTTP verb
+    # to the template for strict mode parsing after inline login (POST with
+    # compressed SAMLRequest from an original GET needs to decompress).
+    return None, render_template(
+        "login.html",
+        error=login_error,
+        saml_request=saml_request_b64,
+        relay_state=relay_state,
+        original_verb=request.method,
+        users=list(config.users.keys()),
+        persona_mode=persona_mode,
     )
 
-    # Determine ACS URL
-    requested_acs = saml_info.get("acs_url") if saml_info else None
-    acs_url = requested_acs or config.settings.default_acs_url
 
-    in_response_to = saml_info.get("id") if saml_info else None
+def _sso_build_attributes(config: Any, user: Any) -> Dict[str, Any]:
+    """The assertion's attribute set for this user.
 
-    # Build SAML attributes
-    saml_attrs = {
+    Roles/groups are opt-in: they have no standard SAML attribute name, so
+    the SP-specific name is configured alongside the switch.
+    """
+    saml_attrs: Dict[str, Any] = {
         "identity_class": user.identity_class,
         "entitlements": user.entitlements,
         "email": user.email,
     }
-    # Roles/groups are opt-in: they have no standard SAML attribute name, so the
-    # SP-specific name is configured alongside the switch.
     if config.settings.saml_export_roles and user.roles:
         _add_export_attr(saml_attrs, config.settings.saml_roles_attr_name, user.roles)
     if config.settings.saml_export_groups and user.groups:
-        _add_export_attr(
-            saml_attrs, config.settings.saml_groups_attr_name, user.groups
-        )
-    # Add custom attributes
+        _add_export_attr(saml_attrs, config.settings.saml_groups_attr_name, user.groups)
     if user.attributes:
         saml_attrs.update(user.attributes)
+    return saml_attrs
+
+
+def _sso_parse_request(
+    config: Any, saml_request_b64: str
+) -> tuple[Optional[str], Optional[str], Optional[ResponseReturnValue]]:
+    """Parse the SAMLRequest: (acs_url, in_response_to, None) or (None, None, error).
+
+    Signature verification (when enabled) already happened in
+    _verify_authn_request_signature (#69); without the opt-in,
+    Signature/SigAlg query params are accepted and ignored, as before.
+
+    Uses the original HTTP verb from the form if set (inline login case: an
+    original GET's compressed SAMLRequest is POSTed back after the login
+    form submission). Normalized to uppercase and validated.
+    """
+    form_verb = request.form.get("saml_original_verb")
+    if form_verb and form_verb.upper() not in ("GET", "POST"):
+        return None, None, abort(400, description="invalid saml_original_verb")
+    original_verb = (form_verb or request.method or "POST").upper()
+    saml_info = _parse_saml_request(
+        saml_request_b64, http_verb=original_verb, strict=config.settings.strict_saml_binding
+    )
+
+    requested_acs = saml_info.get("acs_url") if saml_info else None
+    acs_url = requested_acs or config.settings.default_acs_url
+    in_response_to = saml_info.get("id") if saml_info else None
+    return acs_url, in_response_to, None
+
+
+def _sso_success_response(
+    config: Any,
+    user: Any,
+    username: str,
+    acs_url: str,
+    in_response_to: Optional[str],
+    relay_state: str,
+) -> ResponseReturnValue:
+    """Build, audit and auto-submit the SAML Response for an authenticated user."""
+    saml_attrs = _sso_build_attributes(config, user)
 
     name_id = user.email or f"{username}@example.org"
 
@@ -598,7 +616,7 @@ def sso() -> ResponseReturnValue:
     # Auto-submit form (escape user-controlled values to prevent XSS)
     safe_acs_url = html.escape(acs_url, quote=True)
     safe_relay_state = html.escape(relay_state, quote=True)
-    response_html = f"""<!DOCTYPE html>
+    return f"""<!DOCTYPE html>
 <html><body onload="document.forms[0].submit()">
 <form method="post" action="{safe_acs_url}">
   <input type="hidden" name="SAMLResponse" value="{saml_b64}"/>
@@ -607,10 +625,65 @@ def sso() -> ResponseReturnValue:
 </form>
 </body></html>"""
 
-    return response_html
+
+@saml_bp.route("/sso", methods=["GET", "POST"])
+def sso() -> ResponseReturnValue:
+    """SAML SSO endpoint.
+
+    Handles both SP-initiated SSO flows:
+    - HTTP-Redirect binding (GET with DEFLATE compressed SAMLRequest)
+    - HTTP-POST binding (POST with uncompressed SAMLRequest)
+
+    If user is not authenticated, shows login form inline (no redirect)
+    to preserve the original binding context.
+
+    Each step is a named helper; every rejection keeps its historical
+    error and audit behavior (#212).
+    """
+    config = get_config()
+
+    saml_request_b64 = request.form.get("SAMLRequest") or request.args.get("SAMLRequest")
+    relay_state = request.form.get("RelayState") or request.args.get("RelayState", "")
+
+    if not saml_request_b64:
+        return abort(400, description="missing SAMLRequest")
+
+    rejected = _verify_authn_request_signature(config, saml_request_b64, relay_state)
+    if rejected is not None:
+        return rejected
+
+    username, login_page = _sso_authenticate_inline(config, saml_request_b64, relay_state)
+    if login_page is not None:
+        return login_page
+    assert username is not None  # _sso_authenticate_inline returns one or the other
+
+    user = config.get_user(username)
+    if not user:
+        audit_event(
+            "saml_request",
+            "failed",
+            endpoint="/saml/sso",
+            username=username,
+            details={"reason": "User not found"},
+        )
+        return abort(401, description=f"user '{username}' not found")
+
+    acs_url, in_response_to, invalid = _sso_parse_request(config, saml_request_b64)
+    if invalid is not None:
+        return invalid
+
+    # acs_url is None only when the request names no ACS URL AND
+    # saml.default_acs_url is unset - a latent pre-existing 500 (the old
+    # inline code crashed on html.escape(None) the same way), preserved
+    # as-is by this refactor and left for its own fix.
+    return _sso_success_response(
+        config, user, username, cast(str, acs_url), in_response_to, relay_state
+    )
 
 
-def _build_attribute_query_response(user_id: str, attributes: dict, request_id: str, issuer_url: str) -> str:
+def _build_attribute_query_response(
+    user_id: str, attributes: dict, request_id: str, issuer_url: str
+) -> str:
     """
     Build a SAML Response for AttributeQuery (backend-to-backend).
 
@@ -809,13 +882,9 @@ def attribute_query() -> ResponseReturnValue:
             # Roles/groups only when explicitly enabled (see /saml/sso).
             # Lists, not ",".join: same reason as entitlements above (#134).
             if config.settings.saml_export_roles and user.roles:
-                _add_export_attr(
-                    attributes, config.settings.saml_roles_attr_name, user.roles
-                )
+                _add_export_attr(attributes, config.settings.saml_roles_attr_name, user.roles)
             if config.settings.saml_export_groups and user.groups:
-                _add_export_attr(
-                    attributes, config.settings.saml_groups_attr_name, user.groups
-                )
+                _add_export_attr(attributes, config.settings.saml_groups_attr_name, user.groups)
 
             # Add custom attributes
             if user.attributes:
@@ -843,7 +912,9 @@ def attribute_query() -> ResponseReturnValue:
         )
 
         # Sign the response (if configured)
-        signed_response = _sign_attribute_query_response(response_xml, config.settings.saml_sign_responses)
+        signed_response = _sign_attribute_query_response(
+            response_xml, config.settings.saml_sign_responses
+        )
 
         # Wrap in SOAP envelope
         soap_response = f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -861,13 +932,16 @@ def attribute_query() -> ResponseReturnValue:
             details={"attributes_count": len(attributes)},
         )
 
-        logger.info(f"AttributeQuery response issued for user '{user_id}' with {len(attributes)} attributes")
+        logger.info(
+            f"AttributeQuery response issued for user '{user_id}' with {len(attributes)} attributes"
+        )
 
         return Response(soap_response, mimetype="text/xml")
 
     except Exception as e:
         logger.error(f"AttributeQuery error: {e}")
         import traceback
+
         traceback.print_exc()
 
         audit_event(


### PR DESCRIPTION
The last two monolithic protocol handlers, broken into named steps with zero behavior change - same error bodies, same audit events (including which early rejections deliberately do NOT audit), same session behavior, same ordering. The 1528-test suite passes untouched and a live examples/test_agent.py run is 56/57 (the known environmental exact-match failure only).

/authorize (radon E, CC 39 -> 8): `_read_authorize_params` (dataclass + the GET-leg session store, still before any validation), `_validate_authorize_client`, `_validate_authorize_scope` (#186's check, mutating the params to the granted value), `_validate_authorize_redirect_uri` (syntax + registration + oauth21, historical order), `_validate_authorize_pkce`, `_handle_authorize_login` (the POST leg), `_render_authorize_login`. The shared audit-then-reject shape lives in `_authorize_reject`; the pre-lookup checks keep building their responses directly because they never audited.

SAML /sso (radon E, CC 39 -> 9): `_verify_authn_request_signature` (the three #69 legs), `_sso_authenticate_inline` (inline login), `_sso_parse_request` (verb validation + parse + ACS resolution), `_sso_build_attributes`, `_sso_success_response` (assertion build + audit + auto-submit page). Same-module helpers, matching the existing `_grant_*` pattern - the pure logic these steps call was already in services/.

Issue targets met: authorize and sso under CC 15; no route function above CC 20 in either file (token sits exactly at 20, unchanged). ruff, black, mypy, import contracts green.

One latent pre-existing issue surfaced by typing, preserved as-is and documented at the call site: when the AuthnRequest names no ACS URL and `saml.default_acs_url` is unset, /sso has always crashed on `html.escape(None)`; the refactor keeps that behavior (cast + comment) rather than silently changing it - worth its own small issue.

Closes #212.