### PR TITLE
refactor+test: client-field parity tests and model-derived settings plumbing (#214)

### DIFF
--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -1401,6 +1401,58 @@ def _tool_validate_config(arguments: dict[str, Any], config: ConfigManager) -> d
     return validate_config_result(config.config_dir, effective)
 
 
+def _blank_to_none(name: str, value: Any) -> Any:
+    """ "" = clear: back to the derived/unset value (#181), mirroring the UI."""
+    return value or None
+
+
+def _normalize_update_list(name: str, value: Any) -> Any:
+    return _normalize_str_list(value, name)
+
+
+def _normalize_update_attr_name(name: str, value: Any) -> Any:
+    return normalize_saml_attr_name(name, value)
+
+
+# update_settings' writable fields, in the response's updated_fields order.
+# Names double as Settings attribute names; tests/test_settings_plumbing_parity.py
+# asserts this tuple against the tool's input_schema, so the two cannot drift.
+_UPDATE_SETTINGS_FIELDS: tuple[str, ...] = (
+    "issuer",
+    "issuer_from_request",
+    "issuer_allowlist",
+    "device_verification_base_url",
+    "issuer_from_proxy_headers",
+    "audience",
+    "token_expiry_minutes",
+    "saml_entity_id",
+    "saml_sso_url",
+    "saml_sign_responses",
+    "saml_export_roles",
+    "saml_export_groups",
+    "saml_roles_attr_name",
+    "saml_groups_attr_name",
+    "saml_c14n_algorithm",
+    "strict_saml_binding",
+    "saml_want_authn_requests_signed",
+    "saml_sp_certificates",
+    "verbose_logging",
+    "refresh_token_rotation",
+    "require_pkce",
+    "login_mode",
+)
+
+_UPDATE_SETTINGS_NORMALIZERS: dict[str, Callable[[str, Any], Any]] = {
+    "issuer_allowlist": _normalize_update_list,
+    "saml_sp_certificates": _normalize_update_list,
+    "saml_roles_attr_name": _normalize_update_attr_name,
+    "saml_groups_attr_name": _normalize_update_attr_name,
+    "device_verification_base_url": _blank_to_none,
+    "saml_entity_id": _blank_to_none,
+    "saml_sso_url": _blank_to_none,
+}
+
+
 def _tool_update_settings(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
     settings = config.settings
 
@@ -1409,81 +1461,15 @@ def _tool_update_settings(arguments: dict[str, Any], config: ConfigManager) -> d
     # login_mode, so call_tool()'s jsonschema pass already rejects an
     # invalid value before this handler ever runs.
     updated = []
-    if "issuer" in arguments:
-        settings.issuer = arguments["issuer"]
-        updated.append("issuer")
-    if "issuer_from_request" in arguments:
-        settings.issuer_from_request = arguments["issuer_from_request"]
-        updated.append("issuer_from_request")
-    if "issuer_allowlist" in arguments:
-        settings.issuer_allowlist = _normalize_str_list(
-            arguments["issuer_allowlist"], "issuer_allowlist"
-        )
-        updated.append("issuer_allowlist")
-    if "device_verification_base_url" in arguments:
-        settings.device_verification_base_url = arguments["device_verification_base_url"] or None
-        updated.append("device_verification_base_url")
-    if "issuer_from_proxy_headers" in arguments:
-        settings.issuer_from_proxy_headers = arguments["issuer_from_proxy_headers"]
-        updated.append("issuer_from_proxy_headers")
-    if "audience" in arguments:
-        settings.audience = arguments["audience"]
-        updated.append("audience")
-    if "token_expiry_minutes" in arguments:
-        settings.token_expiry_minutes = arguments["token_expiry_minutes"]
-        updated.append("token_expiry_minutes")
-    if "saml_entity_id" in arguments:
-        # "" = back to derived (#181), mirroring the UI form's blank field
-        settings.saml_entity_id = arguments["saml_entity_id"] or None
-        updated.append("saml_entity_id")
-    if "saml_sso_url" in arguments:
-        settings.saml_sso_url = arguments["saml_sso_url"] or None
-        updated.append("saml_sso_url")
-    if "saml_sign_responses" in arguments:
-        settings.saml_sign_responses = arguments["saml_sign_responses"]
-        updated.append("saml_sign_responses")
-    if "saml_export_roles" in arguments:
-        settings.saml_export_roles = arguments["saml_export_roles"]
-        updated.append("saml_export_roles")
-    if "saml_export_groups" in arguments:
-        settings.saml_export_groups = arguments["saml_export_groups"]
-        updated.append("saml_export_groups")
-    if "saml_roles_attr_name" in arguments:
-        settings.saml_roles_attr_name = normalize_saml_attr_name(
-            "saml_roles_attr_name", arguments["saml_roles_attr_name"]
-        )
-        updated.append("saml_roles_attr_name")
-    if "saml_groups_attr_name" in arguments:
-        settings.saml_groups_attr_name = normalize_saml_attr_name(
-            "saml_groups_attr_name", arguments["saml_groups_attr_name"]
-        )
-        updated.append("saml_groups_attr_name")
-    if "saml_c14n_algorithm" in arguments:
-        settings.saml_c14n_algorithm = arguments["saml_c14n_algorithm"]
-        updated.append("saml_c14n_algorithm")
-    if "strict_saml_binding" in arguments:
-        settings.strict_saml_binding = arguments["strict_saml_binding"]
-        updated.append("strict_saml_binding")
-    if "saml_want_authn_requests_signed" in arguments:
-        settings.saml_want_authn_requests_signed = arguments["saml_want_authn_requests_signed"]
-        updated.append("saml_want_authn_requests_signed")
-    if "saml_sp_certificates" in arguments:
-        settings.saml_sp_certificates = _normalize_str_list(
-            arguments["saml_sp_certificates"], "saml_sp_certificates"
-        )
-        updated.append("saml_sp_certificates")
-    if "verbose_logging" in arguments:
-        settings.verbose_logging = arguments["verbose_logging"]
-        updated.append("verbose_logging")
-    if "refresh_token_rotation" in arguments:
-        settings.refresh_token_rotation = arguments["refresh_token_rotation"]
-        updated.append("refresh_token_rotation")
-    if "require_pkce" in arguments:
-        settings.require_pkce = arguments["require_pkce"]
-        updated.append("require_pkce")
-    if "login_mode" in arguments:
-        settings.login_mode = arguments["login_mode"]
-        updated.append("login_mode")
+    for field in _UPDATE_SETTINGS_FIELDS:
+        if field not in arguments:
+            continue
+        value = arguments[field]
+        normalize = _UPDATE_SETTINGS_NORMALIZERS.get(field)
+        if normalize is not None:
+            value = normalize(field, value)
+        setattr(settings, field, value)
+        updated.append(field)
 
     return {
         "success": True,

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -31,6 +31,7 @@ import os
 import re
 import shutil
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
@@ -50,7 +51,7 @@ _yaml_rt.indent(mapping=2, sequence=2, offset=0)
 _yaml_rt.preserve_quotes = True
 _yaml_rt.width = 4096  # avoid re-wrapping long values (URLs, descriptions)
 
-_ENV_VAR_RE = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}')
+_ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}")
 
 
 def expand_env_vars(value: Any) -> Any:
@@ -62,11 +63,13 @@ def expand_env_vars(value: Any) -> Any:
     Only string leaf values are processed; dicts/lists are traversed recursively.
     """
     if isinstance(value, str):
+
         def _replace(m: re.Match) -> str:
             var_name, default = m.group(1), m.group(2)
             if default is None:
                 return os.environ.get(var_name, "")
             return os.environ.get(var_name, default)
+
         return _ENV_VAR_RE.sub(_replace, value)
     if isinstance(value, dict):
         return {k: expand_env_vars(v) for k, v in value.items()}
@@ -133,7 +136,6 @@ def merge_optional_nested_field(
         document[section_key].pop(field_key, None)
         if not document[section_key]:
             document.pop(section_key, None)
-
 
 
 def _quoted(value: str) -> SingleQuotedScalarString:
@@ -310,18 +312,16 @@ def merge_oauth_clients(
     still unchanged, but genuine edits replace the matching fields without
     rebuilding the whole list. Added clients are appended; removed ones drop out.
     """
-    raw_entries = [r for r in raw_clients if isinstance(r, dict)] if isinstance(
-        raw_clients, list
-    ) else []
+    raw_entries = (
+        [r for r in raw_clients if isinstance(r, dict)] if isinstance(raw_clients, list) else []
+    )
 
     merged: list[Dict[str, Any]] = []
 
     for client in settings_clients:
         # Match by expanded client_id so a raw ``${CLIENT_ID:app1}`` entry is
         # recognised as the same client and its placeholders are preserved (#127).
-        raw_entry = next(
-            (r for r in raw_entries if client_id_matches(r, client.client_id)), None
-        )
+        raw_entry = next((r for r in raw_entries if client_id_matches(r, client.client_id)), None)
         if raw_entry is None:
             merged.append(client_to_yaml(client))
         else:
@@ -358,8 +358,7 @@ def user_to_yaml(user: User) -> Dict[str, Any]:
         entry["source_acl"] = user.source_acl
     if user.attributes:
         entry["attributes"] = {
-            k: (_quoted(v) if isinstance(v, str) else v)
-            for k, v in user.attributes.items()
+            k: (_quoted(v) if isinstance(v, str) else v) for k, v in user.attributes.items()
         }
     return entry
 
@@ -372,6 +371,72 @@ _FALLBACK_DEFAULTS: Dict[str, Any] = {
     "security_profile": "dev",
     "login.mode": "password",
 }
+
+
+@dataclass(frozen=True)
+class OwnedSetting:
+    """One settings.yaml key this codebase manages (#214).
+
+    The single description of where a Settings attribute lives in the file
+    and how its absence is encoded; ``apply_settings_document`` below and
+    ``yaml_writer.update_oauth_settings``/``update_saml_settings`` both
+    drive from ``OWNED_SETTINGS`` instead of repeating one if-block per
+    field. A test asserts every row against the document models
+    (config_documents), so the models stay the single source of truth.
+
+    ``doc_mode`` is how ``apply_settings_document`` encodes the attribute:
+    - "plain": always written when changed.
+    - "omit_when_falsy": a falsy value means the key is absent from the
+      file (``empty`` is the falsy stand-in used for the unchanged check).
+    - "omit_when_none": None means absent (derived values, #181); any
+      non-None value, including "", is written.
+    The writer's per-call semantics are simpler and shared: a kwarg that is
+    None was not on the form (leave the file alone, #131); for non-plain
+    rows a falsy provided value clears the key.
+    """
+
+    section: str  # "" = a top-level key
+    key: str
+    attr: str  # the Settings attribute name
+    doc_mode: str = "plain"
+    empty: Any = None
+
+
+OWNED_SETTINGS: tuple[OwnedSetting, ...] = (
+    OwnedSetting("server", "host", "host"),
+    OwnedSetting("server", "port", "port"),
+    OwnedSetting("oauth", "issuer", "issuer"),
+    OwnedSetting("oauth", "issuer_from_request", "issuer_from_request"),
+    OwnedSetting("oauth", "issuer_allowlist", "issuer_allowlist", "omit_when_falsy", []),
+    OwnedSetting(
+        "oauth",
+        "device_verification_base_url",
+        "device_verification_base_url",
+        "omit_when_falsy",
+        "",
+    ),
+    OwnedSetting("oauth", "issuer_from_proxy_headers", "issuer_from_proxy_headers"),
+    OwnedSetting("oauth", "audience", "audience"),
+    OwnedSetting("oauth", "token_expiry_minutes", "token_expiry_minutes"),
+    OwnedSetting("oauth", "refresh_token_rotation", "refresh_token_rotation"),
+    OwnedSetting("oauth", "require_pkce", "require_pkce"),
+    OwnedSetting("oauth", "logos_dir", "logos_dir", "omit_when_falsy", ""),
+    OwnedSetting("saml", "entity_id", "saml_entity_id", "omit_when_none"),
+    OwnedSetting("saml", "sso_url", "saml_sso_url", "omit_when_none"),
+    OwnedSetting("saml", "default_acs_url", "default_acs_url"),
+    OwnedSetting("saml", "sign_responses", "saml_sign_responses"),
+    OwnedSetting("saml", "export_roles", "saml_export_roles"),
+    OwnedSetting("saml", "export_groups", "saml_export_groups"),
+    OwnedSetting("saml", "roles_attr_name", "saml_roles_attr_name"),
+    OwnedSetting("saml", "groups_attr_name", "saml_groups_attr_name"),
+    OwnedSetting("saml", "c14n_algorithm", "saml_c14n_algorithm"),
+    OwnedSetting("saml", "strict_binding", "strict_saml_binding"),
+    OwnedSetting("saml", "want_authn_requests_signed", "saml_want_authn_requests_signed"),
+    OwnedSetting("saml", "sp_certificates", "saml_sp_certificates", "omit_when_falsy", []),
+    OwnedSetting("logging", "verbose_logging", "verbose_logging"),
+    OwnedSetting("", "authority_prefixes", "authority_prefixes"),
+    OwnedSetting("", "allowed_identity_classes", "allowed_identity_classes", "omit_when_falsy", []),
+)
 
 
 def apply_settings_document(
@@ -391,108 +456,38 @@ def apply_settings_document(
     Each field is only overwritten when its expanded on-disk value actually
     differs from the new one (#127), so untouched ``${VAR}`` placeholders,
     comments and quote style survive a save that changed something else.
-    """
-    server = document.setdefault("server", {})
-    if not is_unchanged(server.get("host"), settings.host):
-        server["host"] = settings.host
-    if not is_unchanged(server.get("port"), settings.port):
-        server["port"] = settings.port
 
+    The per-field encodings live on ``OWNED_SETTINGS`` (#214); only the two
+    defaults-dependent keys (``security_profile``, ``login.mode``) are
+    handled explicitly below.
+    """
+    for field in OWNED_SETTINGS:
+        target = document if not field.section else document.setdefault(field.section, {})
+        value = getattr(settings, field.attr)
+        if field.doc_mode == "plain":
+            if not is_unchanged(target.get(field.key), value):
+                target[field.key] = value
+        elif field.doc_mode == "omit_when_falsy":
+            if not is_unchanged(target.get(field.key), value or field.empty):
+                if value:
+                    target[field.key] = value
+                else:
+                    target.pop(field.key, None)
+        else:  # omit_when_none: derived-when-absent (#181)
+            if value is None:
+                target.pop(field.key, None)
+            elif not is_unchanged(target.get(field.key), value):
+                target[field.key] = value
+
+    # Clients are a merged list, not a scalar key: each entry round-trips
+    # through merge_client_entry, so they stay outside OWNED_SETTINGS.
     oauth = document.setdefault("oauth", {})
-    if not is_unchanged(oauth.get("issuer"), settings.issuer):
-        oauth["issuer"] = settings.issuer
-    if not is_unchanged(oauth.get("issuer_from_request"), settings.issuer_from_request):
-        oauth["issuer_from_request"] = settings.issuer_from_request
-    if not is_unchanged(oauth.get("issuer_allowlist"), settings.issuer_allowlist or []):
-        if settings.issuer_allowlist:
-            oauth["issuer_allowlist"] = settings.issuer_allowlist
-        else:
-            oauth.pop("issuer_allowlist", None)
-    device_verification_base_url = settings.device_verification_base_url or ""
-    if not is_unchanged(
-        oauth.get("device_verification_base_url"),
-        device_verification_base_url,
-    ):
-        if settings.device_verification_base_url:
-            oauth["device_verification_base_url"] = settings.device_verification_base_url
-        else:
-            oauth.pop("device_verification_base_url", None)
-    if not is_unchanged(
-        oauth.get("issuer_from_proxy_headers"), settings.issuer_from_proxy_headers
-    ):
-        oauth["issuer_from_proxy_headers"] = settings.issuer_from_proxy_headers
-    if not is_unchanged(oauth.get("audience"), settings.audience):
-        oauth["audience"] = settings.audience
-    if not is_unchanged(oauth.get("token_expiry_minutes"), settings.token_expiry_minutes):
-        oauth["token_expiry_minutes"] = settings.token_expiry_minutes
-    if not is_unchanged(
-        oauth.get("refresh_token_rotation"), settings.refresh_token_rotation
-    ):
-        oauth["refresh_token_rotation"] = settings.refresh_token_rotation
-    if not is_unchanged(oauth.get("require_pkce"), settings.require_pkce):
-        oauth["require_pkce"] = settings.require_pkce
-    logos_dir = settings.logos_dir or ""
-    if not is_unchanged(oauth.get("logos_dir"), logos_dir):
-        if settings.logos_dir:
-            oauth["logos_dir"] = settings.logos_dir
-        else:
-            oauth.pop("logos_dir", None)
     new_clients = merge_oauth_clients(oauth.get("clients", []), settings.clients)
     if new_clients != oauth.get("clients", []):
         if new_clients:
             oauth["clients"] = new_clients
         else:
             oauth.pop("clients", None)
-
-    saml = document.setdefault("saml", {})
-    # entity_id / sso_url: None means "derived from the effective issuer"
-    # (#181) and is represented by the key being absent - a derived value is
-    # never materialized into the file, so it keeps following the issuer.
-    for key, value in (("entity_id", settings.saml_entity_id), ("sso_url", settings.saml_sso_url)):
-        if value is None:
-            saml.pop(key, None)
-        elif not is_unchanged(saml.get(key), value):
-            saml[key] = value
-    if not is_unchanged(saml.get("default_acs_url"), settings.default_acs_url):
-        saml["default_acs_url"] = settings.default_acs_url
-    if not is_unchanged(saml.get("sign_responses"), settings.saml_sign_responses):
-        saml["sign_responses"] = settings.saml_sign_responses
-    if not is_unchanged(saml.get("export_roles"), settings.saml_export_roles):
-        saml["export_roles"] = settings.saml_export_roles
-    if not is_unchanged(saml.get("export_groups"), settings.saml_export_groups):
-        saml["export_groups"] = settings.saml_export_groups
-    if not is_unchanged(saml.get("roles_attr_name"), settings.saml_roles_attr_name):
-        saml["roles_attr_name"] = settings.saml_roles_attr_name
-    if not is_unchanged(saml.get("groups_attr_name"), settings.saml_groups_attr_name):
-        saml["groups_attr_name"] = settings.saml_groups_attr_name
-    if not is_unchanged(saml.get("c14n_algorithm"), settings.saml_c14n_algorithm):
-        saml["c14n_algorithm"] = settings.saml_c14n_algorithm
-    if not is_unchanged(saml.get("strict_binding"), settings.strict_saml_binding):
-        saml["strict_binding"] = settings.strict_saml_binding
-    if not is_unchanged(
-        saml.get("want_authn_requests_signed"), settings.saml_want_authn_requests_signed
-    ):
-        saml["want_authn_requests_signed"] = settings.saml_want_authn_requests_signed
-    if not is_unchanged(saml.get("sp_certificates"), settings.saml_sp_certificates or []):
-        if settings.saml_sp_certificates:
-            saml["sp_certificates"] = settings.saml_sp_certificates
-        else:
-            saml.pop("sp_certificates", None)
-
-    logging_section = document.setdefault("logging", {})
-    if not is_unchanged(logging_section.get("verbose_logging"), settings.verbose_logging):
-        logging_section["verbose_logging"] = settings.verbose_logging
-
-    if not is_unchanged(document.get("authority_prefixes"), settings.authority_prefixes):
-        document["authority_prefixes"] = settings.authority_prefixes
-
-    if not is_unchanged(
-        document.get("allowed_identity_classes"), settings.allowed_identity_classes or []
-    ):
-        if settings.allowed_identity_classes:
-            document["allowed_identity_classes"] = settings.allowed_identity_classes
-        else:
-            document.pop("allowed_identity_classes", None)
 
     # "Omit at default" decisions read the loader's defaults (#175 piece 2).
     resolved_defaults = defaults if defaults is not None else _FALLBACK_DEFAULTS
@@ -517,9 +512,7 @@ def apply_users_document(
 
     The full user map is owned; unknown top-level keys are preserved.
     """
-    document["users"] = {
-        username: user_to_yaml(user) for username, user in users.items()
-    }
+    document["users"] = {username: user_to_yaml(user) for username, user in users.items()}
     document["default_user"] = default_user
     return document
 

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -427,8 +427,14 @@ OWNED_SETTINGS: tuple[OwnedSetting, ...] = (
     OwnedSetting("saml", "sign_responses", "saml_sign_responses"),
     OwnedSetting("saml", "export_roles", "saml_export_roles"),
     OwnedSetting("saml", "export_groups", "saml_export_groups"),
-    OwnedSetting("saml", "roles_attr_name", "saml_roles_attr_name"),
-    OwnedSetting("saml", "groups_attr_name", "saml_groups_attr_name"),
+    # Blank clears the key so the default attribute name applies again
+    # (the writer's historical contract; #226 review caught these two
+    # flattened to "plain", which persisted a literal "" instead). The
+    # document side never sees a falsy value here - the Settings validator
+    # normalizes blank back to the "roles"/"groups" defaults - so for
+    # apply_settings_document this mode is equivalent to plain.
+    OwnedSetting("saml", "roles_attr_name", "saml_roles_attr_name", "omit_when_falsy", ""),
+    OwnedSetting("saml", "groups_attr_name", "saml_groups_attr_name", "omit_when_falsy", ""),
     OwnedSetting("saml", "c14n_algorithm", "saml_c14n_algorithm"),
     OwnedSetting("saml", "strict_binding", "strict_saml_binding"),
     OwnedSetting("saml", "want_authn_requests_signed", "saml_want_authn_requests_signed"),

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -11,6 +11,7 @@ from ..config import OAuthClient, Settings, User, get_config
 from ..config_documents import document_defaults
 from ..hooks import HookError
 from ..serialization import (
+    OWNED_SETTINGS,
     atomic_write_yaml,
     client_id_matches,
     client_to_yaml,
@@ -88,7 +89,6 @@ class YamlWriter:
 
         self._atomic_write(self.users_file, data)
 
-
     def delete_user(self, username: str) -> None:
         """
         Delete a user from users.yaml.
@@ -109,7 +109,6 @@ class YamlWriter:
             data["default_user"] = remaining_users[0] if remaining_users else ""
 
         self._atomic_write(self.users_file, data)
-
 
     def set_default_user(self, username: str) -> None:
         """Set the default user for client_credentials grant."""
@@ -173,6 +172,33 @@ class YamlWriter:
 
     # ==================== Settings Operations ====================
 
+    def _apply_provided_settings(self, section_name: str, provided: "Dict[str, Any]") -> None:
+        """Apply form-provided values for one settings.yaml section (#214).
+
+        The per-field encoding comes from serialization.OWNED_SETTINGS, the
+        same table apply_settings_document drives from - one row per owned
+        key instead of one hand-written if-block per field. Semantics per
+        value: None was not on the form and leaves the file alone (#131);
+        for a non-"plain" row a provided-but-falsy value clears the key
+        (absent = default/derived); everything else is written only when
+        the expanded on-disk value actually differs (#127), so untouched
+        ``${VAR}`` placeholders and comments survive.
+        """
+        data = self._load_settings_yaml()
+        section = data.setdefault(section_name, {})
+        rows = {f.key: f for f in OWNED_SETTINGS if f.section == section_name}
+        for key, value in provided.items():
+            if value is None:
+                continue
+            field = rows[key]
+            compare = value if (field.doc_mode == "plain" or value) else field.empty
+            if not is_unchanged(section.get(key), compare):
+                if field.doc_mode != "plain" and not value:
+                    section.pop(key, None)
+                else:
+                    section[key] = value
+        self._atomic_write(self.settings_file, data)
+
     def update_oauth_settings(
         self,
         issuer: Optional[str] = None,
@@ -186,64 +212,27 @@ class YamlWriter:
         refresh_token_rotation: Optional[bool] = None,
         logos_dir: Optional[str] = None,
     ) -> None:
-        """Update OAuth settings.
+        """Update OAuth settings (per-field encodings: OWNED_SETTINGS, #214).
 
         Skips writing a field whose expanded on-disk value already matches
         what's being submitted, so unchanged ``${VAR}`` placeholders and
         comments survive a form save that only changed other fields (#127).
         """
-        data = self._load_settings_yaml()
-        oauth = data.setdefault("oauth", {})
-
-        if issuer is not None and not is_unchanged(oauth.get("issuer"), issuer):
-            oauth["issuer"] = issuer
-        if issuer_from_request is not None and not is_unchanged(
-            oauth.get("issuer_from_request"), issuer_from_request
-        ):
-            oauth["issuer_from_request"] = issuer_from_request
-        if issuer_allowlist is not None:
-            if issuer_allowlist:
-                if not is_unchanged(oauth.get("issuer_allowlist"), issuer_allowlist):
-                    oauth["issuer_allowlist"] = issuer_allowlist
-            else:
-                oauth.pop("issuer_allowlist", None)
-        if device_verification_base_url is not None:
-            next_url = device_verification_base_url or ""
-            if not is_unchanged(
-                oauth.get("device_verification_base_url"),
-                next_url,
-            ):
-                if device_verification_base_url:
-                    oauth["device_verification_base_url"] = device_verification_base_url
-                else:
-                    oauth.pop("device_verification_base_url", None)
-        if issuer_from_proxy_headers is not None and not is_unchanged(
-            oauth.get("issuer_from_proxy_headers"), issuer_from_proxy_headers
-        ):
-            oauth["issuer_from_proxy_headers"] = issuer_from_proxy_headers
-        if audience is not None and not is_unchanged(oauth.get("audience"), audience):
-            oauth["audience"] = audience
-        if token_expiry_minutes is not None and not is_unchanged(
-            oauth.get("token_expiry_minutes"), token_expiry_minutes
-        ):
-            oauth["token_expiry_minutes"] = token_expiry_minutes
-        if require_pkce is not None and not is_unchanged(
-            oauth.get("require_pkce"), require_pkce
-        ):
-            oauth["require_pkce"] = require_pkce
-        if refresh_token_rotation is not None and not is_unchanged(
-            oauth.get("refresh_token_rotation"), refresh_token_rotation
-        ):
-            oauth["refresh_token_rotation"] = refresh_token_rotation
-        if logos_dir is not None:
-            next_logos_dir = logos_dir or ""
-            if not is_unchanged(oauth.get("logos_dir"), next_logos_dir):
-                if logos_dir:
-                    oauth["logos_dir"] = logos_dir
-                else:
-                    oauth.pop("logos_dir", None)
-
-        self._atomic_write(self.settings_file, data)
+        self._apply_provided_settings(
+            "oauth",
+            {
+                "issuer": issuer,
+                "issuer_from_request": issuer_from_request,
+                "issuer_allowlist": issuer_allowlist,
+                "device_verification_base_url": device_verification_base_url,
+                "issuer_from_proxy_headers": issuer_from_proxy_headers,
+                "audience": audience,
+                "token_expiry_minutes": token_expiry_minutes,
+                "require_pkce": require_pkce,
+                "refresh_token_rotation": refresh_token_rotation,
+                "logos_dir": logos_dir,
+            },
+        )
 
     def update_saml_settings(
         self,
@@ -260,68 +249,28 @@ class YamlWriter:
         roles_attr_name: Optional[str] = None,
         groups_attr_name: Optional[str] = None,
     ) -> None:
-        """Update SAML settings (same unchanged-field guard as #127 above)."""
-        data = self._load_settings_yaml()
-        saml = data.setdefault("saml", {})
+        """Update SAML settings (same #127 guard; encodings: OWNED_SETTINGS).
 
-        # Blank clears the key: absent = derived from the effective issuer
-        # (#181), the same "present-but-blank = clear" contract as #131.
-        for key, value in (("entity_id", entity_id), ("sso_url", sso_url)):
-            if value is None:
-                continue
-            if not value:
-                saml.pop(key, None)
-            elif not is_unchanged(saml.get(key), value):
-                saml[key] = value
-        if default_acs_url is not None and not is_unchanged(
-            saml.get("default_acs_url"), default_acs_url
-        ):
-            saml["default_acs_url"] = default_acs_url
-        if sign_responses is not None and not is_unchanged(
-            saml.get("sign_responses"), sign_responses
-        ):
-            saml["sign_responses"] = sign_responses
-        if strict_binding is not None and not is_unchanged(
-            saml.get("strict_binding"), strict_binding
-        ):
-            saml["strict_binding"] = strict_binding
-        if want_authn_requests_signed is not None and not is_unchanged(
-            saml.get("want_authn_requests_signed"), want_authn_requests_signed
-        ):
-            saml["want_authn_requests_signed"] = want_authn_requests_signed
-        if sp_certificates is not None:
-            if sp_certificates:
-                if not is_unchanged(saml.get("sp_certificates"), sp_certificates):
-                    saml["sp_certificates"] = sp_certificates
-            else:
-                saml.pop("sp_certificates", None)
-        if c14n_algorithm is not None and not is_unchanged(
-            saml.get("c14n_algorithm"), c14n_algorithm
-        ):
-            saml["c14n_algorithm"] = c14n_algorithm
-        if export_roles is not None and not is_unchanged(
-            saml.get("export_roles"), export_roles
-        ):
-            saml["export_roles"] = export_roles
-        if export_groups is not None and not is_unchanged(
-            saml.get("export_groups"), export_groups
-        ):
-            saml["export_groups"] = export_groups
-        # Empty string drops the key so the default name applies again.
-        if roles_attr_name is not None:
-            if roles_attr_name:
-                if not is_unchanged(saml.get("roles_attr_name"), roles_attr_name):
-                    saml["roles_attr_name"] = roles_attr_name
-            else:
-                saml.pop("roles_attr_name", None)
-        if groups_attr_name is not None:
-            if groups_attr_name:
-                if not is_unchanged(saml.get("groups_attr_name"), groups_attr_name):
-                    saml["groups_attr_name"] = groups_attr_name
-            else:
-                saml.pop("groups_attr_name", None)
-
-        self._atomic_write(self.settings_file, data)
+        Blank clears entity_id/sso_url: absent = derived from the effective
+        issuer (#181), the same "present-but-blank = clear" contract as #131.
+        """
+        self._apply_provided_settings(
+            "saml",
+            {
+                "entity_id": entity_id,
+                "sso_url": sso_url,
+                "default_acs_url": default_acs_url,
+                "sign_responses": sign_responses,
+                "strict_binding": strict_binding,
+                "want_authn_requests_signed": want_authn_requests_signed,
+                "sp_certificates": sp_certificates,
+                "c14n_algorithm": c14n_algorithm,
+                "export_roles": export_roles,
+                "export_groups": export_groups,
+                "roles_attr_name": roles_attr_name,
+                "groups_attr_name": groups_attr_name,
+            },
+        )
 
     def update_authority_prefixes(self, prefixes: Dict[str, str]) -> None:
         """Update authority prefix mappings."""

--- a/tests/test_client_field_parity.py
+++ b/tests/test_client_field_parity.py
@@ -1,9 +1,14 @@
 """
-Client-field parity across every surface of the 13-point flow (#214).
+Client-field parity across the declared surfaces of the client-field flow (#214).
 
 The registry idea was declined: the manual flow works, but a forgotten leg
-must become a suite failure instead of a review catch (the #32 shape).
-Every field of OAuthClient must therefore appear in:
+should become a suite failure instead of a review catch (the #32 shape)
+wherever that check is cheap. These tests cover the DECLARATIVE surfaces -
+the ones whose field lists can be introspected. They do NOT prove that the
+imperative legs (client_to_yaml, merge_client_entry, the UI form parsers,
+the MCP create/update handler bodies) actually apply a new field; those
+stay covered by the per-feature tests the flow requires. Every field of
+OAuthClient must appear in:
 
 - config_documents.ClientEntry (the YAML load contract),
 - mcp_server._client_to_dict (MCP read surface),

--- a/tests/test_client_field_parity.py
+++ b/tests/test_client_field_parity.py
@@ -1,0 +1,54 @@
+"""
+Client-field parity across every surface of the 13-point flow (#214).
+
+The registry idea was declined: the manual flow works, but a forgotten leg
+must become a suite failure instead of a review catch (the #32 shape).
+Every field of OAuthClient must therefore appear in:
+
+- config_documents.ClientEntry (the YAML load contract),
+- mcp_server._client_to_dict (MCP read surface),
+- the create_client and update_client tool schemas,
+- the clients form template (UI create/edit surface).
+
+The regenerate-secret leg needs no entry here: it copies the whole model
+(model_copy, #218), so it cannot miss a field by construction. The settings
+contract already gets the same treatment from #175 piece 3's parity tests.
+"""
+
+import re
+from pathlib import Path
+
+from nanoidp.config_documents import ClientEntry
+from nanoidp.mcp_server import _TOOL_SCHEMAS, _client_to_dict
+from nanoidp.models import OAuthClient
+
+_MODEL_FIELDS = set(OAuthClient.model_fields)
+
+_TEMPLATE = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "nanoidp"
+    / "templates"
+    / "clients_form.html"
+)
+
+
+class TestClientFieldParity:
+    def test_yaml_load_contract_matches_the_model(self):
+        assert set(ClientEntry.model_fields) == _MODEL_FIELDS
+
+    def test_mcp_read_surface_matches_the_model(self):
+        client = OAuthClient(client_id="parity", client_secret="s")
+        # client_secret is the one intentional omission: the read surface
+        # never echoes the secret back.
+        assert set(_client_to_dict(client)) == _MODEL_FIELDS - {"client_secret"}
+
+    def test_mcp_tool_schemas_match_the_model(self):
+        for tool in ("create_client", "update_client"):
+            assert set(_TOOL_SCHEMAS[tool]["properties"]) == _MODEL_FIELDS, tool
+
+    def test_clients_form_has_an_input_per_field(self):
+        html = _TEMPLATE.read_text()
+        form_names = set(re.findall(r'name="([a-z_]+)"', html))
+        missing = _MODEL_FIELDS - form_names
+        assert not missing, f"clients_form.html has no input for: {sorted(missing)}"

--- a/tests/test_settings_plumbing_parity.py
+++ b/tests/test_settings_plumbing_parity.py
@@ -1,0 +1,71 @@
+"""
+The settings plumbing derives from one table, and the table derives from
+the models (#214).
+
+serialization.OWNED_SETTINGS is the single description of which
+settings.yaml keys the codebase manages; apply_settings_document and
+yaml_writer's update_oauth_settings/update_saml_settings drive from it,
+and mcp_server._UPDATE_SETTINGS_FIELDS is the MCP tool's writable-field
+list. These tests pin every one of those surfaces to the document models
+and the Settings model, so a new setting that misses a surface (or a
+table row that names a key the models do not know) fails the suite
+instead of silently drifting - the same treatment the client fields get
+in tests/test_client_field_parity.py.
+"""
+
+import inspect
+
+from nanoidp import config_documents as cd
+from nanoidp.mcp_server import _TOOL_SCHEMAS, _UPDATE_SETTINGS_FIELDS
+from nanoidp.models import Settings
+from nanoidp.serialization import OWNED_SETTINGS
+from nanoidp.services.yaml_writer import YamlWriter
+
+_SECTION_MODELS = {
+    "server": cd.ServerSection,
+    "oauth": cd.OAuthSection,
+    "saml": cd.SamlSection,
+    "logging": cd.LoggingSection,
+    "": cd.SettingsDocument,
+}
+
+
+class TestOwnedSettingsDeriveFromTheModels:
+    def test_every_row_names_a_settings_attribute(self):
+        for row in OWNED_SETTINGS:
+            assert row.attr in Settings.model_fields, row
+
+    def test_every_row_names_a_document_model_field(self):
+        for row in OWNED_SETTINGS:
+            model = _SECTION_MODELS[row.section]
+            assert row.key in model.model_fields, row
+
+    def test_rows_are_unique_per_key(self):
+        keys = [(row.section, row.key) for row in OWNED_SETTINGS]
+        assert len(keys) == len(set(keys))
+
+
+class TestYamlWriterMatchesTheTable:
+    def _writer_params(self, method_name):
+        signature = inspect.signature(getattr(YamlWriter, method_name))
+        return set(signature.parameters) - {"self"}
+
+    def test_update_oauth_settings_covers_exactly_the_oauth_rows(self):
+        # `clients` is a merged list with its own save_client path, not a
+        # scalar row, and stays out of both the table and this method.
+        table = {row.key for row in OWNED_SETTINGS if row.section == "oauth"}
+        assert self._writer_params("update_oauth_settings") == table
+
+    def test_update_saml_settings_covers_exactly_the_saml_rows(self):
+        table = {row.key for row in OWNED_SETTINGS if row.section == "saml"}
+        assert self._writer_params("update_saml_settings") == table
+
+
+class TestMcpUpdateSettingsMatchesItsSchema:
+    def test_field_tuple_equals_the_tool_schema(self):
+        schema = set(_TOOL_SCHEMAS["update_settings"]["properties"])
+        assert set(_UPDATE_SETTINGS_FIELDS) == schema
+
+    def test_every_field_is_a_settings_attribute(self):
+        for field in _UPDATE_SETTINGS_FIELDS:
+            assert field in Settings.model_fields, field

--- a/tests/test_settings_plumbing_parity.py
+++ b/tests/test_settings_plumbing_parity.py
@@ -69,3 +69,51 @@ class TestMcpUpdateSettingsMatchesItsSchema:
     def test_every_field_is_a_settings_attribute(self):
         for field in _UPDATE_SETTINGS_FIELDS:
             assert field in Settings.model_fields, field
+
+
+class TestBlankClearsTheSamlAttrNames:
+    """Regression for the #226 review finding: blank means REMOVE the key.
+
+    The writer's historical contract for roles_attr_name/groups_attr_name is
+    "empty string drops the key so the default name applies again"; the
+    first table version flattened them to plain rows and persisted a literal
+    "" instead. The runtime masked it (the Settings validator normalizes
+    blank back to the defaults), so only the persisted document showed the
+    regression - which is exactly what this test reads.
+    """
+
+    def _seed(self, tmp_path):
+        import shutil
+        from pathlib import Path
+
+        import yaml
+
+        from nanoidp.config import ConfigManager
+
+        repo_config = Path(__file__).resolve().parent.parent / "config"
+        for name in ("settings.yaml", "users.yaml"):
+            shutil.copy(repo_config / name, tmp_path / name)
+        data = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+        data["saml"]["roles_attr_name"] = "memberOf"
+        data["saml"]["groups_attr_name"] = "memberGroups"
+        (tmp_path / "settings.yaml").write_text(yaml.safe_dump(data))
+        ConfigManager(str(tmp_path))  # the writer resolves its dir from this
+        return YamlWriter(str(tmp_path))
+
+    def test_blank_removes_the_keys_from_yaml(self, tmp_path):
+        import yaml
+
+        writer = self._seed(tmp_path)
+        writer.update_saml_settings(roles_attr_name="", groups_attr_name="")
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert "roles_attr_name" not in saml
+        assert "groups_attr_name" not in saml
+
+    def test_custom_value_still_persists(self, tmp_path):
+        import yaml
+
+        writer = self._seed(tmp_path)
+        writer.update_saml_settings(roles_attr_name="entitlementsOf")
+        saml = yaml.safe_load((tmp_path / "settings.yaml").read_text())["saml"]
+        assert saml["roles_attr_name"] == "entitlementsOf"
+        assert saml["groups_attr_name"] == "memberGroups"


### PR DESCRIPTION
Implements #214 as decided (registry declined - see the issue comment): make a forgotten leg a suite failure, and collapse the real hotspots into one table derived from the models.

**Piece 1, client-field parity** (tests/test_client_field_parity.py): every OAuthClient field must appear in config_documents.ClientEntry, mcp _client_to_dict (one commented exception: the read surface never echoes client_secret), both client tool schemas, and the clients form template. The regenerate-secret leg needs no entry: model_copy (#218) cannot miss a field by construction.

**Piece 2, settings plumbing**: serialization gains `OwnedSetting`/`OWNED_SETTINGS` - one row per owned settings.yaml key with its section, Settings attribute and absence encoding (plain / omit-when-falsy / omit-when-none for the #181 derived keys). Three consumers now drive from it instead of one hand-written if-block per field:
- `apply_settings_document`: CC 44 (radon F, the worst left in the repo) -> 16; the two defaults-dependent keys (security_profile, login.mode) and the merged clients list stay explicit.
- `yaml_writer.update_oauth_settings`/`update_saml_settings`: CC 26/28 -> the file has no C-grade function left; the #131 absent-is-unchanged and #127 placeholder-preserving guards are stated once in `_apply_provided_settings`.
- `mcp _tool_update_settings`: CC 26 -> a loop over `_UPDATE_SETTINGS_FIELDS` plus a small normalizer map; updated_fields order and the response body unchanged.

**The derivation contract** (tests/test_settings_plumbing_parity.py): every table row must name a real Settings attribute and a real document-model field for its section; the two writer signatures must cover exactly their sections' rows; the MCP field tuple must equal the tool's input_schema. The models stay the single source of truth - the table cannot drift from them without a test failure, which is the property the declined registry was supposed to buy, at a fraction of the machinery.

One deliberate micro-unification, visible only in a corner: the original writers disagreed among themselves on whether clearing an optional key that is already absent/empty pops unconditionally or under the unchanged-guard; the shared helper always guards, so a literal empty value already on disk is never rewritten. No effective-settings change in any case.

1539 tests green (11 new), ruff/mypy/import contracts clean, live examples/test_agent.py 56/57 (known environmental failure only).

Closes #214.