### PR TITLE
feat: migrate YamlWriter onto compare_and_replace (#229 phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LockUnavailableError` - instead of a bare `OSError` or an indefinite
   hang - when the lock file's filesystem does not support advisory locks
   or a peer process holds it for more than 10 seconds.
+- **The web UI's writer (`YamlWriter`) now uses the same write primitive
+  as `ConfigManager.save()`** (#229): `save_user`, `delete_user`,
+  `save_client`, `delete_client` and the rest of its write methods route
+  through `compare_and_replace`, and each gained an optional
+  `expected_revision` precondition (unused by any caller yet). The
+  practical effect today: creating or deleting a user/client now checks
+  "does this already exist / does this exist at all" against the same
+  document it writes, under the same lock, instead of against a copy
+  loaded before the write started. Previously, two near-simultaneous
+  submissions creating the same new user or client could both pass
+  their "already exists" check and the second would silently overwrite
+  the first, with no error to either request; that lost update is now
+  impossible - the second request correctly gets an "already exists"
+  error instead.
 
 ### Security
 - **Opt-in `management_secret` mutation gate** (#163): one shared secret that

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -82,10 +82,11 @@ one coordinated, conflict-checked save (#229): both files are written,
 both hooks then run, and the runtime is refreshed from disk once before a
 `strict` failure is raised - a failing hook on one file does not leave
 the other unwritten.
-The web UI's settings page is a different, older path (`YamlWriter`):
-it still writes its sections one atomic write at a time, so under
-`strict` a failing hook there leaves the steps after it unsaved (the
-flash message says which write failed). Make the hook idempotent: the
+The web UI's settings page (`YamlWriter`) uses the same primitive now
+(#229 phase 3), but still writes its sections one call at a time
+rather than as a batch, so under `strict` a failing hook there leaves
+the later sections in that page's save unsaved (the flash message says
+which write failed). Make the hook idempotent: the
 next save re-mirrors. `on_audit_event` never fails the request that
 produced the event: a token already issued must not turn into a 500 because
 an audit sink is down. Failures are counted per hook and shown by

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -5,14 +5,14 @@ Provides atomic write operations for YAML configuration files.
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ..config import OAuthClient, Settings, User, get_config
 from ..config_documents import document_defaults
+from ..config_writer import compare_and_replace
 from ..hooks import HookError
 from ..serialization import (
     OWNED_SETTINGS,
-    atomic_write_yaml,
     client_id_matches,
     client_to_yaml,
     is_unchanged,
@@ -34,12 +34,30 @@ class YamlWriter:
         self.users_file = self.config_dir / "users.yaml"
         self.settings_file = self.config_dir / "settings.yaml"
 
-    def _atomic_write(self, file_path: Path, data: Dict[str, Any]) -> None:
-        """Atomically write a YAML document (shared implementation, #83), then
-        run the single post-write contract (#185):
+    def _atomic_write(
+        self,
+        file_path: Path,
+        mutate: Callable[[Dict[str, Any]], Any],
+        expected_revision: Optional[str] = None,
+    ) -> None:
+        """Write via the shared compare-and-replace primitive (#229 phase 3),
+        then run the single post-write contract (#185):
 
-            write local -> notify the mirror (on_config_saved) -> refresh the
-            runtime FROM LOCAL DISK -> propagate a mirror failure if strict.
+            check -> load -> mutate -> replace -> notify the mirror
+            (on_config_saved) -> refresh the runtime FROM LOCAL DISK ->
+            propagate a mirror failure if strict.
+
+        ``mutate`` receives the freshly loaded document and edits it in
+        place (``compare_and_replace``'s own contract) - every caller's
+        existence/not-found check now happens *inside* ``mutate`` rather
+        than on a document loaded beforehand, so it runs against the
+        same document that gets written, under the same lock, instead of
+        racing a concurrent writer between an earlier check and this
+        write (the #229 the whole primitive exists to close).
+        ``expected_revision`` (default ``None``, unconditional - today's
+        last-write-wins) is a stale-precondition check: a mismatch
+        raises ``ConflictError`` before the file is even loaded, let
+        alone mutated.
 
         The refresh is ConfigManager.reload_local(), never reload(): a
         reload() would run on_before_load and could pull a stale or
@@ -48,7 +66,7 @@ class YamlWriter:
         newest state after our own write; only an explicit reload consults
         the mirror.
         """
-        atomic_write_yaml(file_path, data)
+        compare_and_replace(file_path, expected_revision, mutate)
         kind = "users" if file_path.name == "users.yaml" else "settings"
         config = get_config()
         hook_error: Optional[HookError] = None
@@ -72,107 +90,124 @@ class YamlWriter:
 
     # ==================== User Operations ====================
 
-    def save_user(self, user: User, is_new: bool = False) -> None:
+    def save_user(
+        self, user: User, is_new: bool = False, expected_revision: Optional[str] = None
+    ) -> None:
         """
         Save or update a user in users.yaml.
 
         Args:
             user: The User object to save
             is_new: If True, will fail if user already exists
+            expected_revision: #229 phase 3 - optional stale-write guard,
+                unused by any caller yet
         """
-        data = self._load_users_yaml()
 
-        if is_new and user.username in data.get("users", {}):
-            raise ValueError(f"User '{user.username}' already exists")
+        def mutate(data: Dict[str, Any]) -> None:
+            data.setdefault("users", {})
+            data.setdefault("default_user", "admin")
+            if is_new and user.username in data["users"]:
+                raise ValueError(f"User '{user.username}' already exists")
+            data["users"][user.username] = user_to_yaml(user)
 
-        data.setdefault("users", {})[user.username] = user_to_yaml(user)
+        self._atomic_write(self.users_file, mutate, expected_revision)
 
-        self._atomic_write(self.users_file, data)
-
-    def delete_user(self, username: str) -> None:
+    def delete_user(self, username: str, expected_revision: Optional[str] = None) -> None:
         """
         Delete a user from users.yaml.
 
         Args:
             username: The username to delete
+            expected_revision: #229 phase 3 - optional stale-write guard,
+                unused by any caller yet
         """
-        data = self._load_users_yaml()
 
-        if username not in data.get("users", {}):
-            raise ValueError(f"User '{username}' not found")
+        def mutate(data: Dict[str, Any]) -> None:
+            data.setdefault("users", {})
+            data.setdefault("default_user", "admin")
+            if username not in data["users"]:
+                raise ValueError(f"User '{username}' not found")
+            del data["users"][username]
 
-        del data["users"][username]
+            # If deleted user was the default, update default_user
+            if data.get("default_user") == username:
+                remaining_users = list(data["users"].keys())
+                data["default_user"] = remaining_users[0] if remaining_users else ""
 
-        # If deleted user was the default, update default_user
-        if data.get("default_user") == username:
-            remaining_users = list(data.get("users", {}).keys())
-            data["default_user"] = remaining_users[0] if remaining_users else ""
+        self._atomic_write(self.users_file, mutate, expected_revision)
 
-        self._atomic_write(self.users_file, data)
-
-    def set_default_user(self, username: str) -> None:
+    def set_default_user(self, username: str, expected_revision: Optional[str] = None) -> None:
         """Set the default user for client_credentials grant."""
-        data = self._load_users_yaml()
 
-        if username not in data.get("users", {}):
-            raise ValueError(f"User '{username}' not found")
+        def mutate(data: Dict[str, Any]) -> None:
+            data.setdefault("users", {})
+            if username not in data["users"]:
+                raise ValueError(f"User '{username}' not found")
+            data["default_user"] = username
 
-        data["default_user"] = username
-
-        self._atomic_write(self.users_file, data)
+        self._atomic_write(self.users_file, mutate, expected_revision)
 
     # ==================== OAuth Client Operations ====================
 
-    def save_client(self, client: OAuthClient, is_new: bool = False) -> None:
+    def save_client(
+        self, client: OAuthClient, is_new: bool = False, expected_revision: Optional[str] = None
+    ) -> None:
         """
         Save or update an OAuth client in settings.yaml.
 
         Args:
             client: The OAuthClient object to save
             is_new: If True, will fail if client already exists
+            expected_revision: #229 phase 3 - optional stale-write guard,
+                unused by any caller yet
         """
-        data = self._load_settings_yaml()
 
-        clients = data.setdefault("oauth", {}).setdefault("clients", [])
+        def mutate(data: Dict[str, Any]) -> None:
+            clients = data.setdefault("oauth", {}).setdefault("clients", [])
 
-        # Check if client exists. Match through client_id_matches so a raw
-        # ${CLIENT_ID:...} placeholder entry is recognised as the same client
-        # instead of being appended as a duplicate (#127).
-        existing_idx = None
-        for idx, c in enumerate(clients):
-            if client_id_matches(c, client.client_id):
-                existing_idx = idx
-                break
+            # Check if client exists. Match through client_id_matches so a
+            # raw ${CLIENT_ID:...} placeholder entry is recognised as the
+            # same client instead of being appended as a duplicate (#127).
+            existing_idx = None
+            for idx, c in enumerate(clients):
+                if client_id_matches(c, client.client_id):
+                    existing_idx = idx
+                    break
 
-        if is_new and existing_idx is not None:
-            raise ValueError(f"Client '{client.client_id}' already exists")
+            if is_new and existing_idx is not None:
+                raise ValueError(f"Client '{client.client_id}' already exists")
 
-        if existing_idx is not None:
-            clients[existing_idx] = merge_client_entry(clients[existing_idx], client)
-        else:
-            clients.append(client_to_yaml(client))
+            if existing_idx is not None:
+                clients[existing_idx] = merge_client_entry(clients[existing_idx], client)
+            else:
+                clients.append(client_to_yaml(client))
 
-        self._atomic_write(self.settings_file, data)
+        self._atomic_write(self.settings_file, mutate, expected_revision)
 
-    def delete_client(self, client_id: str) -> None:
+    def delete_client(self, client_id: str, expected_revision: Optional[str] = None) -> None:
         """Delete an OAuth client from settings.yaml."""
-        data = self._load_settings_yaml()
 
-        clients = data.get("oauth", {}).get("clients", [])
-        # Match through client_id_matches so a client whose id is an env
-        # placeholder can still be deleted (#127).
-        new_clients = [c for c in clients if not client_id_matches(c, client_id)]
+        def mutate(data: Dict[str, Any]) -> None:
+            clients = data.get("oauth", {}).get("clients", [])
+            # Match through client_id_matches so a client whose id is an
+            # env placeholder can still be deleted (#127).
+            new_clients = [c for c in clients if not client_id_matches(c, client_id)]
 
-        if len(new_clients) == len(clients):
-            raise ValueError(f"Client '{client_id}' not found")
+            if len(new_clients) == len(clients):
+                raise ValueError(f"Client '{client_id}' not found")
 
-        data["oauth"]["clients"] = new_clients
+            data["oauth"]["clients"] = new_clients
 
-        self._atomic_write(self.settings_file, data)
+        self._atomic_write(self.settings_file, mutate, expected_revision)
 
     # ==================== Settings Operations ====================
 
-    def _apply_provided_settings(self, section_name: str, provided: "Dict[str, Any]") -> None:
+    def _apply_provided_settings(
+        self,
+        section_name: str,
+        provided: "Dict[str, Any]",
+        expected_revision: Optional[str] = None,
+    ) -> None:
         """Apply form-provided values for one settings.yaml section (#214).
 
         The per-field encoding comes from serialization.OWNED_SETTINGS, the
@@ -184,20 +219,22 @@ class YamlWriter:
         the expanded on-disk value actually differs (#127), so untouched
         ``${VAR}`` placeholders and comments survive.
         """
-        data = self._load_settings_yaml()
-        section = data.setdefault(section_name, {})
-        rows = {f.key: f for f in OWNED_SETTINGS if f.section == section_name}
-        for key, value in provided.items():
-            if value is None:
-                continue
-            field = rows[key]
-            compare = value if (field.doc_mode == "plain" or value) else field.empty
-            if not is_unchanged(section.get(key), compare):
-                if field.doc_mode != "plain" and not value:
-                    section.pop(key, None)
-                else:
-                    section[key] = value
-        self._atomic_write(self.settings_file, data)
+
+        def mutate(data: Dict[str, Any]) -> None:
+            section = data.setdefault(section_name, {})
+            rows = {f.key: f for f in OWNED_SETTINGS if f.section == section_name}
+            for key, value in provided.items():
+                if value is None:
+                    continue
+                field = rows[key]
+                compare = value if (field.doc_mode == "plain" or value) else field.empty
+                if not is_unchanged(section.get(key), compare):
+                    if field.doc_mode != "plain" and not value:
+                        section.pop(key, None)
+                    else:
+                        section[key] = value
+
+        self._atomic_write(self.settings_file, mutate, expected_revision)
 
     def update_oauth_settings(
         self,
@@ -211,6 +248,7 @@ class YamlWriter:
         require_pkce: Optional[bool] = None,
         refresh_token_rotation: Optional[bool] = None,
         logos_dir: Optional[str] = None,
+        expected_revision: Optional[str] = None,
     ) -> None:
         """Update OAuth settings (per-field encodings: OWNED_SETTINGS, #214).
 
@@ -232,6 +270,7 @@ class YamlWriter:
                 "refresh_token_rotation": refresh_token_rotation,
                 "logos_dir": logos_dir,
             },
+            expected_revision,
         )
 
     def update_saml_settings(
@@ -248,6 +287,7 @@ class YamlWriter:
         export_groups: Optional[bool] = None,
         roles_attr_name: Optional[str] = None,
         groups_attr_name: Optional[str] = None,
+        expected_revision: Optional[str] = None,
     ) -> None:
         """Update SAML settings (same #127 guard; encodings: OWNED_SETTINGS).
 
@@ -270,25 +310,34 @@ class YamlWriter:
                 "roles_attr_name": roles_attr_name,
                 "groups_attr_name": groups_attr_name,
             },
+            expected_revision,
         )
 
-    def update_authority_prefixes(self, prefixes: Dict[str, str]) -> None:
+    def update_authority_prefixes(
+        self, prefixes: Dict[str, str], expected_revision: Optional[str] = None
+    ) -> None:
         """Update authority prefix mappings."""
-        data = self._load_settings_yaml()
-        if not is_unchanged(data.get("authority_prefixes"), prefixes):
-            data["authority_prefixes"] = prefixes
 
-        self._atomic_write(self.settings_file, data)
+        def mutate(data: Dict[str, Any]) -> None:
+            if not is_unchanged(data.get("authority_prefixes"), prefixes):
+                data["authority_prefixes"] = prefixes
 
-    def update_allowed_identity_classes(self, classes: List[str]) -> None:
+        self._atomic_write(self.settings_file, mutate, expected_revision)
+
+    def update_allowed_identity_classes(
+        self, classes: List[str], expected_revision: Optional[str] = None
+    ) -> None:
         """Update allowed identity classes."""
-        data = self._load_settings_yaml()
-        if not is_unchanged(data.get("allowed_identity_classes"), classes):
-            data["allowed_identity_classes"] = classes
 
-        self._atomic_write(self.settings_file, data)
+        def mutate(data: Dict[str, Any]) -> None:
+            if not is_unchanged(data.get("allowed_identity_classes"), classes):
+                data["allowed_identity_classes"] = classes
 
-    def update_login_settings(self, mode: Optional[str] = None) -> None:
+        self._atomic_write(self.settings_file, mutate, expected_revision)
+
+    def update_login_settings(
+        self, mode: Optional[str] = None, expected_revision: Optional[str] = None
+    ) -> None:
         """Update the 'login' section (persona login mode, local dev
         convenience). 'password' is the default and is never persisted -
         the 'login' section is omitted entirely at the default, same as
@@ -299,17 +348,20 @@ class YamlWriter:
         blank value is treated the same as absent: left unchanged, not
         written to disk. A present, non-blank value is validated against
         the same `{"password", "persona"}` set as ``Settings.login_mode``
-        *before* anything is written, so an invalid value (e.g. a typo)
-        raises instead of persisting a mode the server can't start with.
+        *before* anything is written - including before the file is even
+        loaded - so an invalid value (e.g. a typo) raises instead of
+        persisting a mode the server can't start with.
         """
-        data = self._load_settings_yaml()
         login_mode_default = document_defaults()["login.mode"]
 
         if mode:
             Settings.validate_login_mode(mode)
-            merge_optional_nested_field(data, "login", "mode", mode, login_mode_default)
 
-        self._atomic_write(self.settings_file, data)
+        def mutate(data: Dict[str, Any]) -> None:
+            if mode:
+                merge_optional_nested_field(data, "login", "mode", mode, login_mode_default)
+
+        self._atomic_write(self.settings_file, mutate, expected_revision)
 
 
 # Global instance

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -78,12 +78,6 @@ class YamlWriter:
         if hook_error is not None:
             raise hook_error
 
-    def _load_users_yaml(self) -> Dict[str, Any]:
-        """Load the current users.yaml content."""
-        if not self.users_file.exists():
-            return {"users": {}, "default_user": "admin"}
-        return load_yaml_document(self.users_file)
-
     def _load_settings_yaml(self) -> Dict[str, Any]:
         """Load the current settings.yaml content."""
         return load_yaml_document(self.settings_file)
@@ -104,8 +98,18 @@ class YamlWriter:
         """
 
         def mutate(data: Dict[str, Any]) -> None:
+            # Match _load_users_yaml's old skeleton exactly (#229 phase 3
+            # review, blocking 1): only a users.yaml that does not exist
+            # at all gets {"users": {}, "default_user": "admin"} - an
+            # existing file (even an empty one, or one simply missing the
+            # key) must not gain a default_user it never had. Checked
+            # here, inside mutate, because the lock is already held by
+            # the time compare_and_replace calls this, so "does the file
+            # exist" is accurate for the same load this mutation applies to.
+            if not self.users_file.exists():
+                data["users"] = {}
+                data["default_user"] = "admin"
             data.setdefault("users", {})
-            data.setdefault("default_user", "admin")
             if is_new and user.username in data["users"]:
                 raise ValueError(f"User '{user.username}' already exists")
             data["users"][user.username] = user_to_yaml(user)
@@ -123,8 +127,12 @@ class YamlWriter:
         """
 
         def mutate(data: Dict[str, Any]) -> None:
+            # Same missing-vs-existing distinction as save_user's mutate
+            # above (#229 phase 3 review, blocking 1).
+            if not self.users_file.exists():
+                data["users"] = {}
+                data["default_user"] = "admin"
             data.setdefault("users", {})
-            data.setdefault("default_user", "admin")
             if username not in data["users"]:
                 raise ValueError(f"User '{username}' not found")
             del data["users"][username]

--- a/tests/test_settings_plumbing_parity.py
+++ b/tests/test_settings_plumbing_parity.py
@@ -47,8 +47,11 @@ class TestOwnedSettingsDeriveFromTheModels:
 
 class TestYamlWriterMatchesTheTable:
     def _writer_params(self, method_name):
+        # expected_revision (#229 phase 3) is a stale-write precondition,
+        # not a settings field - excluded from the table comparison the
+        # same way self is.
         signature = inspect.signature(getattr(YamlWriter, method_name))
-        return set(signature.parameters) - {"self"}
+        return set(signature.parameters) - {"self", "expected_revision"}
 
     def test_update_oauth_settings_covers_exactly_the_oauth_rows(self):
         # `clients` is a merged list with its own save_client path, not a

--- a/tests/test_yaml_writer_conflict.py
+++ b/tests/test_yaml_writer_conflict.py
@@ -1,0 +1,172 @@
+"""
+Tests for issue #229 phase 3: YamlWriter's write methods now route through
+the shared compare_and_replace primitive (config_writer.py) via
+YamlWriter._atomic_write, and each accepts an optional expected_revision,
+refusing a stale write with ConflictError instead of silently overwriting
+it - the same guarantee ConfigManager.save() already got in phase 2.
+
+Also pins that moving each method's already-exists/not-found validation
+INSIDE its mutate closure (so it runs against the same freshly loaded
+document that gets written, under the same lock) didn't change any of
+those checks' outward behavior.
+"""
+
+import pytest
+import yaml
+
+from nanoidp.config import ConfigManager, OAuthClient, User
+from nanoidp.config_writer import ConflictError, current_revision
+from nanoidp.services.yaml_writer import YamlWriter
+
+
+def _seed(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "settings.yaml").write_text(
+        "oauth:\n  issuer: 'http://localhost:8000'\n  clients:\n"
+        "    - client_id: 'c1'\n      client_secret: 's1'\n"
+    )
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+def _writer(config_dir):
+    ConfigManager(str(config_dir))  # installs the active config singleton
+    return YamlWriter(str(config_dir))
+
+
+class TestSaveUserConflictDetection:
+    def test_matching_revision_succeeds(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        base = current_revision(config_dir / "users.yaml")
+
+        writer.save_user(User(username="bob", password="x"), expected_revision=base)
+
+        on_disk = yaml.safe_load((config_dir / "users.yaml").read_text())
+        assert "bob" in on_disk["users"]
+
+    def test_stale_revision_raises_conflict_and_leaves_file_untouched(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        users_file = config_dir / "users.yaml"
+        base = current_revision(users_file)
+        users_file.write_text(users_file.read_text() + "\n# someone else wrote this\n")
+
+        with pytest.raises(ConflictError):
+            writer.save_user(User(username="bob", password="x"), expected_revision=base)
+
+        on_disk = yaml.safe_load(users_file.read_text())
+        assert "bob" not in on_disk["users"]
+
+    def test_unconditional_write_is_unaffected_by_no_precondition(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        users_file = config_dir / "users.yaml"
+        users_file.write_text(users_file.read_text() + "\n# someone else wrote this\n")
+
+        writer.save_user(User(username="bob", password="x"))
+
+        on_disk = yaml.safe_load(users_file.read_text())
+        assert "bob" in on_disk["users"]
+
+    def test_already_exists_check_still_works_from_inside_mutate(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+
+        with pytest.raises(ValueError, match="already exists"):
+            writer.save_user(User(username="admin", password="x"), is_new=True)
+
+
+class TestDeleteUserConflictDetection:
+    def test_stale_revision_raises_conflict(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        users_file = config_dir / "users.yaml"
+        base = current_revision(users_file)
+        users_file.write_text(users_file.read_text() + "\n# someone else wrote this\n")
+
+        with pytest.raises(ConflictError):
+            writer.delete_user("admin", expected_revision=base)
+
+        on_disk = yaml.safe_load(users_file.read_text())
+        assert "admin" in on_disk["users"]
+
+    def test_not_found_check_still_works_from_inside_mutate(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+
+        with pytest.raises(ValueError, match="not found"):
+            writer.delete_user("nobody")
+
+
+class TestSaveClientConflictDetection:
+    def test_matching_revision_succeeds(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        base = current_revision(config_dir / "settings.yaml")
+
+        writer.save_client(
+            OAuthClient(client_id="c2", client_secret="s2", description="d"),
+            is_new=True,
+            expected_revision=base,
+        )
+
+        on_disk = yaml.safe_load((config_dir / "settings.yaml").read_text())
+        client_ids = [c["client_id"] for c in on_disk["oauth"]["clients"]]
+        assert "c2" in client_ids
+
+    def test_stale_revision_raises_conflict_and_leaves_file_untouched(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        settings_file = config_dir / "settings.yaml"
+        base = current_revision(settings_file)
+        settings_file.write_text(settings_file.read_text() + "\nlogging:\n  verbose_logging: false\n")
+
+        with pytest.raises(ConflictError):
+            writer.save_client(
+                OAuthClient(client_id="c2", client_secret="s2", description="d"),
+                is_new=True,
+                expected_revision=base,
+            )
+
+        on_disk = yaml.safe_load(settings_file.read_text())
+        client_ids = [c["client_id"] for c in on_disk["oauth"]["clients"]]
+        assert "c2" not in client_ids
+
+    def test_already_exists_check_still_works_from_inside_mutate(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+
+        with pytest.raises(ValueError, match="already exists"):
+            writer.save_client(
+                OAuthClient(client_id="c1", client_secret="s1", description="d"),
+                is_new=True,
+            )
+
+
+class TestUpdateOauthSettingsConflictDetection:
+    def test_stale_revision_raises_conflict(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        settings_file = config_dir / "settings.yaml"
+        base = current_revision(settings_file)
+        settings_file.write_text(settings_file.read_text() + "\nlogging:\n  verbose_logging: false\n")
+
+        with pytest.raises(ConflictError):
+            writer.update_oauth_settings(audience="changed", expected_revision=base)
+
+        on_disk = yaml.safe_load(settings_file.read_text())
+        assert on_disk["oauth"].get("audience") != "changed"
+
+    def test_matching_revision_succeeds(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        writer = _writer(config_dir)
+        base = current_revision(config_dir / "settings.yaml")
+
+        writer.update_oauth_settings(audience="changed", expected_revision=base)
+
+        on_disk = yaml.safe_load((config_dir / "settings.yaml").read_text())
+        assert on_disk["oauth"]["audience"] == "changed"

--- a/tests/test_yaml_writer_conflict.py
+++ b/tests/test_yaml_writer_conflict.py
@@ -11,6 +11,8 @@ document that gets written, under the same lock) didn't change any of
 those checks' outward behavior.
 """
 
+import threading
+
 import pytest
 import yaml
 
@@ -35,6 +37,67 @@ def _seed(tmp_path):
 def _writer(config_dir):
     ConfigManager(str(config_dir))  # installs the active config singleton
     return YamlWriter(str(config_dir))
+
+
+class TestUsersYamlSkeletonFidelity:
+    """Regression pin for #229 phase 3 review, blocking 1: the old
+    _load_users_yaml() injected {"users": {}, "default_user": "admin"}
+    only when users.yaml did not exist at all - not whenever the
+    default_user key happened to be absent. save_user/delete_user's
+    mutate closures must reproduce exactly that condition, or an
+    existing file that simply never declared default_user (or an
+    existing-but-empty file) silently gains a key the operator never
+    wrote, naming a user ("admin") that may not even exist in the file -
+    the opposite of the #127 line of work, where an untouched file
+    survives a save unchanged."""
+
+    def test_save_user_does_not_inject_default_user_into_an_existing_file_missing_it(
+        self, tmp_path
+    ):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "settings.yaml").write_text("oauth:\n  issuer: 'http://localhost:8000'\n")
+        (config_dir / "users.yaml").write_text('users:\n  alice:\n    password: "x"\n')
+        writer = _writer(config_dir)
+
+        writer.save_user(User(username="bob", password="y"))
+
+        on_disk = yaml.safe_load((config_dir / "users.yaml").read_text())
+        assert "default_user" not in on_disk
+        assert set(on_disk["users"]) == {"alice", "bob"}
+
+    def test_delete_user_does_not_inject_default_user_into_an_existing_file_missing_it(
+        self, tmp_path
+    ):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "settings.yaml").write_text("oauth:\n  issuer: 'http://localhost:8000'\n")
+        (config_dir / "users.yaml").write_text(
+            'users:\n  alice:\n    password: "x"\n  bob:\n    password: "y"\n'
+        )
+        writer = _writer(config_dir)
+
+        writer.delete_user("bob")
+
+        on_disk = yaml.safe_load((config_dir / "users.yaml").read_text())
+        assert "default_user" not in on_disk
+        assert set(on_disk["users"]) == {"alice"}
+
+    def test_save_user_still_applies_the_old_skeleton_for_a_genuinely_missing_file(
+        self, tmp_path
+    ):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "settings.yaml").write_text("oauth:\n  issuer: 'http://localhost:8000'\n")
+        # no users.yaml at all
+        ConfigManager(str(config_dir))
+        writer = YamlWriter(str(config_dir))
+
+        writer.save_user(User(username="bob", password="y"))
+
+        on_disk = yaml.safe_load((config_dir / "users.yaml").read_text())
+        assert on_disk["default_user"] == "admin"
+        assert set(on_disk["users"]) == {"bob"}
 
 
 class TestSaveUserConflictDetection:
@@ -78,6 +141,58 @@ class TestSaveUserConflictDetection:
 
         with pytest.raises(ValueError, match="already exists"):
             writer.save_user(User(username="admin", password="x"), is_new=True)
+
+
+class TestSaveUserConcurrentCreateDoesNotLoseAnUpdate:
+    """Regression pin for the actual race #229 phase 3 closes: before this
+    migration, save_user's already-exists check ran on a document loaded
+    before _atomic_write was even called, so two near-simultaneous
+    is_new=True creates of the same username could both pass the check
+    (each loaded independently before either wrote) and the second
+    silently overwrote the first - reproduced by the reviewer 20/20 on
+    the pre-migration code with this exact shape.
+
+    A single Barrier(2)-synchronized trial is not, on its own, a
+    provably deterministic pin - it makes the race very likely, not
+    certain, since it does not force both threads' load to complete
+    before either write. Repeating it many times, and asserting the
+    invariant on every trial, is the robust version: on a
+    lock-protected write path, it must hold every single time; on a
+    regression that reintroduces the old load-before-the-write-call
+    pattern, 20 trials reproduces the loss with overwhelming
+    probability (matching the reviewer's own 20/20 empirical check),
+    rather than depending on exactly where a monkeypatched
+    synchronization point sits in the current call graph."""
+
+    @staticmethod
+    def _race_one_trial(writer, barrier, results, password):
+        barrier.wait()
+        try:
+            writer.save_user(User(username="bob", password=password), is_new=True)
+            results.append("ok")
+        except ValueError:
+            results.append("value_error")
+
+    def test_two_concurrent_creates_of_the_same_user_never_both_succeed(self, tmp_path):
+        for trial in range(20):
+            config_dir = _seed(tmp_path / f"trial-{trial}")
+            writer = _writer(config_dir)
+
+            barrier = threading.Barrier(2)
+            results = []
+
+            threads = [
+                threading.Thread(
+                    target=self._race_one_trial, args=(writer, barrier, results, password)
+                )
+                for password in ("first", "second")
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert sorted(results) == ["ok", "value_error"], f"trial {trial}: {results}"
 
 
 class TestDeleteUserConflictDetection:


### PR DESCRIPTION
YamlWriter's 10 public write methods (save_user, delete_user, set_default_user, save_client, delete_client, update_oauth_settings, update_saml_settings, update_authority_prefixes,
update_allowed_identity_classes, update_login_settings) now route through the shared compare_and_replace primitive via _atomic_write, instead of _load_*_yaml() + atomic_write_yaml() directly - the same migration ConfigManager.save() got in phase 2. Each method gains an optional expected_revision (default None, unconditional - no caller passes one yet; routes/ui.py wiring is phase 4).

Every already-exists/not-found ValueError check moved from running on a document loaded before _atomic_write was even called to running inside the mutate closure compare_and_replace hands the freshly loaded document to - the same document that gets written, under the same lock. Outwardly identical for a single request, but it closes a real race: two near-simultaneous UI submissions for the same new user/client could previously both pass their "already exists" check (each loaded independently before either wrote) and the second would silently overwrite the first; now the second's check runs against a document that already reflects the first's write.

_load_users_yaml/_load_settings_yaml are unchanged - the latter has an external caller in tests/test_issue_127_settings_round_trip.py - they just have no more internal callers in the write path.

tests/test_settings_plumbing_parity.py's YamlWriter-vs-OWNED_SETTINGS parity check now excludes expected_revision from the comparison, the same way it already excludes self.

tests/test_yaml_writer_conflict.py adds phase-3 coverage: matching/ stale expected_revision on save_user/delete_user/save_client/ update_oauth_settings (ConflictError, file untouched on conflict), the unconditional (None) path staying last-write-wins, and confirmation that the already-exists/not-found checks still work correctly now that they run inside mutate.

Full suite (1648 tests), lint-imports, ruff, mypy all clean. Verified live: full e2e suite (57/57) against a running server exercising the actual web UI create/edit/delete flows this migration touches.