### PR TITLE
fix: give the UI logout its own rule so the dashboard Logout button works again (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The dashboard's Logout button logs the UI session out again** (#221).
+  The UI logout route registered the same `/logout` rule as the OIDC
+  end-session endpoint and always lost: clicking Logout landed on the
+  end-session confirmation page and the UI logout audit event was never
+  written. The UI logout now lives at `GET /ui/logout` (the button follows
+  automatically via `url_for`), redirects back to the dashboard, and writes
+  its `logout` audit event; `/logout` (alias `/end_session`) remains the
+  OIDC endpoint, unchanged.
 - **Regenerating a client secret no longer resets the client's branding**
   (#213 review): `/clients/<id>/regenerate-secret` rebuilt the client with
   only five fields, silently dropping `background_color`, `header_color`

--- a/book/src/reference/endpoints.md
+++ b/book/src/reference/endpoints.md
@@ -12,6 +12,7 @@
 | `POST /introspect` | Token Introspection (RFC 7662) |
 | `POST /revoke` | Token Revocation (RFC 7009) |
 | `GET/POST /logout` | OIDC End Session / Logout (alias: `/end_session`) |
+| `GET /ui/logout` | Dashboard session logout (the web UI's Logout button) |
 | `POST /device_authorization` | Device Authorization (RFC 8628; alias: `/device/code`) |
 | `GET/POST /device` | Device verification page |
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -121,9 +121,17 @@ def login() -> ResponseReturnValue:
     return redirect(url_for("ui.index"))
 
 
-@ui_bp.route("/logout")
+@ui_bp.route("/ui/logout")
 def logout() -> ResponseReturnValue:
-    """Logout and clear session."""
+    """Log the dashboard session out and return to the dashboard.
+
+    On its own rule (#221): this endpoint used to claim "/logout", where it
+    was unreachable dead code - oauth_bp registers "/logout" as an alias of
+    the OIDC end-session endpoint and create_app registers oauth_bp first,
+    so every request went there. The dashboard's Logout button (base.html,
+    url_for('ui.logout')) therefore landed users on the end-session
+    confirmation page, and this audit event was never written.
+    """
     username = session.get("user")
     session.clear()
 
@@ -131,7 +139,7 @@ def logout() -> ResponseReturnValue:
         audit_event(
             "logout",
             "success",
-            endpoint="/logout",
+            endpoint="/ui/logout",
             username=username,
         )
 

--- a/tests/test_ui_forms.py
+++ b/tests/test_ui_forms.py
@@ -86,19 +86,30 @@ class TestLoginLogout:
         with client.session_transaction() as sess:
             assert "user" not in sess
 
-    def test_logout_clears_session(self, client):
-        # /logout is handled by oauth_bp's OIDC end-session endpoint, which
-        # shadows the ui.logout route entirely (both register the same rule;
-        # oauth_bp wins). ui.logout is unreachable dead code - a known
-        # non-blocking finding from the #176 review. What matters to the UI
-        # is the observable contract: hitting /logout drops the session.
-        # The status is deliberately loose (200 today, 302 if the shadowing
-        # is ever fixed and ui.logout's redirect takes over).
+    def test_oidc_end_session_clears_session(self, client):
+        # /logout belongs solely to oauth_bp's OIDC end-session endpoint
+        # since #221 moved the UI logout to its own rule; the earlier loose
+        # (200, 302) assertion here can be exact again.
         _login(client)
         resp = client.get("/logout")
-        assert resp.status_code in (200, 302)
+        assert resp.status_code == 200
         with client.session_transaction() as sess:
             assert "user" not in sess
+
+    def test_ui_logout_redirects_to_dashboard_and_audits(self, app, client):
+        from nanoidp.services import get_audit_log
+
+        _login(client)
+        resp = client.get("/ui/logout")
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/")
+        with client.session_transaction() as sess:
+            assert "user" not in sess
+        # The audit event ui.logout was supposed to write for years but never
+        # could while the route was shadowed (#221).
+        with app.app_context():
+            entries = get_audit_log().get_entries(limit=10, event_type="logout")
+        assert any(e.get("username") == "admin" for e in entries)
 
 
 class TestUserForms:


### PR DESCRIPTION
Option 1 from the issue, the behavior-restoring one: the UI logout moves from `/logout` (where oauth_bp's OIDC end-session alias always won the route and made `ui.logout` unreachable dead code) to its own `GET /ui/logout` rule. The endpoint name stays `ui.logout`, so base.html's Logout button follows automatically via `url_for` - it now redirects back to the dashboard and writes the `logout` audit event that could never fire before. `/logout` (alias `/end_session`) remains purely the OIDC endpoint, byte-for-byte unchanged.

Tests: the previously loose logout assertion (200 or 302, hedging on the shadowing) is exact again for the OIDC endpoint, and a new test drives the UI flow end to end: login, GET /ui/logout, 302 back to the dashboard, session cleared, logout audit entry present - the assertion that was impossible to write while the route was dead. Docs: endpoints.md gains the /ui/logout row; CHANGELOG entry under Unreleased/Fixed.

Note the ui_login_required interaction is intentional: with the gate on, an anonymous GET /ui/logout redirects to /login like any other UI page (previously the request never reached ui_bp at all).

1529 tests green.

Closes #221.