### PR TITLE
feat: save_config accepts revision preconditions, read tools expose them (#229 phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only the secret, so every field (present and future) is carried.
 
 ### Added
+- **MCP callers can make `save_config` conflict-checked** (#229 phase 5,
+  the MCP leg of the same loop the web UI's forms got in phase 4): the
+  read tools return the revision of the file the runtime was loaded
+  from (`list_users`/`get_user` carry `users_revision`;
+  `list_clients`/`get_client`/`get_settings` carry `settings_revision`),
+  and `save_config` accepts them back as `expected_users_revision` /
+  `expected_settings_revision`, refusing the save with
+  `{"success": false, "kind": "conflict"}` - nothing written - when
+  another writer (the web UI, another agent, a second nanoidp process
+  on the same directory) moved a file since. `reload_config` and a
+  successful `save_config` return fresh revisions, so the retry loop is
+  reload, reapply, save. The revision is deliberately the one the
+  runtime was LOADED from, not the file's hash at ask time: on a
+  runtime that is stale against the directory, a fresh disk hash would
+  pass the precondition exactly when the lost update is real. Omitting
+  the revisions keeps the save unconditional (last write wins), same
+  as before.
 - **Display-only `description` on users, shown in the persona login
   picker** (#244): a user in `users.yaml` can carry an optional
   `description` (max 200 characters, plain text) rendered next to the
@@ -101,8 +118,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime already reflects them - only the mirror push failed. This also
   closes a gap where MCP's `save_config` tool left the process holding
   its pre-save view of anything the save's read-modify-write cycle picked
-  up from disk: it now sees the refreshed state too. No caller passes a
-  precondition revision yet; that lands with the surface that needs it.
+  up from disk: it now sees the refreshed state too. The precondition
+  revisions were unused when this entry was first written; MCP's
+  `save_config` now supplies them (see Added).
   The runtime refresh can itself fail (an in-memory value that bypassed
   field validation, since `Settings` has no `validate_assignment`, can
   reach the file and then fail to parse back in) - `save()` now tells

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reload, reapply, save. The revision is deliberately the one the
   runtime was LOADED from, not the file's hash at ask time: on a
   runtime that is stale against the directory, a fresh disk hash would
-  pass the precondition exactly when the lost update is real. Omitting
-  the revisions keeps the save unconditional (last write wins), same
-  as before.
+  pass the precondition exactly when the lost update is real. Because
+  `save_config` always writes both files, there are exactly two modes:
+  omitting both revisions keeps the save unconditional (last write
+  wins, same as before), and supplying either makes the whole save
+  conflict-checked, with the omitted revision defaulting to the one
+  this runtime was loaded from - a save guarded on one file can never
+  silently overwrite the other from a stale snapshot.
 - **Display-only `description` on users, shown in the persona login
   picker** (#244): a user in `users.yaml` can carry an optional
   `description` (max 200 characters, plain text) rendered next to the

--- a/book/src/project/architecture.md
+++ b/book/src/project/architecture.md
@@ -109,9 +109,13 @@ There are exactly two kinds of state, and they never share a store:
   The UI's per-field saves go through `services/yaml_writer.py`; the
   MCP `save_config` tool and reloads persist whole documents through
   `ConfigManager.save()`. Both delegate their entry-building to
-  `serialization.py`, so the two paths cannot drift on content - but
-  they are two separate read-modify-write owners, with no cross-request
-  conflict detection (last write wins).
+  `serialization.py`, so the two paths cannot drift on content, and both
+  write through the same `config_writer.compare_and_replace` pipeline
+  (#229): each write can carry the revision the caller's state was read
+  at, and a stale one is refused instead of overwriting a concurrent
+  change - the UI's forms submit it as a hidden field, MCP callers pass
+  it to `save_config`. Without a revision a write stays unconditional
+  (last write wins), stated as such.
 - **Runtime state** lives in memory inside `services/`: authorization
   codes, device codes, revocation and rotation families, the audit
   log, and Flask sessions. It is lost on restart by design; an

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -51,8 +51,16 @@ back as `expected_users_revision` / `expected_settings_revision`. A save
 whose revision no longer matches the file is refused with
 `{"success": false, "kind": "conflict"}` before anything is written: call
 `reload_config`, reapply the change on the fresh state, and save again
-with the revisions from its response. Omitting the revisions keeps the
-save unconditional (last write wins), same as before.
+with the revisions from its response.
+
+`save_config` always writes both files, so there are exactly two modes.
+Omitting both revisions keeps the save unconditional (last write wins),
+same as before. Supplying either revision makes the whole save
+conflict-checked: the omitted one defaults to the revision this runtime
+was loaded from, so a save guarded on `users.yaml` cannot silently
+overwrite a `settings.yaml` another writer changed in the meantime, or
+vice versa - there is no mode where one file is guarded and the other is
+overwritten from a stale snapshot.
 
 ## Claude Code configuration
 

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -27,8 +27,8 @@ readonly mode, and the exposure warnings, see the
 | `delete_client` | Delete an OAuth client |
 | `get_settings` | Get current IdP settings |
 | `update_settings` | Update IdP settings |
-| `save_config` | Persist the current configuration to the YAML files |
-| `reload_config` | Reload configuration from files |
+| `save_config` | Persist the current configuration to the YAML files, optionally guarded by `expected_users_revision` / `expected_settings_revision` (see below) |
+| `reload_config` | Reload configuration from files (the response carries fresh `users_revision` / `settings_revision`) |
 | `validate_config` | Lint the running config directory without starting or executing anything (no hook, no plugin): `{valid, findings}` |
 | `get_oidc_discovery` | Get OIDC discovery document (same document as `/.well-known/openid-configuration`) |
 | `get_jwks` | Get JSON Web Key Set |
@@ -37,6 +37,22 @@ readonly mode, and the exposure warnings, see the
 | `clear_audit_log` | Clear the audit log |
 | `get_keys_info` | Get signing key info (active kid, previous keys) |
 | `rotate_keys` | Rotate signing keys (old key stays valid for verification) |
+
+## Conflict-checked saves
+
+The declared configuration can have several writers at once: the web UI,
+another agent, or a second nanoidp process (a Flask server and a
+`nanoidp-mcp` companion) on the same directory. To catch a concurrent
+change instead of silently overwriting it, the read tools return the
+revision of the file the runtime was loaded from - `list_users` and
+`get_user` carry `users_revision`; `list_clients`, `get_client` and
+`get_settings` carry `settings_revision` - and `save_config` accepts them
+back as `expected_users_revision` / `expected_settings_revision`. A save
+whose revision no longer matches the file is refused with
+`{"success": false, "kind": "conflict"}` before anything is written: call
+`reload_config`, reapply the change on the fresh state, and save again
+with the revisions from its response. Omitting the revisions keeps the
+save unconditional (last write wins), same as before.
 
 ## Claude Code configuration
 

--- a/examples/mcp_smoke_test.py
+++ b/examples/mcp_smoke_test.py
@@ -83,6 +83,44 @@ async def run(config_dir: str) -> int:
                 return 1
             print("[OK] get_keys_info")
 
+            # Revision preconditions (#229 phase 5). Read tools hand out the
+            # revision of the file the runtime was loaded from; save_config
+            # with a deliberately WRONG revision must be refused with kind
+            # 'conflict' before anything is written. Deliberately no
+            # positive save here: this script may run against a checked-in
+            # config directory, and the conflict branch is the one leg
+            # guaranteed to leave every file byte-identical.
+            result = await session.call_tool("list_users", {})
+            users_payload = json.loads(result.content[0].text)
+            users_revision = users_payload.get("users_revision", "")
+            if len(users_revision) != 64:
+                print(f"[FAIL] list_users users_revision not a sha256 hex: {users_revision!r}")
+                return 1
+            result = await session.call_tool("get_settings", {})
+            settings_payload = json.loads(result.content[0].text)
+            if len(settings_payload.get("settings_revision", "")) != 64:
+                print(
+                    f"[FAIL] get_settings settings_revision not a sha256 hex: "
+                    f"{settings_payload.get('settings_revision')!r}"
+                )
+                return 1
+            result = await session.call_tool(
+                "save_config", {"expected_users_revision": "0" * 64}
+            )
+            conflict = json.loads(result.content[0].text)
+            if conflict.get("success") is not False or conflict.get("kind") != "conflict":
+                print(f"[FAIL] stale save_config not refused as a conflict: {conflict!r}")
+                return 1
+            result = await session.call_tool("list_users", {})
+            after = json.loads(result.content[0].text).get("users_revision")
+            if after != users_revision:
+                print(
+                    f"[FAIL] users.yaml moved despite the refused save: "
+                    f"{users_revision} -> {after}"
+                )
+                return 1
+            print("[OK] revision preconditions: read tools expose them, stale save refused")
+
             # NANOIDP_E2E_PLUGIN: the installed reference plugin, bootstrapped
             # through NANOIDP_BOOTSTRAP_PLUGIN, must be visible to an agent
             # through get_settings (#185 parity with /api/config).

--- a/src/nanoidp/config.py
+++ b/src/nanoidp/config.py
@@ -22,7 +22,7 @@ from .config_documents import (
     load_settings_document,
     load_users_document,
 )
-from .config_writer import compare_and_replace, compare_and_replace_many
+from .config_writer import compare_and_replace, compare_and_replace_many, revision_of_bytes
 from .hooks import SOURCE_SETTINGS, HookError, HookRegistry, bootstrap_registry
 from .models import (  # noqa: F401
     SECURITY_PROFILES,
@@ -238,9 +238,20 @@ class ConfigManager:
             staged["settings"] = self._default_settings()
             staged["hooks_section"] = None
             staged["plugins"] = {}
+            # Same revision current_revision() gives a missing file: the
+            # hash of empty bytes (#229 phase 5).
+            staged["settings_revision"] = revision_of_bytes(b"")
         else:
-            with open(settings_file, "r") as f:
-                data = yaml.safe_load(f) or {}
+            # Read the bytes once and hash exactly what gets parsed (#229
+            # phase 5): the revision must describe the state this runtime
+            # was loaded from, so a save precondition built on it catches
+            # every on-disk change since - hashing a second read could
+            # describe newer content than the parse saw. The read itself
+            # is still unlocked (#246).
+            with open(settings_file, "rb") as f:
+                raw = f.read()
+            staged["settings_revision"] = revision_of_bytes(raw)
+            data = yaml.safe_load(raw) or {}
             # Candidate strictness: an edited config_validation takes effect
             # on the load that reads it, an explicit --strict-config keeps
             # winning, and a load that FAILS never changes the running mode
@@ -264,9 +275,12 @@ class ConfigManager:
         if not users_file.exists():
             logger.warning(f"Users file not found: {users_file}, using defaults")
             staged["users"], staged["default_user"] = self._default_users(), "admin"
+            staged["users_revision"] = revision_of_bytes(b"")
         else:
-            with open(users_file, "r") as f:
-                udata = yaml.safe_load(f) or {}
+            with open(users_file, "rb") as f:
+                uraw = f.read()
+            staged["users_revision"] = revision_of_bytes(uraw)
+            udata = yaml.safe_load(uraw) or {}
             # config_version is checked BEFORE placeholder expansion: it must
             # be a literal integer, never ${VAR} (#175 review).
             users_version = check_config_version(udata, users_file)
@@ -303,6 +317,16 @@ class ConfigManager:
         self.config_version = staged["version"]
         self.users = staged["users"]
         self.default_user = staged["default_user"]
+        # The revisions of the bytes this runtime was loaded from (#229
+        # phase 5) - what a caller passes back to save() as
+        # expected_*_revision to mean "refuse my save if the file moved
+        # since the state I based my change on". Deliberately NOT the
+        # file's revision at ask time: on a runtime that is stale against
+        # the directory (another process wrote), a fresh disk hash would
+        # satisfy the precondition exactly when the lost update is real.
+        # Every successful write path refreshes these via reload_local().
+        self.users_revision = staged["users_revision"]
+        self.settings_revision = staged["settings_revision"]
 
     def _configure_hooks_from(self, hooks: HooksSection, plugins: Dict[str, Dict[str, Any]]) -> None:
         """Replace the settings.yaml-sourced hooks/plugins with the file's

--- a/src/nanoidp/config_writer.py
+++ b/src/nanoidp/config_writer.py
@@ -307,13 +307,24 @@ def _read_bytes(file_path: Path) -> bytes:
     return file_path.read_bytes()
 
 
+def revision_of_bytes(raw: bytes) -> Revision:
+    """The revision of content a caller has already read.
+
+    One recipe for the whole codebase: a reader that parses raw bytes
+    itself (ConfigManager._stage_directory, #229 phase 5) must hash the
+    bytes it actually parsed, not re-read the file - a second read could
+    hash different content than what its parse saw.
+    """
+    return hashlib.sha256(raw).hexdigest()
+
+
 def current_revision(file_path: Path) -> Revision:
     """The revision a reader hands back later as ``expected_revision``.
 
     A missing file has a well-defined revision (the hash of empty bytes),
     so a caller can request "only create this if it still doesn't exist".
     """
-    return hashlib.sha256(_read_bytes(file_path)).hexdigest()
+    return revision_of_bytes(_read_bytes(file_path))
 
 
 WriteItem = Tuple[Path, Optional[Revision], Callable[[Dict[str, Any]], Any]]

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -901,8 +901,14 @@ _TOOLS: list[Tool] = [
             "tool handed back (list_users and get_user carry "
             "users_revision; list_clients, get_client and get_settings "
             "carry settings_revision; reload_config and a successful "
-            "save_config carry both). Omitting them keeps today's "
-            "unconditional last-write-wins. A failure response's 'kind' "
+            "save_config carry both). save_config always writes both "
+            "files, so there are exactly two modes: omitting both "
+            "revisions keeps today's unconditional last-write-wins, and "
+            "supplying either makes the WHOLE save conflict-checked - "
+            "the omitted revision defaults to the one this runtime was "
+            "loaded from, so a save guarded on users.yaml cannot "
+            "silently overwrite a settings.yaml another writer changed, "
+            "or vice versa. A failure response's 'kind' "
             "distinguishes four outcomes: 'conflict' (nothing was written - "
             "a supplied revision was stale; call reload_config, reapply "
             "your change on the fresh state and save with the revisions "
@@ -924,7 +930,10 @@ _TOOLS: list[Tool] = [
                     "description": (
                         "users.yaml revision from a read tool; the save is "
                         "refused with kind 'conflict' if the file no longer "
-                        "matches it. Omit for unconditional last-write-wins."
+                        "matches it. Supplying either revision makes the "
+                        "whole two-file save conflict-checked (the omitted "
+                        "one defaults to this runtime's loaded revision); "
+                        "omit both for unconditional last-write-wins."
                     ),
                 },
                 "expected_settings_revision": {
@@ -1595,11 +1604,28 @@ def _tool_save_config(arguments: dict[str, Any], config: ConfigManager) -> dict[
     try:
         # Optional preconditions (#229 phase 5): the revisions a read tool
         # (list_users/get_user, list_clients/get_client/get_settings) or
-        # reload_config handed back. Absent = unconditional last-write-wins,
-        # same as save()'s own default and the UI's revision-less forms.
+        # reload_config handed back. save() always writes BOTH files, so
+        # there are exactly two modes and no third (#252 review): with no
+        # revision supplied the save is unconditional last-write-wins,
+        # same as save()'s own default and the UI's revision-less forms;
+        # with EITHER revision supplied the whole save is conflict-checked,
+        # the omitted one defaulting to the revision this runtime was
+        # loaded from. Passing a caller's partial precondition straight
+        # through would guard one file while this runtime's stale snapshot
+        # silently overwrote the other - the exact lost update the
+        # revisions exist to catch. "is None", not falsy: an explicit
+        # empty string is a supplied (and stale) revision, refused as a
+        # conflict rather than silently replaced.
+        users_rev = arguments.get("expected_users_revision")
+        settings_rev = arguments.get("expected_settings_revision")
+        if users_rev is not None or settings_rev is not None:
+            if users_rev is None:
+                users_rev = config.users_revision
+            if settings_rev is None:
+                settings_rev = config.settings_revision
         config.save(
-            expected_users_revision=arguments.get("expected_users_revision"),
-            expected_settings_revision=arguments.get("expected_settings_revision"),
+            expected_users_revision=users_rev,
+            expected_settings_revision=settings_rev,
         )
         # The post-save reload refreshed the tracked revisions to what was
         # just written, so a follow-up save can chain from this response.

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -894,21 +894,47 @@ _TOOLS: list[Tool] = [
             "via create/update tools without persist=True support). Writes "
             "users.yaml and settings.yaml as one coordinated, conflict-checked "
             "save (#229) and then refreshes the running configuration from "
-            "what was just written. A failure response's 'kind' distinguishes "
-            "four outcomes: 'conflict' (nothing was written - unused by this "
-            "tool today, reserved for a future precondition), 'lock_timeout' "
-            "or 'lock_unsupported' (nothing was written either - the write "
-            "never started; lock_timeout is worth retrying, lock_unsupported "
-            "means this config directory's filesystem does not support "
-            "advisory locks and will not succeed on retry), a hook's own "
-            "'kind' under hooks.strict (both files ARE written; only the "
-            "mirror push failed), or 'reload_after_save' (both files ARE "
-            "written but the runtime could not adopt them - do not retry "
-            "expecting a different result, the file on disk is authoritative)."
+            "what was just written. To refuse the save if another writer "
+            "(the web UI, another agent, a second nanoidp process on the "
+            "same directory) changed a file since you read it, pass the "
+            "expected_users_revision / expected_settings_revision a read "
+            "tool handed back (list_users and get_user carry "
+            "users_revision; list_clients, get_client and get_settings "
+            "carry settings_revision; reload_config and a successful "
+            "save_config carry both). Omitting them keeps today's "
+            "unconditional last-write-wins. A failure response's 'kind' "
+            "distinguishes four outcomes: 'conflict' (nothing was written - "
+            "a supplied revision was stale; call reload_config, reapply "
+            "your change on the fresh state and save with the revisions "
+            "from its response), 'lock_timeout' or 'lock_unsupported' "
+            "(nothing was written either - the write never started; "
+            "lock_timeout is worth retrying, lock_unsupported means this "
+            "config directory's filesystem does not support advisory locks "
+            "and will not succeed on retry), a hook's own 'kind' under "
+            "hooks.strict (both files ARE written; only the mirror push "
+            "failed), or 'reload_after_save' (both files ARE written but "
+            "the runtime could not adopt them - do not retry expecting a "
+            "different result, the file on disk is authoritative)."
         ),
         input_schema={
             "type": "object",
-            "properties": {},
+            "properties": {
+                "expected_users_revision": {
+                    "type": "string",
+                    "description": (
+                        "users.yaml revision from a read tool; the save is "
+                        "refused with kind 'conflict' if the file no longer "
+                        "matches it. Omit for unconditional last-write-wins."
+                    ),
+                },
+                "expected_settings_revision": {
+                    "type": "string",
+                    "description": (
+                        "settings.yaml revision from a read tool; same "
+                        "contract as expected_users_revision."
+                    ),
+                },
+            },
             "required": [],
         },
     ),
@@ -1113,6 +1139,10 @@ def _tool_list_users(arguments: dict[str, Any], config: ConfigManager) -> dict[s
     return {
         "count": len(users),
         "default_user": config.default_user,
+        # The users.yaml revision this runtime was loaded from (#229 phase
+        # 5): pass it to save_config as expected_users_revision to refuse
+        # the save if another writer moved the file since.
+        "users_revision": config.users_revision,
         "users": users,
     }
 
@@ -1121,8 +1151,11 @@ def _tool_get_user(arguments: dict[str, Any], config: ConfigManager) -> dict[str
     username = arguments["username"]
     user = config.get_user(username)
     if user:
-        return {"found": True, "user": _user_to_dict(user)}
-    return {"found": False, "username": username}
+        return {"found": True, "user": _user_to_dict(user), "users_revision": config.users_revision}
+    # Meaningful on the not-found branch too: get_user -> create_user ->
+    # save_config(expected_users_revision=...) is "create this user only
+    # if the file still looks like it did when I saw them absent".
+    return {"found": False, "username": username, "users_revision": config.users_revision}
 
 
 def _tool_create_user(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
@@ -1248,15 +1281,25 @@ def _tool_verify_token(arguments: dict[str, Any], config: ConfigManager) -> dict
 # Client Management
 def _tool_list_clients(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
     clients = [_client_to_dict(c) for c in config.settings.clients]
-    return {"count": len(clients), "clients": clients}
+    # Clients live in settings.yaml, so their precondition is the
+    # settings revision (#229 phase 5).
+    return {
+        "count": len(clients),
+        "settings_revision": config.settings_revision,
+        "clients": clients,
+    }
 
 
 def _tool_get_client(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
     client_id = arguments["client_id"]
     client = config.get_client(client_id)
     if client:
-        return {"found": True, "client": _client_to_dict(client)}
-    return {"found": False, "client_id": client_id}
+        return {
+            "found": True,
+            "client": _client_to_dict(client),
+            "settings_revision": config.settings_revision,
+        }
+    return {"found": False, "client_id": client_id, "settings_revision": config.settings_revision}
 
 
 def _tool_create_client(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
@@ -1365,6 +1408,9 @@ def _tool_get_settings(arguments: dict[str, Any], config: ConfigManager) -> dict
         # Same key as GET /api/config (#175): the contract an agent targets.
         "config_version": config.config_version,
         "config_validation": "strict" if config.strict_config else "warn",
+        # The settings.yaml revision this runtime was loaded from (#229
+        # phase 5), for save_config's expected_settings_revision.
+        "settings_revision": config.settings_revision,
         "issuer": settings.issuer,
         "issuer_from_request": settings.issuer_from_request,
         "issuer_allowlist": settings.issuer_allowlist,
@@ -1424,7 +1470,15 @@ def _tool_reload_config(arguments: dict[str, Any], config: ConfigManager) -> dic
         config.reload()
     except HookError as exc:
         return {"success": False, "error": f"Reload failed: {exc.message}", "kind": exc.kind}
-    return {"success": True, "message": "Configuration reloaded"}
+    # Fresh revisions right in the response (#229 phase 5): after a
+    # save_config conflict, reload -> reapply the change -> save with
+    # these, without another read call in between.
+    return {
+        "success": True,
+        "message": "Configuration reloaded",
+        "users_revision": config.users_revision,
+        "settings_revision": config.settings_revision,
+    }
 
 
 def _tool_validate_config(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
@@ -1539,11 +1593,24 @@ def _tool_update_settings(arguments: dict[str, Any], config: ConfigManager) -> d
 
 def _tool_save_config(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
     try:
-        config.save()
-        return {"success": True, "message": "Configuration saved to YAML files"}
+        # Optional preconditions (#229 phase 5): the revisions a read tool
+        # (list_users/get_user, list_clients/get_client/get_settings) or
+        # reload_config handed back. Absent = unconditional last-write-wins,
+        # same as save()'s own default and the UI's revision-less forms.
+        config.save(
+            expected_users_revision=arguments.get("expected_users_revision"),
+            expected_settings_revision=arguments.get("expected_settings_revision"),
+        )
+        # The post-save reload refreshed the tracked revisions to what was
+        # just written, so a follow-up save can chain from this response.
+        return {
+            "success": True,
+            "message": "Configuration saved to YAML files",
+            "users_revision": config.users_revision,
+            "settings_revision": config.settings_revision,
+        }
     except ConflictError as exc:
-        # Nothing was written - the precondition (unused by this tool
-        # today, but shared by the underlying save()) was stale.
+        # Nothing was written - a supplied expected_*_revision was stale.
         return {"success": False, "error": exc.message, "kind": exc.kind}
     except LockUnavailableError as exc:
         # Nothing was written either - the lock is acquired before

--- a/tests/test_config_revisions.py
+++ b/tests/test_config_revisions.py
@@ -42,8 +42,11 @@ class TestLoadedRevisionsTrackTheParsedBytes:
         (config_dir / "users.yaml").unlink()
         config = ConfigManager(str(config_dir))
 
-        # Same value current_revision() reports for a missing path, so
-        # "create only if it still doesn't exist" round-trips.
+        # Same value current_revision() reports for a missing path - and
+        # for an existing zero-byte file, which shares sha256(b""): the
+        # precondition this enables means "the file still has the
+        # missing/empty revision", not literally "the file is still
+        # absent" (semantics from phase 2, kept as is).
         assert config.users_revision == revision_of_bytes(b"")
         assert config.users_revision == current_revision(config_dir / "users.yaml")
 

--- a/tests/test_config_revisions.py
+++ b/tests/test_config_revisions.py
@@ -1,0 +1,137 @@
+"""
+Tests for issue #229 phase 5 (ConfigManager side): the manager tracks the
+revision of the bytes each YAML file was LOADED from, so a caller (the MCP
+save_config tool) can build a save precondition on the state its change
+was actually based on.
+
+The tracked revision is deliberately not the file's revision at ask time:
+on a runtime that is stale against the directory (another process wrote),
+a fresh disk hash would satisfy save()'s precondition exactly when the
+lost update is real. That distinction is what the two-manager tests pin.
+"""
+
+import pytest
+import yaml
+
+from nanoidp.config import ConfigManager
+from nanoidp.config_writer import ConflictError, current_revision, revision_of_bytes
+
+
+def _seed(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "settings.yaml").write_text(
+        "oauth:\n  issuer: 'http://localhost:8000'\n  audience: 'default'\n"
+    )
+    (config_dir / "users.yaml").write_text(
+        'users:\n  admin:\n    password: "admin"\ndefault_user: admin\n'
+    )
+    return config_dir
+
+
+class TestLoadedRevisionsTrackTheParsedBytes:
+    def test_after_load_the_revisions_match_the_files(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        config = ConfigManager(str(config_dir))
+
+        assert config.users_revision == current_revision(config_dir / "users.yaml")
+        assert config.settings_revision == current_revision(config_dir / "settings.yaml")
+
+    def test_a_missing_file_has_the_empty_bytes_revision(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        (config_dir / "users.yaml").unlink()
+        config = ConfigManager(str(config_dir))
+
+        # Same value current_revision() reports for a missing path, so
+        # "create only if it still doesn't exist" round-trips.
+        assert config.users_revision == revision_of_bytes(b"")
+        assert config.users_revision == current_revision(config_dir / "users.yaml")
+
+    def test_an_external_write_does_not_move_the_tracked_revision(self, tmp_path):
+        """The tracked revision describes what THIS runtime loaded, not
+        the directory's current state - that staleness is exactly what a
+        save precondition needs to carry."""
+        config_dir = _seed(tmp_path)
+        config = ConfigManager(str(config_dir))
+        loaded = config.settings_revision
+
+        settings_file = config_dir / "settings.yaml"
+        settings_file.write_text(settings_file.read_text() + "\n# another writer\n")
+
+        assert config.settings_revision == loaded
+        assert config.settings_revision != current_revision(settings_file)
+
+    def test_reload_local_refreshes_the_revisions(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        config = ConfigManager(str(config_dir))
+        settings_file = config_dir / "settings.yaml"
+        settings_file.write_text(settings_file.read_text() + "\n# another writer\n")
+
+        config.reload_local()
+
+        assert config.settings_revision == current_revision(settings_file)
+
+    def test_save_refreshes_the_revisions_to_what_was_written(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        config = ConfigManager(str(config_dir))
+
+        config.settings.audience = "changed"
+        config.save()
+
+        assert config.settings_revision == current_revision(config_dir / "settings.yaml")
+        assert config.users_revision == current_revision(config_dir / "users.yaml")
+
+
+class TestTwoRuntimesOnOneDirectory:
+    """The scenario phase 5 exists for: a Flask process and a nanoidp-mcp
+    companion (here: two ConfigManagers) writing the same directory."""
+
+    def test_the_stale_runtime_is_refused_not_silently_clobbering(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        a = ConfigManager(str(config_dir))
+        b = ConfigManager(str(config_dir))
+
+        b.settings.audience = "written-by-b"
+        b.save()
+
+        a.settings.audience = "written-by-a"
+        with pytest.raises(ConflictError):
+            a.save(expected_settings_revision=a.settings_revision)
+
+        on_disk = yaml.safe_load((config_dir / "settings.yaml").read_text())
+        assert on_disk["oauth"]["audience"] == "written-by-b"
+
+    def test_reload_then_save_with_fresh_revisions_succeeds(self, tmp_path):
+        config_dir = _seed(tmp_path)
+        a = ConfigManager(str(config_dir))
+        b = ConfigManager(str(config_dir))
+
+        b.settings.audience = "written-by-b"
+        b.save()
+
+        a.reload_local()
+        a.settings.audience = "written-by-a"
+        a.save(
+            expected_users_revision=a.users_revision,
+            expected_settings_revision=a.settings_revision,
+        )
+
+        on_disk = yaml.safe_load((config_dir / "settings.yaml").read_text())
+        assert on_disk["oauth"]["audience"] == "written-by-a"
+
+    def test_without_a_precondition_the_stale_runtime_still_wins(self, tmp_path):
+        """Unchanged contract: no revision supplied = last-write-wins,
+        stated as such - the two-process lost update phase 5 lets a
+        caller catch is still the default behaviour when nobody asks."""
+        config_dir = _seed(tmp_path)
+        a = ConfigManager(str(config_dir))
+        b = ConfigManager(str(config_dir))
+
+        b.settings.audience = "written-by-b"
+        b.save()
+
+        a.settings.audience = "written-by-a"
+        a.save()
+
+        on_disk = yaml.safe_load((config_dir / "settings.yaml").read_text())
+        assert on_disk["oauth"]["audience"] == "written-by-a"

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -200,6 +200,8 @@ class TestMCPSecurityIntegration:
             config.users = {}
             # Concrete, or the tool result is a MagicMock that cannot be serialized.
             config.default_user = "admin"
+            config.users_revision = "0" * 64
+            config.settings_revision = "0" * 64
             config.settings.clients = []
             config.settings.issuer = "http://localhost:8000"
             config.settings.audience = "test"

--- a/tests/test_mcp_tool_branches.py
+++ b/tests/test_mcp_tool_branches.py
@@ -17,7 +17,7 @@ import pytest
 import yaml
 
 from nanoidp.config import ConfigManager, ReloadAfterSaveError
-from nanoidp.config_writer import ConflictError, LockUnavailableError
+from nanoidp.config_writer import ConflictError, LockUnavailableError, current_revision
 from nanoidp.hooks import HookError
 
 
@@ -305,7 +305,7 @@ class TestConfigToolBranches:
     async def test_save_config_failure_is_a_clean_error(
         self, mcp_config, mcp_call_tool, monkeypatch
     ):
-        def _failing_save():
+        def _failing_save(**kwargs):
             raise OSError("disk full")
 
         monkeypatch.setattr(mcp_config, "save", _failing_save)
@@ -323,7 +323,7 @@ class TestConfigToolBranches:
         was written" (ConflictError) apart from the other two save()
         failure modes by more than the free-text error message."""
 
-        def _failing_save():
+        def _failing_save(**kwargs):
             raise ConflictError("settings.yaml changed since it was last read")
 
         monkeypatch.setattr(mcp_config, "save", _failing_save)
@@ -341,7 +341,7 @@ class TestConfigToolBranches:
         mirror hook fails - the error text says so, and 'kind' carries
         the hook's own kind rather than a generic one."""
 
-        def _failing_save():
+        def _failing_save(**kwargs):
             raise HookError("on_config_saved shell hook exited 1", kind="on_config_saved")
 
         monkeypatch.setattr(mcp_config, "save", _failing_save)
@@ -361,7 +361,7 @@ class TestConfigToolBranches:
         mistake this for "nothing was written" and retry expecting a
         different outcome."""
 
-        def _failing_save():
+        def _failing_save(**kwargs):
             raise ReloadAfterSaveError("runtime could not reload settings.yaml")
 
         monkeypatch.setattr(mcp_config, "save", _failing_save)
@@ -382,7 +382,7 @@ class TestConfigToolBranches:
         actually catch it rather than falling through to the generic
         branch, which would drop 'kind' entirely."""
 
-        def _failing_save():
+        def _failing_save(**kwargs):
             raise LockUnavailableError(
                 "Timed out after 10.0s waiting for the write lock", kind="lock_timeout"
             )
@@ -409,6 +409,114 @@ class TestConfigToolBranches:
         rotated = _payload(await mcp_call_tool("rotate_keys", {}))
         assert rotated["success"] is True
         assert rotated["new_kid"] != kid_before
+
+
+class TestRevisionPreconditions:
+    """#229 phase 5: the read tools hand out the revisions the runtime was
+    loaded from, and save_config accepts them as optional preconditions -
+    the MCP leg of the same read -> mutate -> conflict-checked-save loop
+    the web UI's forms got in phase 4."""
+
+    @pytest.mark.asyncio
+    async def test_read_tools_expose_the_loaded_revisions(
+        self, mcp_config, mcp_call_tool
+    ):
+        users_rev = mcp_config.users_revision
+        settings_rev = mcp_config.settings_revision
+
+        assert _payload(await mcp_call_tool("list_users", {}))["users_revision"] == users_rev
+        found = _payload(await mcp_call_tool("get_user", {"username": "admin"}))
+        assert found["users_revision"] == users_rev
+        # The not-found branch carries it too: get_user -> create_user ->
+        # save_config is "create only if the file still looks like it did
+        # when I saw them absent".
+        absent = _payload(await mcp_call_tool("get_user", {"username": "nobody"}))
+        assert absent["found"] is False
+        assert absent["users_revision"] == users_rev
+
+        assert (
+            _payload(await mcp_call_tool("list_clients", {}))["settings_revision"]
+            == settings_rev
+        )
+        client = _payload(await mcp_call_tool("get_client", {"client_id": "branch-client"}))
+        assert client["settings_revision"] == settings_rev
+        no_client = _payload(await mcp_call_tool("get_client", {"client_id": "ghost"}))
+        assert no_client["found"] is False
+        assert no_client["settings_revision"] == settings_rev
+
+        assert (
+            _payload(await mcp_call_tool("get_settings", {}))["settings_revision"]
+            == settings_rev
+        )
+
+    @pytest.mark.asyncio
+    async def test_reload_config_hands_back_fresh_revisions(
+        self, mcp_config, mcp_call_tool
+    ):
+        settings_file = mcp_config.config_dir / "settings.yaml"
+        settings_file.write_text(settings_file.read_text() + "\n# another writer\n")
+
+        payload = _payload(await mcp_call_tool("reload_config", {}))
+
+        assert payload["success"] is True
+        assert payload["settings_revision"] == current_revision(settings_file)
+        assert payload["users_revision"] == current_revision(
+            mcp_config.config_dir / "users.yaml"
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_config_with_fresh_revisions_succeeds_and_chains(
+        self, mcp_config, mcp_call_tool
+    ):
+        _payload(await mcp_call_tool("update_settings", {"audience": "rev-aud"}))
+        payload = _payload(
+            await mcp_call_tool(
+                "save_config",
+                {
+                    "expected_users_revision": mcp_config.users_revision,
+                    "expected_settings_revision": mcp_config.settings_revision,
+                },
+            )
+        )
+
+        assert payload["success"] is True
+        saved = yaml.safe_load((mcp_config.config_dir / "settings.yaml").read_text())
+        assert saved["oauth"]["audience"] == "rev-aud"
+        # The response's revisions describe what was just written, so a
+        # follow-up save can chain from them without another read call.
+        assert payload["settings_revision"] == current_revision(
+            mcp_config.config_dir / "settings.yaml"
+        )
+        assert payload["users_revision"] == current_revision(
+            mcp_config.config_dir / "users.yaml"
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_config_with_a_stale_revision_is_refused_writing_nothing(
+        self, mcp_config, mcp_call_tool
+    ):
+        """The real two-writer path, no monkeypatching: another writer
+        moves users.yaml after this runtime loaded; a save carrying the
+        loaded revision must be refused with kind 'conflict' and leave
+        BOTH files exactly as that writer left them."""
+        loaded_users_rev = mcp_config.users_revision
+        users_file = mcp_config.config_dir / "users.yaml"
+        settings_file = mcp_config.config_dir / "settings.yaml"
+        users_file.write_text(users_file.read_text() + "\n# another writer\n")
+        users_before = users_file.read_bytes()
+        settings_before = settings_file.read_bytes()
+
+        _payload(await mcp_call_tool("update_settings", {"audience": "must-not-land"}))
+        result = await mcp_call_tool(
+            "save_config", {"expected_users_revision": loaded_users_rev}
+        )
+
+        assert result.is_error is True
+        payload = _payload(result)
+        assert payload["success"] is False
+        assert payload["kind"] == "conflict"
+        assert users_file.read_bytes() == users_before
+        assert settings_file.read_bytes() == settings_before
 
 
 class TestDispatchGuards:

--- a/tests/test_mcp_tool_branches.py
+++ b/tests/test_mcp_tool_branches.py
@@ -518,6 +518,70 @@ class TestRevisionPreconditions:
         assert users_file.read_bytes() == users_before
         assert settings_file.read_bytes() == settings_before
 
+    @pytest.mark.asyncio
+    async def test_a_users_only_guard_still_protects_settings(
+        self, mcp_config, mcp_call_tool
+    ):
+        """#252 review blocker: save_config always writes BOTH files, so a
+        caller following the natural flow (get_user -> mutate user ->
+        save with only expected_users_revision) must not have its stale
+        settings snapshot silently overwrite a settings.yaml another
+        writer - one that touches only that file, like the UI's settings
+        form - changed in the meantime. Supplying either revision makes
+        the whole save conflict-checked; the omitted one defaults to the
+        runtime's loaded revision."""
+        loaded_users_rev = mcp_config.users_revision
+        users_file = mcp_config.config_dir / "users.yaml"
+        settings_file = mcp_config.config_dir / "settings.yaml"
+
+        # Another writer moves ONLY settings.yaml; users.yaml still
+        # matches the revision this runtime loaded.
+        settings_file.write_text(settings_file.read_text() + "\n# settings-only writer\n")
+        users_before = users_file.read_bytes()
+        settings_before = settings_file.read_bytes()
+
+        _payload(
+            await mcp_call_tool(
+                "create_user", {"username": "cross-user", "password": "pw12345"}
+            )
+        )
+        result = await mcp_call_tool(
+            "save_config", {"expected_users_revision": loaded_users_rev}
+        )
+
+        assert result.is_error is True
+        payload = _payload(result)
+        assert payload["success"] is False
+        assert payload["kind"] == "conflict"
+        assert users_file.read_bytes() == users_before
+        assert settings_file.read_bytes() == settings_before
+
+    @pytest.mark.asyncio
+    async def test_a_settings_only_guard_still_protects_users(
+        self, mcp_config, mcp_call_tool
+    ):
+        """The symmetric leg: a save guarded only on settings.yaml must
+        not overwrite a users.yaml another writer changed."""
+        loaded_settings_rev = mcp_config.settings_revision
+        users_file = mcp_config.config_dir / "users.yaml"
+        settings_file = mcp_config.config_dir / "settings.yaml"
+
+        users_file.write_text(users_file.read_text() + "\n# users-only writer\n")
+        users_before = users_file.read_bytes()
+        settings_before = settings_file.read_bytes()
+
+        _payload(await mcp_call_tool("update_settings", {"audience": "must-not-land"}))
+        result = await mcp_call_tool(
+            "save_config", {"expected_settings_revision": loaded_settings_rev}
+        )
+
+        assert result.is_error is True
+        payload = _payload(result)
+        assert payload["success"] is False
+        assert payload["kind"] == "conflict"
+        assert users_file.read_bytes() == users_before
+        assert settings_file.read_bytes() == settings_before
+
 
 class TestDispatchGuards:
     @pytest.mark.asyncio


### PR DESCRIPTION
The MCP leg of the read -> mutate -> conflict-checked-save loop the web UI's forms got in phase 4 (#251), and the piece that makes the two-process scenario - a Flask server and a nanoidp-mcp companion on one config directory - safe to opt into: without it, an MCP save_config silently overwrites whatever the other process wrote since this runtime loaded. With it, #229 is complete on every write surface: primitive (phase 1), ConfigManager.save() (phase 2), YamlWriter (phase 3), web UI (phase 4), MCP (this).

**ConfigManager tracks the loaded revisions.** _stage_directory hashes exactly the bytes each YAML file's parse saw (new config_writer.revision_of_bytes, one recipe shared with current_revision; a missing file gets the empty-bytes hash so "create only if still absent" round-trips), and _commit_directory promotes them as users_revision / settings_revision. Deliberately NOT the file's hash at ask time: on a runtime that is stale against the directory (another process wrote), a fresh disk hash would satisfy the precondition exactly when the lost update is real. Every load path refreshes the pair - reload, reload_local, and the post-save refresh - so a successful save chains naturally.

**MCP surface.** list_users and get_user return users_revision (on the not-found branch too: get_user -> create_user -> save_config is "create this user only if the file still looks like it did when I saw them absent"); list_clients, get_client and get_settings return settings_revision; reload_config and a successful save_config return both, so the conflict retry loop is reload, reapply, save - no extra read call. save_config accepts optional expected_users_revision / expected_settings_revision and hands them to ConfigManager.save(), whose precondition parameters have waited for a caller since phase 2. A stale revision comes back as the already-specified {"success": false, "kind": "conflict"} with nothing written. Because save_config always writes BOTH files, the contract has exactly two modes and no third (review round 1): omitting both revisions keeps the unconditional last-write-wins default, and supplying either makes the WHOLE save conflict-checked, the omitted revision defaulting to the one this runtime was loaded from - a pass-through of a partial precondition would have guarded one file while the runtime's stale snapshot silently overwrote the other, the exact lost update the revisions exist to catch, reachable through the API's own recommended flow (the check is "is None", not falsy: an explicit empty string is a supplied, stale revision and conflicts rather than being silently replaced). No new tool: the smoke test's EXPECTED_TOOLS stays 26.

**Tests.** tests/test_config_revisions.py pins the tracking semantics: revisions match the files at load, an external write does NOT move them (that staleness is the point), reload_local and save() refresh them, a missing file matches current_revision, and the two-manager scenario - the stale runtime is refused while the unconditional default still wins. tests/test_mcp_tool_branches.py gains a TestRevisionPreconditions class driving the real dispatch path: read tools expose the loaded revisions, reload_config hands back fresh ones, a fresh-revision save succeeds and its response chains, and the real two-writer conflict (no monkeypatching) leaves both files byte-identical. Two cross pins from review round 1, one per direction: a settings-only external writer (the shape of the UI's settings form) against a users-guarded save, and a users-only writer against a settings-guarded save - each must conflict with both files untouched; both fail against the pass-through version. The five monkeypatched save fakes now accept the new kwargs, and the mock-config security fixture gets concrete revision values (the established "concrete, or it cannot serialize" pattern).

**e2e.** examples/mcp_smoke_test.py drives the revision fields and a stale save_config through the real stdio transport - deliberately only the conflict leg, which is guaranteed to write nothing, since the script may run against a checked-in config directory (the lock file it touches is already gitignored). Verified live beyond the suite: a Flask process and an MCP companion on one fresh directory - the UI created a user, the companion's save with its loaded revision was refused with kind=conflict, the UI's write was byte-intact on disk, and reload_config -> reapply -> save landed both changes. Full suite 1711 (with the two round-1 pins), mypy, ruff, lint-imports clean; examples/test_agent.py live 57/58 (the one failure is the known environmental Redirect URI Exact Match, identical on main).

**Docs.** reference/mcp.md gains a "Conflict-checked saves" section and updated tool rows; architecture.md's write-path paragraph now describes the shared compare_and_replace pipeline instead of the pre-#229 "no cross-request conflict detection (last write wins)", which phase 4 had already made stale; CHANGELOG entry under Added, and phase 2's "no caller passes a precondition revision yet" sentence corrected the same way phase 4 corrected phase 3's.

Refs #229 (closed; this is its last phase) and the #235 decision table (the MCP companion process contract).
