### PR TITLE
feat: wire the web UI's forms to the compare_and_replace precondition (#229 phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,12 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "changed since it was last read - please reload and try again" flash
   instead of silently overwriting someone else's concurrent change (an
   edit based on a page loaded before another admin deleted or changed
-  the same user/client, for instance). The settings page writes
-  `settings.yaml` four times per submission (OAuth, SAML, identity
-  classes, login mode); each write after the first checks against the
-  revision the *previous write in that same request* produced, so a
-  concurrent writer interleaving between any of the four is still
-  caught, not just one before the first. A submission with no
+  the same user/client, for instance). The settings page's OAuth, SAML,
+  identity-classes and login-mode fields are now applied as one write
+  instead of four separate ones, so a conflict there is all-or-nothing,
+  the same guarantee every other form already had - an earlier version
+  of this ran four writes chained by revision, which meant a conflict
+  partway through could leave the earlier sections already saved while
+  the page reported that nothing had changed. A submission with no
   `expected_revision` at all (an old cached page, a script, the e2e
   test agent) keeps today's unconditional last-write-wins - nothing
   about this requires an existing caller to opt in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,16 +100,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as `ConfigManager.save()`** (#229): `save_user`, `delete_user`,
   `save_client`, `delete_client` and the rest of its write methods route
   through `compare_and_replace`, and each gained an optional
-  `expected_revision` precondition (unused by any caller yet). The
-  practical effect today: creating or deleting a user/client now checks
-  "does this already exist / does this exist at all" against the same
-  document it writes, under the same lock, instead of against a copy
-  loaded before the write started. Previously, two near-simultaneous
-  submissions creating the same new user or client could both pass
-  their "already exists" check and the second would silently overwrite
-  the first, with no error to either request; that lost update is now
-  impossible - the second request correctly gets an "already exists"
-  error instead.
+  `expected_revision` precondition. The practical effect: creating or
+  deleting a user/client now checks "does this already exist / does
+  this exist at all" against the same document it writes, under the
+  same lock, instead of against a copy loaded before the write started.
+  Previously, two near-simultaneous submissions creating the same new
+  user or client could both pass their "already exists" check and the
+  second would silently overwrite the first, with no error to either
+  request; that lost update is now impossible - the second request
+  correctly gets an "already exists" error instead.
+- **Every web UI form that writes `users.yaml`/`settings.yaml` now
+  carries the revision it was rendered with, and refuses a stale
+  submission** (#229 phase 4): create/edit/delete user, create/edit
+  client, regenerate client secret, settings, and authority prefixes
+  all send a hidden `expected_revision` field and get a clear
+  "changed since it was last read - please reload and try again" flash
+  instead of silently overwriting someone else's concurrent change (an
+  edit based on a page loaded before another admin deleted or changed
+  the same user/client, for instance). The settings page writes
+  `settings.yaml` four times per submission (OAuth, SAML, identity
+  classes, login mode); each write after the first checks against the
+  revision the *previous write in that same request* produced, so a
+  concurrent writer interleaving between any of the four is still
+  caught, not just one before the first. A submission with no
+  `expected_revision` at all (an old cached page, a script, the e2e
+  test agent) keeps today's unconditional last-write-wins - nothing
+  about this requires an existing caller to opt in.
 
 ### Security
 - **Opt-in `management_secret` mutation gate** (#163): one shared secret that

--- a/book/src/guides/extending.md
+++ b/book/src/guides/extending.md
@@ -82,11 +82,17 @@ one coordinated, conflict-checked save (#229): both files are written,
 both hooks then run, and the runtime is refreshed from disk once before a
 `strict` failure is raised - a failing hook on one file does not leave
 the other unwritten.
-The web UI's settings page (`YamlWriter`) uses the same primitive now
-(#229 phase 3), but still writes its sections one call at a time
-rather than as a batch, so under `strict` a failing hook there leaves
-the later sections in that page's save unsaved (the flash message says
-which write failed). Make the hook idempotent: the
+The web UI's settings page (`YamlWriter`) uses the same primitive now:
+its one POST composes oauth, saml, identity classes and login mode
+into a single write (#229 phase 4 - an earlier version ran four
+separate writes chained by revision, which meant a conflict partway
+through could leave the earlier sections already saved while the page
+reported nothing had changed; composing them into one write closed
+that), so a failing hook under `strict` there is the same shape as
+`ConfigManager.save()`'s: the one write already landed, only the
+mirror push failed. `YamlWriter`'s other methods (`save_user`,
+`save_client`, ...) each still make their own single write per call,
+same as always. Make the hook idempotent: the
 next save re-mirrors. `on_audit_event` never fails the request that
 produced the event: a token already issued must not turn into a 500 because
 an audit sink is down. Failures are counted per hook and shown by

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -50,6 +50,7 @@ import base64
 import hashlib
 import json
 import os
+import re
 import secrets
 import sys
 import time
@@ -1101,6 +1102,91 @@ class NanoIDPTestAgent:
         finally:
             self.session.post(
                 f"{self.base_url}/clients/{test_client_id}/delete", timeout=5
+            )
+
+    def test_config_write_conflict_detection(self) -> TestResult:
+        """A stale expected_revision on a UI form is refused, not silently
+        overwritten (issue #229 phase 4).
+
+        Fetches the clients page's rendered revision, advances
+        settings.yaml with an unrelated client creation, then resubmits
+        the create form for a *different* client using the now-stale
+        revision - it must not be created, and the response must carry
+        the conflict flash rather than a silent success.
+        """
+        advancer_client_id = f"conflict-advancer-{secrets.token_hex(4)}"
+        stale_client_id = f"conflict-stale-{secrets.token_hex(4)}"
+        try:
+            clients_page = self.session.get(f"{self.base_url}/clients", timeout=5)
+            match = re.search(
+                r'name="expected_revision" value="([^"]*)"', clients_page.text
+            )
+            if not match:
+                return self._add_result(
+                    "Config Write Conflict Detection", TestCategory.API, False,
+                    "No expected_revision hidden field found on /clients",
+                )
+            stale_revision = match.group(1)
+
+            # Advance settings.yaml with an unrelated write, moving it
+            # past the revision the page above was rendered with.
+            advance = self.session.post(
+                f"{self.base_url}/clients/create",
+                data={
+                    "client_id": advancer_client_id,
+                    "client_secret": "advancer-secret",
+                    "description": "Conflict detection e2e advancer client",
+                },
+                allow_redirects=False,
+                timeout=5,
+            )
+            if advance.status_code not in (302, 303):
+                return self._add_result(
+                    "Config Write Conflict Detection", TestCategory.API, False,
+                    f"Advancer client creation failed: status={advance.status_code}",
+                )
+
+            # Resubmit the create form for a different client using the
+            # now-stale revision from before the advancer write.
+            stale_create = self.session.post(
+                f"{self.base_url}/clients/create",
+                data={
+                    "client_id": stale_client_id,
+                    "client_secret": "stale-secret",
+                    "description": "Should not be created",
+                    "expected_revision": stale_revision,
+                },
+                allow_redirects=True,
+                timeout=5,
+            )
+
+            conflict_flashed = "changed since it was last read" in stale_create.text
+            clients_after = self.session.get(f"{self.base_url}/clients", timeout=5).text
+            not_created = stale_client_id not in clients_after
+
+            success = conflict_flashed and not_created
+            return self._add_result(
+                "Config Write Conflict Detection",
+                TestCategory.API,
+                success,
+                "issue #229: a stale expected_revision on the clients create "
+                "form is refused with a conflict flash, not a silent overwrite",
+                {
+                    "conflict_flashed": conflict_flashed,
+                    "not_created": not_created,
+                    "final_status": stale_create.status_code,
+                },
+            )
+        except Exception as e:
+            return self._add_result(
+                "Config Write Conflict Detection", TestCategory.API, False, f"Error: {e}"
+            )
+        finally:
+            self.session.post(
+                f"{self.base_url}/clients/{advancer_client_id}/delete", timeout=5
+            )
+            self.session.post(
+                f"{self.base_url}/clients/{stale_client_id}/delete", timeout=5
             )
 
     def test_client_branding(self) -> TestResult:
@@ -4202,6 +4288,7 @@ class NanoIDPTestAgent:
                 self.test_api_hooks_block,
                 self.test_api_audit_log,
                 self.test_api_audit_stats,
+                self.test_config_write_conflict_detection,
             ]),
             (TestCategory.MANAGEMENT, "Management Secret", [
                 self.test_management_secret_required_for_api_mutation,

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -677,58 +677,46 @@ def settings() -> ResponseReturnValue:
         # never carried. Present-but-blank still means "clear".
         expiry_raw = request.form.get("token_expiry_minutes")
 
-        # This page writes settings.yaml four times in one request (#229
-        # phase 4). The form's own revision only guards the first write;
-        # each write after that checks against the revision the PREVIOUS
-        # write in this same request just produced, not the (now stale)
-        # one the page was rendered with - otherwise every write after
-        # the first would always look conflicted against its own
-        # predecessor. A concurrent writer interleaving between any of
-        # the four is still caught, since each check is against the file
-        # as it actually stands at that moment.
-        revision = _expected_revision_from_form()
-
-        # OAuth settings
-        revision = yaml_writer.update_oauth_settings(
-            issuer=_form_text("issuer"),
-            issuer_from_request=_form_bool("issuer_from_request"),
-            issuer_allowlist=_form_textarea_list("issuer_allowlist"),
-            device_verification_base_url=_form_text("device_verification_base_url"),
-            issuer_from_proxy_headers=_form_bool("issuer_from_proxy_headers"),
-            audience=_form_text("audience"),
-            token_expiry_minutes=int(expiry_raw) if expiry_raw else None,
-            require_pkce=_form_bool("require_pkce"),
-            refresh_token_rotation=_form_bool("refresh_token_rotation"),
-            logos_dir=_form_text("logos_dir"),
-            expected_revision=revision,
-        )
-
-        # SAML settings
-        revision = yaml_writer.update_saml_settings(
-            entity_id=_form_text("saml_entity_id"),
-            sso_url=_form_text("saml_sso_url"),
-            default_acs_url=_form_text("default_acs_url"),
-            sign_responses=_form_bool("saml_sign_responses"),
-            strict_binding=_form_bool("strict_saml_binding"),
-            want_authn_requests_signed=_form_bool("saml_want_authn_requests_signed"),
-            sp_certificates=_form_textarea_list("saml_sp_certificates"),
-            c14n_algorithm=_form_text("saml_c14n_algorithm"),
-            export_roles=_form_bool("saml_export_roles"),
-            export_groups=_form_bool("saml_export_groups"),
-            roles_attr_name=_form_text("saml_roles_attr_name"),
-            groups_attr_name=_form_text("saml_groups_attr_name"),
-            expected_revision=revision,
-        )
-
-        # Identity classes
+        # One write for the whole submission (#229 phase 4 review,
+        # blocking 1): oauth, saml, identity classes and login mode used
+        # to be four separate compare_and_replace calls chained by
+        # revision, but a conflict on write N still left writes 1..N-1
+        # already committed - update_settings_form composes all four
+        # under one write, so expected_revision covers the entire
+        # submission and a conflict is all-or-nothing.
         identity_classes = [ic.strip() for ic in request.form.get("allowed_identity_classes", "").split("\n") if ic.strip()]
-        if identity_classes:
-            revision = yaml_writer.update_allowed_identity_classes(
-                identity_classes, expected_revision=revision
-            )
 
-        # Login mode (persona login, local dev convenience)
-        yaml_writer.update_login_settings(mode=_form_text("login_mode"), expected_revision=revision)
+        yaml_writer.update_settings_form(
+            oauth_fields={
+                "issuer": _form_text("issuer"),
+                "issuer_from_request": _form_bool("issuer_from_request"),
+                "issuer_allowlist": _form_textarea_list("issuer_allowlist"),
+                "device_verification_base_url": _form_text("device_verification_base_url"),
+                "issuer_from_proxy_headers": _form_bool("issuer_from_proxy_headers"),
+                "audience": _form_text("audience"),
+                "token_expiry_minutes": int(expiry_raw) if expiry_raw else None,
+                "require_pkce": _form_bool("require_pkce"),
+                "refresh_token_rotation": _form_bool("refresh_token_rotation"),
+                "logos_dir": _form_text("logos_dir"),
+            },
+            saml_fields={
+                "entity_id": _form_text("saml_entity_id"),
+                "sso_url": _form_text("saml_sso_url"),
+                "default_acs_url": _form_text("default_acs_url"),
+                "sign_responses": _form_bool("saml_sign_responses"),
+                "strict_binding": _form_bool("strict_saml_binding"),
+                "want_authn_requests_signed": _form_bool("saml_want_authn_requests_signed"),
+                "sp_certificates": _form_textarea_list("saml_sp_certificates"),
+                "c14n_algorithm": _form_text("saml_c14n_algorithm"),
+                "export_roles": _form_bool("saml_export_roles"),
+                "export_groups": _form_bool("saml_export_groups"),
+                "roles_attr_name": _form_text("saml_roles_attr_name"),
+                "groups_attr_name": _form_text("saml_groups_attr_name"),
+            },
+            allowed_identity_classes=identity_classes or None,
+            login_mode=_form_text("login_mode"),
+            expected_revision=_expected_revision_from_form(),
+        )
 
         flash("Settings updated successfully", "success")
         return redirect(url_for("ui.settings"))

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -23,6 +23,7 @@ from flask.typing import ResponseReturnValue
 
 from ..branding import effective_logos_dir
 from ..config import OAuthClient, User, get_config
+from ..config_writer import ConflictError, current_revision
 from ..hooks import HookError
 from ..services import get_audit_log, get_token_service, get_yaml_writer
 from ._audit import audit_event
@@ -39,6 +40,23 @@ logger = logging.getLogger(__name__)
 ui_bp = Blueprint("ui", __name__)
 ui_bp.before_request(ui_login_required)
 ui_bp.before_request(management_secret_required_for_ui)
+
+
+def _expected_revision_from_form() -> str | None:
+    """The revision a form's hidden ``expected_revision`` field carried
+    from when it was rendered (#229 phase 4). Absent - an old cached
+    page, a script or e2e test posting directly without loading the
+    form first - means unconditional, today's last-write-wins, exactly
+    like every write path before this phase.
+    """
+    return request.form.get("expected_revision") or None
+
+
+def _conflict_message(exc: ConflictError) -> str:
+    """One phrasing for every 'someone else changed this' flash (#229
+    phase 4): the technical detail from ConflictError is useful (it
+    names the file), the prefix says what to do about it."""
+    return f"{exc} - please reload the page and try again"
 
 
 # ==================== Dashboard ====================
@@ -185,6 +203,8 @@ def user_create() -> ResponseReturnValue:
     """Create new user."""
     config = get_config()
 
+    yaml_writer = get_yaml_writer()
+
     if request.method == "GET":
         return render_template(
             "users_form.html",
@@ -192,6 +212,7 @@ def user_create() -> ResponseReturnValue:
             allowed_identity_classes=config.settings.allowed_identity_classes,
             persona_mode=config.settings.persona_mode_enabled,
             current_user=session.get("user"),
+            revision=current_revision(yaml_writer.users_file),
         )
 
     # POST: Create user
@@ -238,14 +259,18 @@ def user_create() -> ResponseReturnValue:
             attributes=attributes,
         )
 
-        yaml_writer = get_yaml_writer()
-        yaml_writer.save_user(user, is_new=True)
+        yaml_writer.save_user(
+            user, is_new=True, expected_revision=_expected_revision_from_form()
+        )
 
         flash(f"User '{username}' created successfully", "success")
         return redirect(url_for("ui.user_detail", username=username))
 
     except ValueError as e:
         flash(str(e), "error")
+        return redirect(url_for("ui.user_create"))
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
         return redirect(url_for("ui.user_create"))
     except Exception as e:
         logger.exception("Failed to create user")
@@ -284,6 +309,8 @@ def user_edit(username: str) -> ResponseReturnValue:
         flash(f"User '{username}' not found", "error")
         return redirect(url_for("ui.users"))
 
+    yaml_writer = get_yaml_writer()
+
     if request.method == "GET":
         return render_template(
             "users_form.html",
@@ -291,6 +318,7 @@ def user_edit(username: str) -> ResponseReturnValue:
             allowed_identity_classes=config.settings.allowed_identity_classes,
             persona_mode=config.settings.persona_mode_enabled,
             current_user=session.get("user"),
+            revision=current_revision(yaml_writer.users_file),
         )
 
     # POST: Update user
@@ -331,12 +359,16 @@ def user_edit(username: str) -> ResponseReturnValue:
             attributes=attributes,
         )
 
-        yaml_writer = get_yaml_writer()
-        yaml_writer.save_user(updated_user, is_new=False)
+        yaml_writer.save_user(
+            updated_user, is_new=False, expected_revision=_expected_revision_from_form()
+        )
 
         flash(f"User '{username}' updated successfully", "success")
         return redirect(url_for("ui.user_detail", username=username))
 
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
+        return redirect(url_for("ui.user_edit", username=username))
     except Exception as e:
         logger.exception("Failed to update user")
         flash(f"Failed to update user: {e}", "error")
@@ -348,13 +380,16 @@ def user_delete(username: str) -> ResponseReturnValue:
     """Delete user."""
     try:
         yaml_writer = get_yaml_writer()
-        yaml_writer.delete_user(username)
+        yaml_writer.delete_user(username, expected_revision=_expected_revision_from_form())
 
         flash(f"User '{username}' deleted successfully", "success")
         return redirect(url_for("ui.users"))
 
     except ValueError as e:
         flash(str(e), "error")
+        return redirect(url_for("ui.users"))
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
         return redirect(url_for("ui.users"))
     except Exception as e:
         logger.exception("Failed to delete user")
@@ -372,6 +407,7 @@ def clients() -> ResponseReturnValue:
         "clients.html",
         clients=config.settings.clients,
         current_user=session.get("user"),
+        revision=current_revision(get_yaml_writer().settings_file),
     )
 
 
@@ -383,6 +419,8 @@ def _parse_textarea_list(form_value: str) -> list[str]:
 @ui_bp.route("/clients/create", methods=["GET", "POST"])
 def client_create() -> ResponseReturnValue:
     """Create new OAuth client."""
+    yaml_writer = get_yaml_writer()
+
     if request.method == "GET":
         # Generate a random client secret
         generated_secret = secrets.token_urlsafe(32)
@@ -395,6 +433,7 @@ def client_create() -> ResponseReturnValue:
             generated_secret=generated_secret,
             logos_dir=logos_dir,
             current_user=session.get("user"),
+            revision=current_revision(yaml_writer.settings_file),
         )
 
     # POST: Create client
@@ -425,14 +464,18 @@ def client_create() -> ResponseReturnValue:
             allowed_scopes=_parse_textarea_list(request.form.get("allowed_scopes", "")),
         )
 
-        yaml_writer = get_yaml_writer()
-        yaml_writer.save_client(client, is_new=True)
+        yaml_writer.save_client(
+            client, is_new=True, expected_revision=_expected_revision_from_form()
+        )
 
         flash(f"OAuth client '{client_id}' created successfully", "success")
         return redirect(url_for("ui.clients"))
 
     except ValueError as e:
         flash(str(e), "error")
+        return redirect(url_for("ui.client_create"))
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
         return redirect(url_for("ui.client_create"))
     except Exception as e:
         logger.exception("Failed to create client")
@@ -456,6 +499,8 @@ def client_edit(client_id: str) -> ResponseReturnValue:
         flash(f"Client '{client_id}' not found", "error")
         return redirect(url_for("ui.clients"))
 
+    yaml_writer = get_yaml_writer()
+
     if request.method == "GET":
         logos_dir = effective_logos_dir(
             config.settings.logos_dir, current_app.static_folder
@@ -466,6 +511,7 @@ def client_edit(client_id: str) -> ResponseReturnValue:
             generated_secret=None,
             logos_dir=logos_dir,
             current_user=session.get("user"),
+            revision=current_revision(yaml_writer.settings_file),
         )
 
     # POST: Update client
@@ -491,12 +537,16 @@ def client_edit(client_id: str) -> ResponseReturnValue:
             allowed_scopes=_parse_textarea_list(request.form.get("allowed_scopes", "")),
         )
 
-        yaml_writer = get_yaml_writer()
-        yaml_writer.save_client(updated_client, is_new=False)
+        yaml_writer.save_client(
+            updated_client, is_new=False, expected_revision=_expected_revision_from_form()
+        )
 
         flash(f"OAuth client '{client_id}' updated successfully", "success")
         return redirect(url_for("ui.clients"))
 
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
+        return redirect(url_for("ui.client_edit", client_id=client_id))
     except Exception as e:
         logger.exception("Failed to update client")
         flash(f"Failed to update client: {e}", "error")
@@ -508,13 +558,16 @@ def client_delete(client_id: str) -> ResponseReturnValue:
     """Delete OAuth client."""
     try:
         yaml_writer = get_yaml_writer()
-        yaml_writer.delete_client(client_id)
+        yaml_writer.delete_client(client_id, expected_revision=_expected_revision_from_form())
 
         flash(f"OAuth client '{client_id}' deleted successfully", "success")
         return redirect(url_for("ui.clients"))
 
     except ValueError as e:
         flash(str(e), "error")
+        return redirect(url_for("ui.clients"))
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
         return redirect(url_for("ui.clients"))
     except Exception as e:
         logger.exception("Failed to delete client")
@@ -550,11 +603,16 @@ def client_regenerate_secret(client_id: str) -> ResponseReturnValue:
         updated_client = client.model_copy(update={"client_secret": new_secret})
 
         yaml_writer = get_yaml_writer()
-        yaml_writer.save_client(updated_client, is_new=False)
+        yaml_writer.save_client(
+            updated_client, is_new=False, expected_revision=_expected_revision_from_form()
+        )
 
         flash(f"New secret for '{client_id}': {new_secret}", "success")
         return redirect(url_for("ui.clients"))
 
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
+        return redirect(url_for("ui.clients"))
     except Exception as e:
         logger.exception("Failed to regenerate client secret")
         flash(f"Failed to regenerate secret: {e}", "error")
@@ -597,6 +655,8 @@ def settings() -> ResponseReturnValue:
     """IdP settings configuration page."""
     config = get_config()
 
+    yaml_writer = get_yaml_writer()
+
     if request.method == "GET":
         return render_template(
             "settings.html",
@@ -605,12 +665,11 @@ def settings() -> ResponseReturnValue:
             effective_saml_entity_id=effective_saml_entity_id(config.settings),
             effective_saml_sso_url=effective_saml_sso_url(config.settings),
             current_user=session.get("user"),
+            revision=current_revision(yaml_writer.settings_file),
         )
 
     # POST: Update settings
     try:
-        yaml_writer = get_yaml_writer()
-
         # Every value follows the "absent = unchanged" contract (#131): a field
         # missing from the submitted form is passed as None and the YAML writer
         # leaves it alone, so a partial form (a stale tab, a script, the e2e
@@ -618,8 +677,19 @@ def settings() -> ResponseReturnValue:
         # never carried. Present-but-blank still means "clear".
         expiry_raw = request.form.get("token_expiry_minutes")
 
+        # This page writes settings.yaml four times in one request (#229
+        # phase 4). The form's own revision only guards the first write;
+        # each write after that checks against the revision the PREVIOUS
+        # write in this same request just produced, not the (now stale)
+        # one the page was rendered with - otherwise every write after
+        # the first would always look conflicted against its own
+        # predecessor. A concurrent writer interleaving between any of
+        # the four is still caught, since each check is against the file
+        # as it actually stands at that moment.
+        revision = _expected_revision_from_form()
+
         # OAuth settings
-        yaml_writer.update_oauth_settings(
+        revision = yaml_writer.update_oauth_settings(
             issuer=_form_text("issuer"),
             issuer_from_request=_form_bool("issuer_from_request"),
             issuer_allowlist=_form_textarea_list("issuer_allowlist"),
@@ -630,10 +700,11 @@ def settings() -> ResponseReturnValue:
             require_pkce=_form_bool("require_pkce"),
             refresh_token_rotation=_form_bool("refresh_token_rotation"),
             logos_dir=_form_text("logos_dir"),
+            expected_revision=revision,
         )
 
         # SAML settings
-        yaml_writer.update_saml_settings(
+        revision = yaml_writer.update_saml_settings(
             entity_id=_form_text("saml_entity_id"),
             sso_url=_form_text("saml_sso_url"),
             default_acs_url=_form_text("default_acs_url"),
@@ -646,19 +717,25 @@ def settings() -> ResponseReturnValue:
             export_groups=_form_bool("saml_export_groups"),
             roles_attr_name=_form_text("saml_roles_attr_name"),
             groups_attr_name=_form_text("saml_groups_attr_name"),
+            expected_revision=revision,
         )
 
         # Identity classes
         identity_classes = [ic.strip() for ic in request.form.get("allowed_identity_classes", "").split("\n") if ic.strip()]
         if identity_classes:
-            yaml_writer.update_allowed_identity_classes(identity_classes)
+            revision = yaml_writer.update_allowed_identity_classes(
+                identity_classes, expected_revision=revision
+            )
 
         # Login mode (persona login, local dev convenience)
-        yaml_writer.update_login_settings(mode=_form_text("login_mode"))
+        yaml_writer.update_login_settings(mode=_form_text("login_mode"), expected_revision=revision)
 
         flash("Settings updated successfully", "success")
         return redirect(url_for("ui.settings"))
 
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
+        return redirect(url_for("ui.settings"))
     except HookError as e:
         # The local write and the reload already happened (#185): the form's
         # values are in effect, only the mirror hook failed. The message
@@ -764,18 +841,18 @@ def keys_download(key_type: str) -> ResponseReturnValue:
 def claims() -> ResponseReturnValue:
     """Claims and authority prefixes configuration."""
     config = get_config()
+    yaml_writer = get_yaml_writer()
 
     if request.method == "GET":
         return render_template(
             "claims.html",
             settings=config.settings,
             current_user=session.get("user"),
+            revision=current_revision(yaml_writer.settings_file),
         )
 
     # POST: Update authority prefixes
     try:
-        yaml_writer = get_yaml_writer()
-
         prefixes = {}
 
         # Core prefixes
@@ -793,11 +870,16 @@ def claims() -> ResponseReturnValue:
             if key and value:
                 prefixes[key] = value
 
-        yaml_writer.update_authority_prefixes(prefixes)
+        yaml_writer.update_authority_prefixes(
+            prefixes, expected_revision=_expected_revision_from_form()
+        )
 
         flash("Authority prefixes updated successfully", "success")
         return redirect(url_for("ui.claims"))
 
+    except ConflictError as e:
+        flash(_conflict_message(e), "error")
+        return redirect(url_for("ui.claims"))
     except Exception as e:
         logger.exception("Failed to update authority prefixes")
         flash(f"Failed to update prefixes: {e}", "error")

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -39,7 +39,7 @@ class YamlWriter:
         file_path: Path,
         mutate: Callable[[Dict[str, Any]], Any],
         expected_revision: Optional[str] = None,
-    ) -> None:
+    ) -> str:
         """Write via the shared compare-and-replace primitive (#229 phase 3),
         then run the single post-write contract (#185):
 
@@ -65,8 +65,15 @@ class YamlWriter:
         mirror hiccup into a silent rollback (#185 review). The disk is the
         newest state after our own write; only an explicit reload consults
         the mirror.
+
+        Returns the file's new revision (#229 phase 4): the settings
+        page writes settings.yaml several times in one request, and each
+        write after the first must check against the revision the
+        *previous write in this same request* just produced, not the
+        stale one the page was rendered with - otherwise every write
+        after the first would always look conflicted.
         """
-        compare_and_replace(file_path, expected_revision, mutate)
+        new_revision = compare_and_replace(file_path, expected_revision, mutate)
         kind = "users" if file_path.name == "users.yaml" else "settings"
         config = get_config()
         hook_error: Optional[HookError] = None
@@ -77,6 +84,7 @@ class YamlWriter:
         config.reload_local()
         if hook_error is not None:
             raise hook_error
+        return new_revision
 
     def _load_settings_yaml(self) -> Dict[str, Any]:
         """Load the current settings.yaml content."""
@@ -86,7 +94,7 @@ class YamlWriter:
 
     def save_user(
         self, user: User, is_new: bool = False, expected_revision: Optional[str] = None
-    ) -> None:
+    ) -> str:
         """
         Save or update a user in users.yaml.
 
@@ -114,9 +122,9 @@ class YamlWriter:
                 raise ValueError(f"User '{user.username}' already exists")
             data["users"][user.username] = user_to_yaml(user)
 
-        self._atomic_write(self.users_file, mutate, expected_revision)
+        return self._atomic_write(self.users_file, mutate, expected_revision)
 
-    def delete_user(self, username: str, expected_revision: Optional[str] = None) -> None:
+    def delete_user(self, username: str, expected_revision: Optional[str] = None) -> str:
         """
         Delete a user from users.yaml.
 
@@ -142,9 +150,9 @@ class YamlWriter:
                 remaining_users = list(data["users"].keys())
                 data["default_user"] = remaining_users[0] if remaining_users else ""
 
-        self._atomic_write(self.users_file, mutate, expected_revision)
+        return self._atomic_write(self.users_file, mutate, expected_revision)
 
-    def set_default_user(self, username: str, expected_revision: Optional[str] = None) -> None:
+    def set_default_user(self, username: str, expected_revision: Optional[str] = None) -> str:
         """Set the default user for client_credentials grant."""
 
         def mutate(data: Dict[str, Any]) -> None:
@@ -153,13 +161,13 @@ class YamlWriter:
                 raise ValueError(f"User '{username}' not found")
             data["default_user"] = username
 
-        self._atomic_write(self.users_file, mutate, expected_revision)
+        return self._atomic_write(self.users_file, mutate, expected_revision)
 
     # ==================== OAuth Client Operations ====================
 
     def save_client(
         self, client: OAuthClient, is_new: bool = False, expected_revision: Optional[str] = None
-    ) -> None:
+    ) -> str:
         """
         Save or update an OAuth client in settings.yaml.
 
@@ -190,9 +198,9 @@ class YamlWriter:
             else:
                 clients.append(client_to_yaml(client))
 
-        self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(self.settings_file, mutate, expected_revision)
 
-    def delete_client(self, client_id: str, expected_revision: Optional[str] = None) -> None:
+    def delete_client(self, client_id: str, expected_revision: Optional[str] = None) -> str:
         """Delete an OAuth client from settings.yaml."""
 
         def mutate(data: Dict[str, Any]) -> None:
@@ -206,7 +214,7 @@ class YamlWriter:
 
             data["oauth"]["clients"] = new_clients
 
-        self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(self.settings_file, mutate, expected_revision)
 
     # ==================== Settings Operations ====================
 
@@ -215,7 +223,7 @@ class YamlWriter:
         section_name: str,
         provided: "Dict[str, Any]",
         expected_revision: Optional[str] = None,
-    ) -> None:
+    ) -> str:
         """Apply form-provided values for one settings.yaml section (#214).
 
         The per-field encoding comes from serialization.OWNED_SETTINGS, the
@@ -242,7 +250,7 @@ class YamlWriter:
                     else:
                         section[key] = value
 
-        self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(self.settings_file, mutate, expected_revision)
 
     def update_oauth_settings(
         self,
@@ -257,14 +265,14 @@ class YamlWriter:
         refresh_token_rotation: Optional[bool] = None,
         logos_dir: Optional[str] = None,
         expected_revision: Optional[str] = None,
-    ) -> None:
+    ) -> str:
         """Update OAuth settings (per-field encodings: OWNED_SETTINGS, #214).
 
         Skips writing a field whose expanded on-disk value already matches
         what's being submitted, so unchanged ``${VAR}`` placeholders and
         comments survive a form save that only changed other fields (#127).
         """
-        self._apply_provided_settings(
+        return self._apply_provided_settings(
             "oauth",
             {
                 "issuer": issuer,
@@ -296,13 +304,13 @@ class YamlWriter:
         roles_attr_name: Optional[str] = None,
         groups_attr_name: Optional[str] = None,
         expected_revision: Optional[str] = None,
-    ) -> None:
+    ) -> str:
         """Update SAML settings (same #127 guard; encodings: OWNED_SETTINGS).
 
         Blank clears entity_id/sso_url: absent = derived from the effective
         issuer (#181), the same "present-but-blank = clear" contract as #131.
         """
-        self._apply_provided_settings(
+        return self._apply_provided_settings(
             "saml",
             {
                 "entity_id": entity_id,
@@ -323,29 +331,29 @@ class YamlWriter:
 
     def update_authority_prefixes(
         self, prefixes: Dict[str, str], expected_revision: Optional[str] = None
-    ) -> None:
+    ) -> str:
         """Update authority prefix mappings."""
 
         def mutate(data: Dict[str, Any]) -> None:
             if not is_unchanged(data.get("authority_prefixes"), prefixes):
                 data["authority_prefixes"] = prefixes
 
-        self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(self.settings_file, mutate, expected_revision)
 
     def update_allowed_identity_classes(
         self, classes: List[str], expected_revision: Optional[str] = None
-    ) -> None:
+    ) -> str:
         """Update allowed identity classes."""
 
         def mutate(data: Dict[str, Any]) -> None:
             if not is_unchanged(data.get("allowed_identity_classes"), classes):
                 data["allowed_identity_classes"] = classes
 
-        self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(self.settings_file, mutate, expected_revision)
 
     def update_login_settings(
         self, mode: Optional[str] = None, expected_revision: Optional[str] = None
-    ) -> None:
+    ) -> str:
         """Update the 'login' section (persona login mode, local dev
         convenience). 'password' is the default and is never persisted -
         the 'login' section is omitted entirely at the default, same as
@@ -369,7 +377,7 @@ class YamlWriter:
             if mode:
                 merge_optional_nested_field(data, "login", "mode", mode, login_mode_default)
 
-        self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(self.settings_file, mutate, expected_revision)
 
 
 # Global instance

--- a/src/nanoidp/services/yaml_writer.py
+++ b/src/nanoidp/services/yaml_writer.py
@@ -25,6 +25,54 @@ from ..serialization import (
 logger = logging.getLogger(__name__)
 
 
+def _mutate_settings_section(
+    document: Dict[str, Any], section_name: str, provided: Dict[str, Any]
+) -> None:
+    """Apply form-provided values for one settings.yaml section to an
+    already-loaded document (#214; extracted from
+    ``YamlWriter._apply_provided_settings`` in #229 phase 4 review,
+    blocking 1, so several sections can be composed under one
+    ``compare_and_replace`` call instead of each running its own).
+
+    The per-field encoding comes from ``serialization.OWNED_SETTINGS``, the
+    same table ``apply_settings_document`` drives from - one row per owned
+    key instead of one hand-written if-block per field. Semantics per
+    value: ``None`` was not on the form and leaves the file alone (#131);
+    for a non-"plain" row a provided-but-falsy value clears the key
+    (absent = default/derived); everything else is written only when
+    the expanded on-disk value actually differs (#127), so untouched
+    ``${VAR}`` placeholders and comments survive.
+    """
+    section = document.setdefault(section_name, {})
+    rows = {f.key: f for f in OWNED_SETTINGS if f.section == section_name}
+    for key, value in provided.items():
+        if value is None:
+            continue
+        field = rows[key]
+        compare = value if (field.doc_mode == "plain" or value) else field.empty
+        if not is_unchanged(section.get(key), compare):
+            if field.doc_mode != "plain" and not value:
+                section.pop(key, None)
+            else:
+                section[key] = value
+
+
+def _mutate_allowed_identity_classes(document: Dict[str, Any], classes: List[str]) -> None:
+    """Extracted from ``YamlWriter.update_allowed_identity_classes`` (#229
+    phase 4 review, blocking 1) for the same composition reason as
+    ``_mutate_settings_section`` above."""
+    if not is_unchanged(document.get("allowed_identity_classes"), classes):
+        document["allowed_identity_classes"] = classes
+
+
+def _mutate_login_mode(document: Dict[str, Any], mode: str, login_mode_default: str) -> None:
+    """Extracted from ``YamlWriter.update_login_settings`` (#229 phase 4
+    review, blocking 1); ``mode`` here is already known truthy and
+    already validated by the caller - see that method's docstring for
+    why validation happens before any write is even attempted."""
+    merge_optional_nested_field(document, "login", "mode", mode, login_mode_default)
+
+
 class YamlWriter:
     """Service for safely writing YAML configuration files."""
 
@@ -224,33 +272,16 @@ class YamlWriter:
         provided: "Dict[str, Any]",
         expected_revision: Optional[str] = None,
     ) -> str:
-        """Apply form-provided values for one settings.yaml section (#214).
-
-        The per-field encoding comes from serialization.OWNED_SETTINGS, the
-        same table apply_settings_document drives from - one row per owned
-        key instead of one hand-written if-block per field. Semantics per
-        value: None was not on the form and leaves the file alone (#131);
-        for a non-"plain" row a provided-but-falsy value clears the key
-        (absent = default/derived); everything else is written only when
-        the expanded on-disk value actually differs (#127), so untouched
-        ``${VAR}`` placeholders and comments survive.
+        """Apply form-provided values for one settings.yaml section (#214)
+        as a standalone write. See ``_mutate_settings_section`` for the
+        actual per-field logic; ``update_settings_form`` below is the
+        composed, single-write version several sections need together.
         """
-
-        def mutate(data: Dict[str, Any]) -> None:
-            section = data.setdefault(section_name, {})
-            rows = {f.key: f for f in OWNED_SETTINGS if f.section == section_name}
-            for key, value in provided.items():
-                if value is None:
-                    continue
-                field = rows[key]
-                compare = value if (field.doc_mode == "plain" or value) else field.empty
-                if not is_unchanged(section.get(key), compare):
-                    if field.doc_mode != "plain" and not value:
-                        section.pop(key, None)
-                    else:
-                        section[key] = value
-
-        return self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(
+            self.settings_file,
+            lambda data: _mutate_settings_section(data, section_name, provided),
+            expected_revision,
+        )
 
     def update_oauth_settings(
         self,
@@ -344,12 +375,11 @@ class YamlWriter:
         self, classes: List[str], expected_revision: Optional[str] = None
     ) -> str:
         """Update allowed identity classes."""
-
-        def mutate(data: Dict[str, Any]) -> None:
-            if not is_unchanged(data.get("allowed_identity_classes"), classes):
-                data["allowed_identity_classes"] = classes
-
-        return self._atomic_write(self.settings_file, mutate, expected_revision)
+        return self._atomic_write(
+            self.settings_file,
+            lambda data: _mutate_allowed_identity_classes(data, classes),
+            expected_revision,
+        )
 
     def update_login_settings(
         self, mode: Optional[str] = None, expected_revision: Optional[str] = None
@@ -368,14 +398,65 @@ class YamlWriter:
         loaded - so an invalid value (e.g. a typo) raises instead of
         persisting a mode the server can't start with.
         """
-        login_mode_default = document_defaults()["login.mode"]
-
         if mode:
             Settings.validate_login_mode(mode)
+            login_mode_default = document_defaults()["login.mode"]
+            return self._atomic_write(
+                self.settings_file,
+                lambda data: _mutate_login_mode(data, mode, login_mode_default),
+                expected_revision,
+            )
+        return self._atomic_write(self.settings_file, lambda data: None, expected_revision)
+
+    def update_settings_form(
+        self,
+        oauth_fields: Dict[str, Any],
+        saml_fields: Dict[str, Any],
+        allowed_identity_classes: Optional[List[str]] = None,
+        login_mode: Optional[str] = None,
+        expected_revision: Optional[str] = None,
+    ) -> str:
+        """Apply the settings page's whole submission as ONE write (#229
+        phase 4 review, blocking 1).
+
+        The page originally called update_oauth_settings/
+        update_saml_settings/update_allowed_identity_classes/
+        update_login_settings in sequence - four separate
+        compare_and_replace calls on the same file. Chaining each
+        write's resulting revision into the next one's precondition
+        made every individual write conflict-safe, but a conflict on
+        write N still left writes 1..N-1 already committed, their
+        on_config_saved hooks already fired and the runtime already
+        reloaded - reproduced live (#248 review) with a hook that
+        rewrites settings.yaml after every save: one submission with
+        four changed fields landed only the first, the flash said
+        "please reload and try again" for a page that had, in fact,
+        already partly landed. That is the "save() can fail after
+        committing" shape phase 2 closed for ConfigManager.save() by
+        checking every precondition before writing anything - this is
+        the same fix, one file instead of two.
+
+        Composing every section's mutation under one compare_and_replace
+        call means expected_revision covers the entire submission: a
+        conflict here is all-or-nothing, exactly like a single-section
+        write already was, and on_config_saved/reload_local each run
+        once per settings save instead of up to four times.
+
+        login_mode is validated before this call ever touches the file,
+        same as update_login_settings above and for the same reason: an
+        invalid value must never reach the file at all.
+        """
+        if login_mode:
+            Settings.validate_login_mode(login_mode)
+        login_mode_default = document_defaults()["login.mode"]
 
         def mutate(data: Dict[str, Any]) -> None:
-            if mode:
-                merge_optional_nested_field(data, "login", "mode", mode, login_mode_default)
+            _mutate_settings_section(data, "oauth", oauth_fields)
+            _mutate_settings_section(data, "saml", saml_fields)
+            if allowed_identity_classes:
+                _mutate_allowed_identity_classes(data, allowed_identity_classes)
+            if login_mode:
+                _mutate_login_mode(data, login_mode, login_mode_default)
 
         return self._atomic_write(self.settings_file, mutate, expected_revision)
 

--- a/src/nanoidp/templates/claims.html
+++ b/src/nanoidp/templates/claims.html
@@ -11,6 +11,7 @@
     <!-- Authority Prefixes -->
     <div class="col-md-6">
         <form method="post">
+            <input type="hidden" name="expected_revision" value="{{ revision }}">
             <div class="card">
                 <div class="card-header">
                     <i class="bi bi-hash me-2"></i>Authority Prefixes

--- a/src/nanoidp/templates/clients.html
+++ b/src/nanoidp/templates/clients.html
@@ -36,11 +36,13 @@
                                     <i class="bi bi-pencil"></i>
                                 </a>
                                 <form action="{{ url_for('ui.client_regenerate_secret', client_id=client.client_id) }}" method="post" class="d-inline">
+                                    <input type="hidden" name="expected_revision" value="{{ revision }}">
                                     <button type="submit" class="btn btn-outline-warning" title="Regenerate Secret" onclick="return confirm('Regenerate secret for {{ client.client_id }}? The old secret will stop working.')">
                                         <i class="bi bi-arrow-clockwise"></i>
                                     </button>
                                 </form>
                                 <form action="{{ url_for('ui.client_delete', client_id=client.client_id) }}" method="post" class="d-inline">
+                                    <input type="hidden" name="expected_revision" value="{{ revision }}">
                                     <button type="submit" class="btn btn-outline-danger" onclick="return confirm('Delete client {{ client.client_id }}?')">
                                         <i class="bi bi-trash"></i>
                                     </button>

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -20,6 +20,7 @@
 <div class="row">
     <div class="col-md-8">
         <form method="post" class="needs-validation" novalidate>
+            <input type="hidden" name="expected_revision" value="{{ revision }}">
             <div class="card">
                 <div class="card-body">
                     <div class="mb-3">

--- a/src/nanoidp/templates/settings.html
+++ b/src/nanoidp/templates/settings.html
@@ -8,6 +8,7 @@
 </div>
 
 <form method="post">
+    <input type="hidden" name="expected_revision" value="{{ revision }}">
     {# An unchecked checkbox never submits, so on its own it looks identical to
        a checkbox that was never on the form. These markers let the server
        apply "absent = unchanged" (#131): a checkbox is only interpreted when

--- a/src/nanoidp/templates/users_form.html
+++ b/src/nanoidp/templates/users_form.html
@@ -18,6 +18,7 @@
 </div>
 
 <form method="post" class="needs-validation" novalidate>
+    <input type="hidden" name="expected_revision" value="{{ revision }}">
     <div class="row g-4">
         <!-- Basic Information -->
         <div class="col-md-6">
@@ -204,6 +205,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                 <form action="{{ url_for('ui.user_delete', username=user.username) }}" method="post" class="d-inline">
+                    <input type="hidden" name="expected_revision" value="{{ revision }}">
                     <button type="submit" class="btn btn-danger">
                         <i class="bi bi-trash me-2"></i>Delete
                     </button>

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -115,10 +115,16 @@ def template_field_names() -> set:
 
     ``<name>__on_form`` markers are the checkbox contract (#131), not knobs,
     and the per-checkbox hidden marker is derived from the real field.
+    ``expected_revision`` is the stale-write precondition (#229 phase 4),
+    not a settings.yaml key either - same exclusion reasoning.
     """
     html = SETTINGS_TEMPLATE.read_text()
     names = set(re.findall(r'name="([^"]+)"', html))
-    return {name for name in names if not name.endswith("__on_form")}
+    return {
+        name
+        for name in names
+        if not name.endswith("__on_form") and name != "expected_revision"
+    }
 
 
 class TestGeneratedSchema:

--- a/tests/test_ui_expected_revision.py
+++ b/tests/test_ui_expected_revision.py
@@ -12,15 +12,41 @@ have embedded, without coupling these tests to template markup.
 """
 
 import re
+import shutil
+from pathlib import Path
 
+import yaml
+
+from nanoidp.app import create_app
 from nanoidp.config import get_config
 from nanoidp.config_writer import current_revision
+from nanoidp.services import get_yaml_writer
+
+_REPO_CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 
 
 def _hidden_revision(html: str) -> str:
     match = re.search(r'name="expected_revision" value="([^"]*)"', html)
     assert match, "no expected_revision hidden field found in the page"
     return match.group(1)
+
+
+def _make_app_with_on_config_saved_hook(tmp_path, hook_command: str):
+    """An app whose settings.yaml declares an on_config_saved shell hook,
+    for tests that need something else to move the file's revision right
+    after a write completes - the same shape a second admin, the MCP
+    companion or a mirror hook could produce."""
+    cfg = tmp_path / "cfg"
+    cfg.mkdir(exist_ok=True)
+    for name in ("settings.yaml", "users.yaml"):
+        shutil.copy(_REPO_CONFIG_DIR / name, cfg / name)
+    data = yaml.safe_load((cfg / "settings.yaml").read_text())
+    data.setdefault("jwt", {})["keys_dir"] = str(tmp_path / "keys")
+    data["hooks"] = {"on_config_saved": hook_command}
+    (cfg / "settings.yaml").write_text(yaml.safe_dump(data))
+    app = create_app(config_dir=str(cfg))
+    app.config["TESTING"] = True
+    return app
 
 
 class TestGetPagesEmbedARealRevision:
@@ -59,6 +85,44 @@ class TestGetPagesEmbedARealRevision:
 
 
 class TestStaleFormSubmissionIsAConflictNotA500:
+    def test_user_create_with_stale_revision_flashes_and_creates_nothing(
+        self, app, client, isolated_repo_config
+    ):
+        stale = current_revision(isolated_repo_config / "users.yaml")
+        client.post("/users/create", data={"username": "other", "password": "pw"})
+
+        resp = client.post(
+            "/users/create",
+            data={"username": "toolate", "password": "pw", "expected_revision": stale},
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/users/create")
+        with app.app_context():
+            assert get_config().get_user("toolate") is None
+
+    def test_client_create_with_stale_revision_flashes_and_creates_nothing(
+        self, app, client, isolated_repo_config
+    ):
+        stale = current_revision(isolated_repo_config / "settings.yaml")
+        client.post("/clients/create", data={"client_id": "other", "client_secret": "s"})
+
+        resp = client.post(
+            "/clients/create",
+            data={
+                "client_id": "toolate",
+                "client_secret": "s",
+                "expected_revision": stale,
+            },
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/clients/create")
+        with app.app_context():
+            assert not any(
+                c.client_id == "toolate" for c in get_config().settings.clients
+            )
+
     def test_user_edit_with_stale_revision_flashes_and_leaves_user_untouched(
         self, app, client, isolated_repo_config
     ):
@@ -210,14 +274,13 @@ class TestFreshFormSubmissionStillSucceeds:
         with app.app_context():
             assert get_config().get_user("admin").email == "fresh@example.org"
 
-    def test_settings_chained_revision_all_four_writes_succeed(
+    def test_settings_form_composes_all_four_sections_into_one_write(
         self, app, client, isolated_repo_config
     ):
-        """The settings page writes settings.yaml four times per request;
-        only the first write's precondition comes from the form - each
-        later write must chain from the previous write's own resulting
-        revision, or every write after the first would always conflict
-        with itself."""
+        """The settings page applies oauth, saml, identity classes and
+        login mode as one compare_and_replace call (#229 phase 4 review,
+        blocking 1) - all four must land from a single fresh
+        submission."""
         revision = current_revision(isolated_repo_config / "settings.yaml")
 
         resp = client.post(
@@ -249,3 +312,62 @@ class TestFreshFormSubmissionStillSucceeds:
         assert resp.status_code == 302
         with app.app_context():
             assert get_config().get_user("admin").email == "noopt@example.org"
+
+
+class TestSettingsFormIsAllOrNothing:
+    """Regression pin for #229 phase 4 review, blocking 1: the settings
+    page originally ran four separate compare_and_replace calls on
+    settings.yaml, chained by revision. A conflict on write N left
+    writes 1..N-1 already committed, their on_config_saved hooks already
+    fired and the runtime already reloaded, while the flash claimed
+    nothing had landed at all - reproduced live by the review with an
+    on_config_saved hook that rewrites settings.yaml after every save,
+    moving the file's revision exactly as a second admin, the MCP
+    companion or a mirror hook could between two of the four writes.
+
+    update_settings_form composes every section into one write, so this
+    hook firing after THAT one write is irrelevant to the request that
+    triggered it - there is no second write in the same request left to
+    conflict with. This test would fail on the old chained design (write
+    1 lands, the hook moves the revision, write 2 conflicts, writes 3-4
+    never run) and passes on the composed one."""
+
+    def test_settings_post_with_a_moving_file_lands_all_or_nothing(self, tmp_path):
+        app = _make_app_with_on_config_saved_hook(
+            tmp_path, hook_command='sh -c \'echo "# touched by another actor" >> {path}\''
+        )
+        client = app.test_client()
+
+        with app.app_context():
+            revision = current_revision(get_yaml_writer().settings_file)
+
+        resp = client.post(
+            "/settings",
+            data={
+                "audience": "hooked-aud",
+                "saml_entity_id": "urn:hooked",
+                # Not the repo preset's default (INTERNAL/EXTERNAL) - a
+                # value that matches the default too could "land" only
+                # because it was already there, masking a partial write.
+                "allowed_identity_classes": "PARTNER\nSERVICE",
+                "login_mode": "password",
+                "expected_revision": revision,
+            },
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            settings = get_config().settings
+        landed = {
+            "audience": settings.audience == "hooked-aud",
+            "saml_entity_id": settings.saml_entity_id == "urn:hooked",
+            "allowed_identity_classes": settings.allowed_identity_classes
+            == ["PARTNER", "SERVICE"],
+        }
+        assert all(landed.values()) or not any(landed.values()), (
+            f"partial application, not all-or-nothing: {landed}"
+        )
+        # the hook fired at least once and the file did move - a no-op
+        # hook would make this test vacuous
+        with app.app_context():
+            assert "# touched by another actor" in get_yaml_writer().settings_file.read_text()

--- a/tests/test_ui_expected_revision.py
+++ b/tests/test_ui_expected_revision.py
@@ -1,0 +1,251 @@
+"""
+Tests for issue #229 phase 4: routes/ui.py's forms now carry the revision
+they were rendered with as a hidden expected_revision field, and each
+write route passes it through to the corresponding YamlWriter call,
+catching ConflictError with a flash - the same pattern every existing
+ValueError/HookError branch already used.
+
+A form is not itself parsed here (no HTML scraping): current_revision()
+is the same function the routes call, so computing it directly against
+the isolated config directory gives the exact value a real page would
+have embedded, without coupling these tests to template markup.
+"""
+
+import re
+
+from nanoidp.config import get_config
+from nanoidp.config_writer import current_revision
+
+
+def _hidden_revision(html: str) -> str:
+    match = re.search(r'name="expected_revision" value="([^"]*)"', html)
+    assert match, "no expected_revision hidden field found in the page"
+    return match.group(1)
+
+
+class TestGetPagesEmbedARealRevision:
+    """The hidden field must carry an actual revision, not an empty
+    Jinja-undefined string - a template context missing `revision`
+    would render `value=""`, which reads as "not present" per
+    _expected_revision_from_form() and silently disables the guard."""
+
+    def test_user_create_form(self, client, isolated_repo_config):
+        html = client.get("/users/create").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "users.yaml")
+
+    def test_user_edit_form(self, client, isolated_repo_config):
+        html = client.get("/users/admin/edit").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "users.yaml")
+
+    def test_client_create_form(self, client, isolated_repo_config):
+        html = client.get("/clients/create").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "settings.yaml")
+
+    def test_client_edit_form(self, client, isolated_repo_config):
+        html = client.get("/clients/demo-client/edit").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "settings.yaml")
+
+    def test_clients_list_page(self, client, isolated_repo_config):
+        html = client.get("/clients").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "settings.yaml")
+
+    def test_settings_form(self, client, isolated_repo_config):
+        html = client.get("/settings").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "settings.yaml")
+
+    def test_claims_form(self, client, isolated_repo_config):
+        html = client.get("/claims").get_data(as_text=True)
+        assert _hidden_revision(html) == current_revision(isolated_repo_config / "settings.yaml")
+
+
+class TestStaleFormSubmissionIsAConflictNotA500:
+    def test_user_edit_with_stale_revision_flashes_and_leaves_user_untouched(
+        self, app, client, isolated_repo_config
+    ):
+        stale = current_revision(isolated_repo_config / "users.yaml")
+        # someone else writes users.yaml first
+        client.post("/users/create", data={"username": "other", "password": "pw"})
+
+        resp = client.post(
+            "/users/admin/edit",
+            data={"email": "attacker@example.org", "expected_revision": stale},
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/users/admin/edit")
+        with app.app_context():
+            assert get_config().get_user("admin").email != "attacker@example.org"
+
+    def test_user_delete_with_stale_revision_flashes_and_leaves_user_untouched(
+        self, app, client, isolated_repo_config
+    ):
+        client.post("/users/create", data={"username": "todelete", "password": "pw"})
+        stale = current_revision(isolated_repo_config / "users.yaml")
+        client.post("/users/create", data={"username": "other", "password": "pw"})
+
+        resp = client.post(
+            "/users/todelete/delete", data={"expected_revision": stale}
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            assert get_config().get_user("todelete") is not None
+
+    def test_client_edit_with_stale_revision_flashes_and_leaves_client_untouched(
+        self, app, client, isolated_repo_config
+    ):
+        stale = current_revision(isolated_repo_config / "settings.yaml")
+        client.post(
+            "/clients/create", data={"client_id": "other", "client_secret": "s"}
+        )
+
+        resp = client.post(
+            "/clients/demo-client/edit",
+            data={
+                "client_secret": "hacked-secret",
+                "description": "attacker",
+                "expected_revision": stale,
+            },
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/clients/demo-client/edit")
+        with app.app_context():
+            client_obj = next(
+                c for c in get_config().settings.clients if c.client_id == "demo-client"
+            )
+        assert client_obj.description != "attacker"
+
+    def test_client_delete_with_stale_revision_flashes_and_leaves_client_untouched(
+        self, app, client, isolated_repo_config
+    ):
+        client.post(
+            "/clients/create", data={"client_id": "todelete", "client_secret": "s"}
+        )
+        stale = current_revision(isolated_repo_config / "settings.yaml")
+        client.post(
+            "/clients/create", data={"client_id": "other", "client_secret": "s"}
+        )
+
+        resp = client.post(
+            "/clients/todelete/delete", data={"expected_revision": stale}
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            assert any(
+                c.client_id == "todelete" for c in get_config().settings.clients
+            )
+
+    def test_client_regenerate_secret_with_stale_revision_does_not_change_secret(
+        self, app, client, isolated_repo_config
+    ):
+        with app.app_context():
+            original_secret = next(
+                c for c in get_config().settings.clients if c.client_id == "demo-client"
+            ).client_secret
+        stale = current_revision(isolated_repo_config / "settings.yaml")
+        client.post(
+            "/clients/create", data={"client_id": "other", "client_secret": "s"}
+        )
+
+        resp = client.post(
+            "/clients/demo-client/regenerate-secret", data={"expected_revision": stale}
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            current_secret = next(
+                c for c in get_config().settings.clients if c.client_id == "demo-client"
+            ).client_secret
+        assert current_secret == original_secret
+
+    def test_settings_with_stale_revision_flashes_and_leaves_settings_untouched(
+        self, app, client, isolated_repo_config
+    ):
+        stale = current_revision(isolated_repo_config / "settings.yaml")
+        client.post(
+            "/clients/create", data={"client_id": "other", "client_secret": "s"}
+        )
+
+        resp = client.post(
+            "/settings", data={"audience": "attacker-aud", "expected_revision": stale}
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/settings")
+        with app.app_context():
+            assert get_config().settings.audience != "attacker-aud"
+
+    def test_claims_with_stale_revision_flashes_and_leaves_prefixes_untouched(
+        self, app, client, isolated_repo_config
+    ):
+        stale = current_revision(isolated_repo_config / "settings.yaml")
+        client.post(
+            "/clients/create", data={"client_id": "other", "client_secret": "s"}
+        )
+
+        resp = client.post(
+            "/claims", data={"prefix_roles": "ATTACKER_", "expected_revision": stale}
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            assert get_config().settings.authority_prefixes.get("roles") != "ATTACKER_"
+
+
+class TestFreshFormSubmissionStillSucceeds:
+    """The precondition must not turn into a false positive against a
+    form that was, in fact, submitted against the current revision."""
+
+    def test_user_edit_with_current_revision_succeeds(self, app, client, isolated_repo_config):
+        revision = current_revision(isolated_repo_config / "users.yaml")
+
+        resp = client.post(
+            "/users/admin/edit",
+            data={"email": "fresh@example.org", "expected_revision": revision},
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            assert get_config().get_user("admin").email == "fresh@example.org"
+
+    def test_settings_chained_revision_all_four_writes_succeed(
+        self, app, client, isolated_repo_config
+    ):
+        """The settings page writes settings.yaml four times per request;
+        only the first write's precondition comes from the form - each
+        later write must chain from the previous write's own resulting
+        revision, or every write after the first would always conflict
+        with itself."""
+        revision = current_revision(isolated_repo_config / "settings.yaml")
+
+        resp = client.post(
+            "/settings",
+            data={
+                "audience": "chained-aud",
+                "saml_entity_id": "urn:chained",
+                "allowed_identity_classes": "INTERNAL\nEXTERNAL",
+                "login_mode": "password",
+                "expected_revision": revision,
+            },
+        )
+
+        assert resp.status_code == 302
+        with app.app_context():
+            settings = get_config().settings
+        assert settings.audience == "chained-aud"
+        assert settings.saml_entity_id == "urn:chained"
+        assert settings.allowed_identity_classes == ["INTERNAL", "EXTERNAL"]
+
+    def test_no_expected_revision_field_is_unconditional(
+        self, app, client, isolated_repo_config
+    ):
+        """A POST with no expected_revision at all (an old cached page, a
+        script, examples/test_agent.py) keeps today's last-write-wins -
+        nothing about this phase should require every caller to opt in."""
+        resp = client.post("/users/admin/edit", data={"email": "noopt@example.org"})
+
+        assert resp.status_code == 302
+        with app.app_context():
+            assert get_config().get_user("admin").email == "noopt@example.org"


### PR DESCRIPTION
Every routes/ui.py write flow now carries the revision its form was rendered with, closing the gap phases 1-3 opened but didn't use: a hidden expected_revision field, submitted back to the corresponding YamlWriter call, refusing a stale write with ConflictError and a flash instead of silently overwriting a concurrent change - the same pattern every existing ValueError/HookError except-branch already used. A submission with no expected_revision at all (an old cached page, a script, the e2e test agent) keeps today's unconditional last-write-wins; nothing requires an existing caller to opt in.

services/yaml_writer.py: every public write method (and _atomic_write itself) now returns its new revision instead of None. The settings page - the one form whose submission spans several logical sections of settings.yaml - applies oauth, saml, identity classes and login mode as ONE write: the per-section mutation logic is extracted into module-level pure functions (_mutate_settings_section, _mutate_allowed_identity_classes, _mutate_login_mode) and the new update_settings_form composes all four under a single compare_and_replace call, so expected_revision covers the entire submission and a conflict is all-or-nothing, exactly like every other form. An earlier version of this PR chained four separate writes by revision, which made each individual write conflict-safe but not the page: a conflict on write N left writes 1..N-1 already committed, their on_config_saved hooks already fired and the runtime already reloaded, while the flash said nothing had landed (reproduced in review with an on_config_saved hook that moves the file after every save - the same shape a second admin, the MCP companion or a mirror hook could produce). Composing the sections into one write closes that, and on_config_saved/reload_local now run once per settings save instead of up to four times. The standalone single-section writers (update_oauth_settings, update_saml_settings, update_allowed_identity_classes, update_login_settings) are unchanged from the outside and still perform exactly one write each; login_mode is still validated before the file is ever touched.

routes/ui.py: all 12 YamlWriter call sites across 9 handlers (user create/edit/delete, client create/edit/delete/regenerate-secret, settings, authority prefixes) read expected_revision from request.form and catch ConflictError with one shared flash phrasing naming the file and what changed. Delete/regenerate-secret buttons live on list pages (no dedicated edit form of their own), so their hidden field comes from that list page's own render.

Templates (users_form.html incl. the delete modal, clients_form.html, the mini-forms on clients.html, settings.html, claims.html) each gained a hidden
<input type="hidden" name="expected_revision" value="{{ revision }}"> on their write forms.

tests/test_config_schema.py: the settings-form-field parity check (every posted field must map to a real settings.yaml key) now excludes expected_revision, the same way it already excludes the checkbox __on_form markers - it isn't a settings key either.

tests/test_ui_expected_revision.py: every GET page embeds the real current revision (not an empty/undefined one); a stale POST on each flow, the create flows included, gets a clean redirect+flash and leaves the target untouched; fresh submissions still succeed, including the settings page landing all four sections from one write; a POST with no expected_revision field at all stays unconditional; and TestSettingsFormIsAllOrNothing pins the composed design by registering an on_config_saved hook that moves settings.yaml after every save and asserting the submission's fields land all together or not at all - it fails against the chained design (first section lands, the rest never run) and passes against the composed one.

examples/test_agent.py: first e2e coverage for #229 - test_config_write_conflict_detection fetches the clients page's rendered revision, advances settings.yaml with an unrelated client creation, then resubmits the create form for a different client with the stale revision, asserting the conflict flash appears and the client was not created.

book/src/guides/extending.md's hook section updated to match (the settings page's one POST is one write now, the same shape as ConfigManager.save()'s two-file write). CHANGELOG: new entry under Changed, and phase 3's entry corrected - "unused by any caller yet" was true when it was written, this phase is that caller.

Full suite (1672 tests), lint-imports, ruff, mypy all clean. Verified live against a running server, not just tests: a stale revision on a real form gets the exact conflict flash with no 500 and the target confirmed unchanged on disk; one settings POST changing oauth.audience, saml.entity_id and allowed_identity_classes lands all three together with the on_config_saved hook firing exactly once for the submission.
