### PR TITLE
chore: bump to 2.8.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.7.0"
+version = "2.8.0rc1"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
First release candidate of the 2.8 cycle. CHANGELOG stays under [Unreleased] per the pre-release policy (consolidation happens at the final); the rc's content is described in its GitHub pre-release notes. Pre-flight on main (33c3c3a): 1564 tests, ruff, mypy, import contracts, validate-config all green; every 2.8.0-milestone issue closed. After merge: tag v2.8.0-rc1 (hyphenated, :latest stays on 2.7.0), GitHub release with --prerelease, full artifact verification per docs/RELEASING.md.