### PR TITLE
chore: bump to 2.8.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.8.0rc1"
+version = "2.8.0rc2"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Second release candidate for 2.8.0. rc1 (2026-08-25, 3e5e08e) no longer represents the code 2.8.0 would ship: main has since gained the whole #229 pipeline (compare_and_replace primitive with cross-process locking, ConfigManager.save() and YamlWriter on it, UI form revisions with an atomic settings submission, MCP revision preconditions - #234/#248/#251/#252), persona descriptions (#247), the client_credentials fixes (#240/#242) and docs. Per the release policy, CHANGELOG stays under [Unreleased] until the final; the rc's content goes in its pre-release notes.