### PR TITLE
fix: /saml/sso rejects an AuthnRequest with no ACS URL and a blank default_acs_url (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **/saml/sso rejects a request with nowhere to send the assertion** (#227):
+  an AuthnRequest without `AssertionConsumerServiceURL` against a config
+  whose `saml.default_acs_url` is blank now gets a 400 naming both missing
+  sources (with a failed `saml_request` audit entry), instead of rendering
+  an auto-submit form posting to `action=""` - the IdP's own page.
 - **The dashboard's Logout button logs the UI session out again** (#221).
   The UI logout route registered the same `/logout` rule as the OIDC
   end-session endpoint and always lost: clicking Logout landed on the

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -8,7 +8,7 @@ import uuid
 import zlib
 from base64 import b64decode, b64encode
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 from flask import Blueprint, Response, abort, render_template, request, session
 from flask.typing import ResponseReturnValue
@@ -672,13 +672,32 @@ def sso() -> ResponseReturnValue:
     if invalid is not None:
         return invalid
 
-    # acs_url is None only when the request names no ACS URL AND
-    # saml.default_acs_url is unset - a latent pre-existing 500 (the old
-    # inline code crashed on html.escape(None) the same way), preserved
-    # as-is by this refactor and left for its own fix.
-    return _sso_success_response(
-        config, user, username, cast(str, acs_url), in_response_to, relay_state
-    )
+    # No ACS URL to send the assertion to: the request names none and
+    # saml.default_acs_url is blank. Reject cleanly (#227). The None arm of
+    # this used to 500 on html.escape(None) but became unreachable when the
+    # document models gave default_acs_url a non-None default (#175); the
+    # arm that IS reachable is an explicit default_acs_url: "" (a valid str),
+    # which used to render an auto-submit form posting to action="" - the
+    # IdP's own page - instead of failing. The message names both missing
+    # sources, in the spirit of "metadata never lies": neither should errors.
+    if not acs_url:
+        audit_event(
+            "saml_request",
+            "failed",
+            endpoint="/saml/sso",
+            username=username,
+            details={
+                "reason": "AuthnRequest has no AssertionConsumerServiceURL "
+                "and saml.default_acs_url is not configured"
+            },
+        )
+        return abort(
+            400,
+            description="AuthnRequest has no AssertionConsumerServiceURL "
+            "and saml.default_acs_url is not configured",
+        )
+
+    return _sso_success_response(config, user, username, acs_url, in_response_to, relay_state)
 
 
 def _build_attribute_query_response(

--- a/tests/test_sso_missing_acs.py
+++ b/tests/test_sso_missing_acs.py
@@ -1,0 +1,87 @@
+"""
+/sso rejects a request with nowhere to send the assertion (#227).
+
+An AuthnRequest without AssertionConsumerServiceURL, against a config
+whose saml.default_acs_url is blank, used to reach the success path with
+an empty ACS: the None arm (the latent html.escape(None) 500 surfaced by
+#223's typing) became unreachable once the document models gave
+default_acs_url a non-None default (#175), but an explicit
+default_acs_url: "" is a valid str and rendered an auto-submit form
+posting to action="" - the IdP's own page. Both arms are now a clean 400
+naming the two missing sources, with a failed saml_request audit entry.
+"""
+
+import base64
+import shutil
+import zlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nanoidp.app import create_app
+
+_REPO_CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+
+
+def _authn_request_without_acs():
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID="_no_acs_req"
+    Version="2.0"
+    IssueInstant="2025-01-01T00:00:00Z">
+    <saml:Issuer>http://sp.example.com</saml:Issuer>
+</samlp:AuthnRequest>"""
+    compressed = zlib.compress(xml.encode("utf-8"))[2:-4]
+    return base64.b64encode(compressed).decode("ascii")
+
+
+@pytest.fixture
+def acs_less_client(tmp_path):
+    """An app whose config BLANKS saml.default_acs_url.
+
+    Merely omitting the key is not enough: the document models give
+    default_acs_url a non-None default (#175), so the explicit empty
+    string is the one reachable "no default configured" state.
+    """
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    for name in ("settings.yaml", "users.yaml"):
+        shutil.copy(_REPO_CONFIG_DIR / name, cfg / name)
+    data = yaml.safe_load((cfg / "settings.yaml").read_text())
+    data["saml"]["default_acs_url"] = ""
+    data.setdefault("jwt", {})["keys_dir"] = str(tmp_path / "keys")
+    (cfg / "settings.yaml").write_text(yaml.safe_dump(data))
+    app = create_app(config_dir=str(cfg))
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestSsoWithoutAnyAcsUrl:
+    def _login(self, client):
+        client.post("/login", data={"username": "admin", "password": "admin"})
+
+    def test_rejects_with_400_naming_both_missing_sources(self, acs_less_client):
+        from nanoidp.services import get_audit_log
+
+        self._login(acs_less_client)
+        resp = acs_less_client.get(
+            "/saml/sso", query_string={"SAMLRequest": _authn_request_without_acs()}
+        )
+        assert resp.status_code == 400
+        assert b"AssertionConsumerServiceURL" in resp.data
+        assert b"default_acs_url" in resp.data
+        entries = get_audit_log().get_entries(limit=5, event_type="saml_request")
+        assert any(e.get("status") == "failed" for e in entries)
+
+    def test_default_acs_url_still_rescues_an_acs_less_request(self, client):
+        """Control: the shipped preset HAS default_acs_url, so the same
+        request succeeds there - the rejection is only for the double-miss."""
+        self._login(client)
+        resp = client.get(
+            "/saml/sso", query_string={"SAMLRequest": _authn_request_without_acs()}
+        )
+        assert resp.status_code == 200
+        assert b"SAMLResponse" in resp.data


### PR DESCRIPTION
One correction to the issue's premise, found while writing the failing test: the None arm (`html.escape(None)` 500) is UNREACHABLE since #175 gave `default_acs_url` a non-None model default - omitting the key yields the default URL and an explicit `null` fails type validation at startup. The reachable form of "no ACS anywhere" is an explicit `default_acs_url: ""` (a valid str), and its failure mode was not a crash but quieter: the success path rendered an auto-submit form posting to `action=""` - the IdP's own page.

The guard therefore rejects on falsy (covering both the theoretical None and the real ""), with a 400 naming both missing sources and a failed `saml_request` audit event, and #223's documented cast is gone. Tests: the double-miss returns 400 with both names in the body and the audit entry present; a control asserts the shipped preset's default still rescues an ACS-less request. CHANGELOG entry under Unreleased/Fixed.

1564 tests green.

Closes #227.