### PR TITLE
fix: client_credentials service-account fallback no longer 500s (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whose `saml.default_acs_url` is blank now gets a 400 naming both missing
   sources (with a failed `saml_request` audit entry), instead of rendering
   an auto-submit form posting to `action=""` - the IdP's own page.
+- **`client_credentials` no longer 500s when `default_user` names a missing
+  user** (#241): the synthetic `service-account` fallback was built with an
+  empty password, which `User` rejects since #158 made `password` optional
+  with `min_length=1`. The fallback now carries no password, as it never
+  authenticates with one, and the grant answers with `sub=service-account`
+  again.
 - **The dashboard's Logout button logs the UI session out again** (#221).
   The UI logout route registered the same `/logout` rule as the OIDC
   end-session endpoint and always lost: clicking Logout landed on the

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1016,10 +1016,12 @@ def _grant_client_credentials(ctx: _GrantContext) -> GrantResult:
     default_username = ctx.config.default_user
     user = ctx.config.get_user(default_username)
     if not user:
-        # Create a minimal service account user
+        # Create a minimal service account user. No password: it never
+        # authenticates with one, and User.password rejects "" since #158
+        # (min_length=1) - the old empty string made this path a 500 (#241).
         user = User(
             username="service-account",
-            password="",
+            password=None,
             roles=["user"],
             tenant="default",
         )

--- a/tests/test_client_credentials_fallback.py
+++ b/tests/test_client_credentials_fallback.py
@@ -1,0 +1,44 @@
+"""
+Issue #241: the client_credentials service-account fallback must not 500.
+
+When ``default_user`` names a user that does not exist, the grant mints for a
+synthetic ``service-account`` user. Since #158 ``User.password`` rejects the
+empty string, so the fallback has to be built without a password.
+"""
+
+import base64
+import json
+
+import jwt as pyjwt
+
+from nanoidp.config import get_config
+
+BASIC = {"Authorization": "Basic " + base64.b64encode(b"demo-client:demo-secret").decode()}
+
+
+def test_missing_default_user_falls_back_to_the_service_account(app, client):
+    with app.app_context():
+        config = get_config()
+        assert config.get_user("nobody-here") is None
+        config.default_user = "nobody-here"
+
+    response = client.post("/token", data={"grant_type": "client_credentials"}, headers=BASIC)
+
+    assert response.status_code == 200, response.data
+    payload = pyjwt.decode(
+        json.loads(response.data)["access_token"], options={"verify_signature": False}
+    )
+    assert payload["sub"] == "service-account"
+    assert payload["roles"] == ["user"]
+
+
+def test_existing_default_user_is_still_preferred(app, client):
+    with app.app_context():
+        default_user = get_config().default_user
+
+    response = client.post("/token", data={"grant_type": "client_credentials"}, headers=BASIC)
+
+    payload = pyjwt.decode(
+        json.loads(response.data)["access_token"], options={"verify_signature": False}
+    )
+    assert payload["sub"] == default_user


### PR DESCRIPTION
Closes #241.

`_grant_client_credentials` built the synthetic `service-account` user with `password=""` when `default_user` names a user that does not exist. Since #158 made `User.password` `Optional[str]` with `min_length=1`, that constructor raises a pydantic `ValidationError` and the request ends in a 500 (reproduced in the issue).

**Change**: the fallback carries `password=None` (it never authenticates with a password), with a comment naming the constraint. One line of code.

**Tests** (`tests/test_client_credentials_fallback.py`): `default_user` pointed at a missing user -> 200, `sub == "service-account"`, `roles == ["user"]` (fails on main: 500); an existing `default_user` is still preferred. CHANGELOG under Unreleased/Fixed.

**Verification**: 1566 tests green, mypy and ruff clean.

Independent of #240 (both touch the same function but different lines; the CHANGELOG entries sit at different anchors).
