### PR TITLE
docs: add an Adopters section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ pytest
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, the
 end-to-end test agent, code quality tooling, and the release process.
 
+## Adopters
+
+Organizations using NanoIDP in their development or testing workflows:
+
+- [World Direct](https://www.world-direct.at)
+
+Listing means NanoIDP is in use there. It does not imply sponsorship or
+endorsement. If you use it and would like to be listed, open an issue or a
+pull request against this section.
+
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds an `## Adopters` section to the README, between Development and License.

**First entry: [World Direct](https://www.world-direct.at)**, listed with the explicit authorisation of @gprossliner in #244, who reported the persona-mode feedback that started that issue and confirmed his employer may be named.

**Placement:** bottom of the README, not the top. #238 rewrote the README to open from the problem and keep the top lean; an adopters list up there would read as a vitrine.

**Wording:** the section states what a listing means (NanoIDP is in use there, not sponsorship or endorsement) and how to be added, so the next entry is a procedure rather than a decision each time.

Docs only, no code touched.
