### PR TITLE
fix: /token stops issuing a refresh token for client_credentials (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`client_credentials` no longer returns a refresh token** (#239). RFC
+  6749 §4.4.3: "A refresh token SHOULD NOT be included" - the client
+  authenticates itself on every request, and the token handed out was a
+  second, 7-day credential bound to the default user (or the synthetic
+  service account) that the grant never authenticated, spendable at
+  `grant_type=refresh_token` for user-context tokens. The response now
+  has no `refresh_token` key at all; every other grant is unchanged. A
+  client that refreshed a client-credentials token must request a new
+  one with its credentials, which is what the RFC asks of it.
 - **/saml/sso rejects a request with nowhere to send the assertion** (#227):
   an AuthnRequest without `AssertionConsumerServiceURL` against a config
   whose `saml.default_acs_url` is blank now gets a 400 naming both missing

--- a/book/src/guides/token-requests.md
+++ b/book/src/guides/token-requests.md
@@ -26,6 +26,11 @@ curl -X POST 'http://localhost:8000/token' \
   -d 'grant_type=client_credentials'
 ```
 
+The response carries no `refresh_token`: the client authenticates itself
+on every request, so there is nothing a refresh token could stand in for
+(RFC 6749 §4.4.3, "A refresh token SHOULD NOT be included"). Request a
+new access token the same way when the current one expires.
+
 ## Refresh token
 
 ```bash

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -365,11 +365,20 @@ class NanoIDPTestAgent:
                 if jwt and token:
                     decoded = jwt.decode(token, options={"verify_signature": False})
                     sub = decoded.get("sub", "?")
+                # RFC 6749 §4.4.3: no refresh token for this grant (#239).
+                if "refresh_token" in data:
+                    return self._add_result(
+                        "Client Credentials",
+                        TestCategory.OAUTH,
+                        False,
+                        "Response carries a refresh_token (RFC 6749 §4.4.3: SHOULD NOT)",
+                        {"expires_in": expires, "subject": sub},
+                    )
                 return self._add_result(
                     "Client Credentials",
                     TestCategory.OAUTH,
                     True,
-                    f"Token OK, sub={sub}, expires={expires}s",
+                    f"Token OK, sub={sub}, expires={expires}s, no refresh_token",
                     {"expires_in": expires, "subject": sub}
                 )
             error = response.json().get("error", "unknown")

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -528,6 +528,9 @@ class _GrantOutcome:
     # Claim names requested via the OIDC `claims` parameter (§5.5, #104).
     id_token_claims: Optional[list] = None
     userinfo_claims: Optional[list] = None
+    # False for grants with no end user: client_credentials must not hand
+    # out a refresh token (RFC 6749 §4.4.3, #239).
+    issue_refresh_token: bool = True
 
 
 @dataclass
@@ -1023,7 +1026,17 @@ def _grant_client_credentials(ctx: _GrantContext) -> GrantResult:
             roles=["user"],
             tenant="default",
         )
-    return _GrantOutcome(user=user, username=user.username, scope=requested_scope)
+    # RFC 6749 §4.4.3: "A refresh token SHOULD NOT be included." The client
+    # authenticates itself on every request; a refresh token here would be a
+    # second, 7-day credential bound to the default user (or the synthetic
+    # service account) that the grant never authenticated, spendable at
+    # grant_type=refresh_token to obtain user-context tokens (#239).
+    return _GrantOutcome(
+        user=user,
+        username=user.username,
+        scope=requested_scope,
+        issue_refresh_token=False,
+    )
 
 
 def _grant_device_code(ctx: _GrantContext) -> GrantResult:
@@ -1268,6 +1281,7 @@ def token() -> ResponseReturnValue:
         id_token_claims=result.id_token_claims,
         userinfo_claims=result.userinfo_claims,
         issuer=effective_issuer(config.settings),
+        issue_refresh_token=result.issue_refresh_token,
     )
 
     # Audit log

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -217,6 +217,7 @@ class TokenService:
         id_token_claims: Optional[List[str]] = None,
         userinfo_claims: Optional[List[str]] = None,
         issuer: Optional[str] = None,
+        issue_refresh_token: bool = True,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user.
 
@@ -238,6 +239,13 @@ class TokenService:
         caller's own discovery document just advertised (``issuer_from_request``)
         - a token whose ``iss`` doesn't match what discovery said is rejected by
         any spec-compliant client.
+
+        ``issue_refresh_token`` is False for grants without an end user
+        (client_credentials, RFC 6749 §4.4.3: "A refresh token SHOULD NOT be
+        included", #239): the client authenticates itself on every call, so a
+        refresh token would only be a second, long-lived credential bound to a
+        user the grant never involved. When False no refresh JWT is minted and
+        the response carries no ``refresh_token`` key at all.
         """
         settings = self.config.settings
         effective_issuer = issuer or settings.issuer
@@ -370,34 +378,34 @@ class TokenService:
         #   via the OIDC `claims` parameter, so a refreshed ID Token keeps the
         #   requested claims and /userinfo keeps honouring them for the
         #   refreshed access token (OIDC Core §12.2, #112).
-        refresh_extra: Dict[str, Any] = {"token_type": "refresh", "token_use": "refresh"}
-        if scope:
-            refresh_extra["scope"] = scope
-        if effective_auth_time is not None:
-            refresh_extra["auth_time"] = effective_auth_time
-        if client_id:
-            refresh_extra["client_id"] = client_id
-        if id_token_claims:
-            refresh_extra["req_id_token_claims"] = id_token_claims
-        if userinfo_claims:
-            refresh_extra["req_userinfo_claims"] = userinfo_claims
-        refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
-        refresh_token = self.crypto.create_jwt(
-            sub=user.username,
-            issuer=effective_issuer,
-            audience=settings.audience,
-            roles=user.roles,
-            tenant=user.tenant,
-            extra=refresh_extra,
-            exp_minutes=7 * 24 * 60,  # 7 days
-        )
-
-        response = {
+        # Skipped entirely for grants with no end-user context (#239).
+        response: Dict[str, Any] = {
             "access_token": token,
             "token_type": "Bearer",
             "expires_in": exp_minutes * 60,
-            "refresh_token": refresh_token,
         }
+        if issue_refresh_token:
+            refresh_extra: Dict[str, Any] = {"token_type": "refresh", "token_use": "refresh"}
+            if scope:
+                refresh_extra["scope"] = scope
+            if effective_auth_time is not None:
+                refresh_extra["auth_time"] = effective_auth_time
+            if client_id:
+                refresh_extra["client_id"] = client_id
+            if id_token_claims:
+                refresh_extra["req_id_token_claims"] = id_token_claims
+            if userinfo_claims:
+                refresh_extra["req_userinfo_claims"] = userinfo_claims
+            refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
+            response["refresh_token"] = self.crypto.create_jwt(
+                sub=user.username,
+                issuer=effective_issuer,
+                audience=settings.audience,
+                roles=user.roles,
+                tenant=user.tenant,
+                extra=refresh_extra,
+                exp_minutes=7 * 24 * 60,  # 7 days
+            )
         # RFC 6749 §5.1: report the scope actually granted - it may have been
         # narrowed on refresh (§6) and was previously hardcoded to "openid"
         # regardless of the grant (#56). Omitted when no scope was involved.

--- a/tests/test_client_credentials_no_refresh.py
+++ b/tests/test_client_credentials_no_refresh.py
@@ -1,0 +1,145 @@
+"""
+Issue #239: the client_credentials grant must not hand out a refresh token.
+
+RFC 6749 §4.4.3: "A refresh token SHOULD NOT be included." The client
+authenticates itself on every request; a refresh token bound to the default
+user (or the synthetic service account) would be a second, long-lived
+credential for a user the grant never authenticated. Every other grant keeps
+issuing one.
+"""
+
+import base64
+import json
+
+import jwt as pyjwt
+import pytest
+
+from nanoidp.config import User, get_config
+from nanoidp.routes.oauth import _GrantOutcome
+from nanoidp.services.token import get_token_service
+
+BASIC = {"Authorization": "Basic " + base64.b64encode(b"demo-client:demo-secret").decode()}
+
+
+@pytest.fixture
+def oauth21(app):
+    """Switch the active config to the oauth21 profile for one test."""
+    with app.app_context():
+        settings = get_config().settings
+        settings.security_profile = "oauth21"
+    yield settings
+    settings.security_profile = "dev"
+
+
+def _client_credentials(client, **form):
+    response = client.post(
+        "/token", data={"grant_type": "client_credentials", **form}, headers=BASIC
+    )
+    assert response.status_code == 200, response.data
+    return json.loads(response.data)
+
+
+class TestClientCredentialsResponse:
+    def test_response_has_no_refresh_token_key(self, client):
+        data = _client_credentials(client)
+
+        assert "access_token" in data
+        # The key is absent, not present with a null value.
+        assert "refresh_token" not in data
+        assert set(data) == {"access_token", "token_type", "expires_in"}
+
+    def test_still_no_refresh_token_with_a_granted_scope(self, client):
+        data = _client_credentials(client, scope="profile")
+
+        assert data["scope"] == "profile"
+        assert "refresh_token" not in data
+
+    def test_still_no_refresh_token_under_oauth21(self, client, oauth21):
+        data = _client_credentials(client)
+
+        assert "access_token" in data
+        assert "refresh_token" not in data
+
+    def test_access_token_cannot_be_spent_as_a_refresh_token(self, client):
+        """There is nothing to refresh with: the only token handed out is an
+        access token, and the refresh grant rejects it as not a refresh token."""
+        data = _client_credentials(client)
+
+        response = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": data["access_token"]},
+            headers=BASIC,
+        )
+
+        assert response.status_code == 400
+        assert b"Invalid token type" in response.data
+
+    def test_grant_outcome_defaults_to_issuing_a_refresh_token(self):
+        """Only client_credentials opts out; a new handler gets a refresh token
+        unless it says otherwise."""
+        outcome = _GrantOutcome(user=User(username="u", password="p"), username="u")
+
+        assert outcome.issue_refresh_token is True
+
+
+class TestOtherGrantsUnchanged:
+    def test_password_grant_still_issues_a_refresh_token(self, client):
+        response = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers=BASIC,
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        payload = pyjwt.decode(data["refresh_token"], options={"verify_signature": False})
+        assert payload["token_type"] == "refresh"
+
+    def test_refresh_grant_still_issues_a_refresh_token(self, client):
+        first = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers=BASIC,
+        )
+        refresh_token = json.loads(first.data)["refresh_token"]
+
+        response = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+            headers=BASIC,
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert "refresh_token" in data
+
+
+class TestTokenServiceFlag:
+    @pytest.fixture
+    def user(self):
+        return User(username="svc", password="x", roles=["user"], tenant="default")
+
+    def test_flag_false_omits_the_refresh_token(self, app, user):
+        with app.app_context():
+            result = get_token_service().create_token(user, issue_refresh_token=False)
+
+        assert "refresh_token" not in result
+        assert "access_token" in result
+
+    def test_flag_defaults_to_true(self, app, user):
+        with app.app_context():
+            result = get_token_service().create_token(user)
+
+        payload = pyjwt.decode(result["refresh_token"], options={"verify_signature": False})
+        assert payload["token_use"] == "refresh"
+        assert "rt_family" in payload
+
+    def test_flag_false_leaves_the_id_token_alone(self, app, user):
+        """The refresh decision is independent of the ID Token decision."""
+        with app.app_context():
+            result = get_token_service().create_token(
+                user, scope="openid", client_id="demo-client", issue_refresh_token=False
+            )
+
+        assert "id_token" in result
+        assert "refresh_token" not in result


### PR DESCRIPTION
Closes #239.

RFC 6749 s4.4.3: "A refresh token SHOULD NOT be included." The client authenticates itself on every request; the refresh token `/token` handed out was a second, 7-day credential bound to the default user (or the synthetic `service-account`) that the grant never authenticated, spendable at `grant_type=refresh_token` for user-context tokens, and under `oauth21` it entered the rotation/family machinery for nothing.

**Change**
- `TokenService.create_token()` gains `issue_refresh_token: bool = True`. When False the refresh JWT is not minted and the response has no `refresh_token` key at all (not `null`).
- `_GrantOutcome` carries the flag; `_grant_client_credentials` is the only handler setting it to False, so every other grant is byte-for-byte unchanged. A new grant handler gets a refresh token unless it opts out (pinned by a test).
- MCP `generate_token`: assessed for parity as the issue asked. It always mints for a named `username`, so it is a user-context issuance by construction; there is no client-only path there and nothing changes.

**Tests** (`tests/test_client_credentials_no_refresh.py`, 10 tests): response shape under `dev` and `oauth21`, with and without a granted scope; the client-credentials access token spent as a refresh token is rejected (400 "Invalid token type"); password and refresh grants still return one; the service flag in isolation and its independence from ID Token issuance. `examples/test_agent.py` now fails the Client Credentials check if a `refresh_token` comes back.

**Docs**: `guides/token-requests.md`, client credentials section (one paragraph, RFC cited). `reference/tokens.md` does not list the token response shape, so nothing to change there. CHANGELOG under Unreleased/Fixed.

**Verification**: 1574 unit tests green, mypy clean, ruff clean, `lint-imports` 2 kept / 0 broken. Live on a fresh `nanoidp init`: `client_credentials` -> `{access_token, token_type, expires_in}` (with `scope=profile` -> plus `scope`), `password` -> still has `refresh_token`, cc access token as `refresh_token` -> 400, garbage refresh token -> 401. `examples/test_agent.py` 56/57 (the one failure, "Redirect URI Exact Match", is identical on main).

**Side finding, not fixed here**: `_grant_client_credentials`'s fallback `User(username="service-account", password="", ...)` (taken when `default_user` names a user that does not exist) raises a pydantic `ValidationError` since #158 made `password` `min_length=1`, so that path is a 500. Reproduced; filed separately.
