### PR TITLE
feat: RFC 8707 resource indicators bind the access token audience (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only the secret, so every field (present and future) is carried.
 
 ### Added
+- **RFC 8707 Resource Indicators: `resource` binds the access token
+  audience** (#187). A client may send one or more `resource` parameters
+  on `/authorize`, `/token` (every grant) and `/device_authorization`;
+  the access token's `aud` is then those resources (a plain string for
+  one, an array for several) instead of the global `oauth.audience`, so a
+  token minted for one MCP server is rejected by another and a
+  wrong-audience test can finally be written. A `resource` must be an
+  absolute URI without a fragment or the request is `invalid_target`
+  (RFC 8707 §2). New per-client `allowed_resources` gates which resources
+  a client may target (empty = any valid resource, the dev default, same
+  "empty = unrestricted" convention as `allowed_scopes`). The
+  authorization code and refresh token remember the bound resources; a
+  `/token` request may narrow them to a subset but never widen them.
+  Sending no `resource` leaves `aud` at `oauth.audience` - **no change
+  for existing clients**. `/introspect` reports the token's `aud`, and
+  now verifies a token's signature without pinning its audience (so a
+  resource-bound token can be introspected and revoked); `/userinfo`
+  still requires the OP audience. No `resource_indicators_supported`
+  discovery metadata (RFC 8707 defines none). Full support across
+  settings.yaml (`allowed_resources`), the UI client form and the MCP
+  `create_client`/`update_client` tools.
 - **Public clients: `token_endpoint_auth_method: "none"` with mandatory
   PKCE S256** (#188). A client that cannot keep a secret (CLI, desktop
   app, SPA, MCP client) can now be declared with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "empty = unrestricted" convention as `allowed_scopes`). The
   authorization code and refresh token remember the bound resources; a
   `/token` request may narrow them to a subset but never widen them.
+  Narrowing the access token does not narrow the refresh token, which keeps
+  the full original grant so a later refresh can still request any resource
+  the authorization covered (RFC 8707 §2.2).
   Sending no `resource` leaves `aud` at `oauth.audience` - **no change
   for existing clients**. `/introspect` reports the token's `aud`, and
   now verifies a token's signature without pinning its audience (so a

--- a/book/src/guides/token-requests.md
+++ b/book/src/guides/token-requests.md
@@ -74,6 +74,27 @@ without it), cannot use the `client_credentials` grant, and always gets a
 rotating refresh token. A `client_secret` sent by a public client is
 ignored.
 
+## Resource indicators (RFC 8707)
+
+To bind the access token to a specific resource server - so a token for
+MCP server A is rejected by server B - send a `resource` parameter (an
+absolute URI without a fragment). An MCP client sends it on both
+`/authorize` and `/token`; the access token's `aud` becomes that
+resource. `resource` is repeatable for more than one target, and a
+`/token` request may narrow the resources an authorization code bound but
+never widen them. A resource outside the client's `allowed_resources` (or
+not a valid URI) is rejected with `invalid_target`.
+
+```bash
+curl -X POST 'http://localhost:8000/token' \
+  -u 'demo-client:demo-secret' \
+  -d 'grant_type=client_credentials' \
+  -d 'resource=https://mcp.example/server'
+# the returned access token's aud is https://mcp.example/server
+```
+
+Sending no `resource` leaves the audience at `oauth.audience`, unchanged.
+
 ## Device authorization flow
 
 ```bash

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -290,6 +290,11 @@ oauth:
     - client_id: "cli-client"
       token_endpoint_auth_method: "none"  # public client (#188): no secret
       description: "CLI / SPA / MCP client that cannot keep a secret"
+    - client_id: "mcp-client"
+      client_secret: "secret"
+      description: "Client bound to specific MCP servers (RFC 8707, #187)"
+      allowed_resources:        # optional; see "Resource indicators" below
+        - "https://mcp.example/server"
   # logos_dir: "./static/logos"    # optional; defaults to src/nanoidp/static/logos
   # scopes_supported:               # optional; the global scope vocabulary
   #   - openid                      # (default: openid, profile, email, offline_access)
@@ -396,6 +401,22 @@ body parameters and rejects Basic. The other credentialed endpoints -
 `/introspect`, `/revoke`, `/device_authorization` - are not the token
 endpoint and stay lenient: they accept a confidential client's secret
 over either HTTP Basic or the request body.
+
+**Resource indicators** (issue #187, RFC 8707): a client may send one or
+more `resource` parameters on `/authorize`, `/token` and
+`/device_authorization`, and the access token's `aud` is bound to those
+resources - a token minted for one MCP server is then rejected by
+another. A `resource` must be an absolute URI without a fragment,
+otherwise the request is `invalid_target`. Per-client `allowed_resources`
+gates which resources a client may target (empty = any valid resource,
+the dev default, same "empty = unrestricted" convention as
+`allowed_scopes`). A `/token` request may narrow the resources a prior
+step bound (an authorization code, a refresh token) but never widen them.
+Sending no `resource` leaves `aud` at `oauth.audience`, unchanged for
+existing clients. `/introspect` reports the token's `aud`; there is no
+`resource_indicators_supported` discovery metadata (RFC 8707 defines
+none). An MCP client sends `resource` on both `/authorize` and `/token`
+(MCP Authorization).
 
 **Native apps (RFC 8252)**: two things a native client needs are built
 in. A private-use scheme URI such as `com.example.app:/oauth2redirect`

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -17,9 +17,9 @@ readonly mode, and the exposure warnings, see the
 | `create_persona_user` | Create a password-less user for persona login mode (local dev/testing convenience) |
 | `update_user` | Update an existing user (password, email, roles, …) |
 | `delete_user` | Delete a user |
-| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter) |
+| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter; `resource` binds the access token `aud` to an RFC 8707 resource, #187) |
 | `decode_token` | Decode JWT token (without verification) |
-| `verify_token` | Verify JWT token signature and expiration |
+| `verify_token` | Verify JWT token signature and expiration (pass `audience` to also require the token's `aud` to match, simulating a resource server; omit it to accept a resource-bound token and read its claims, #187) |
 | `list_clients` | List OAuth clients |
 | `get_client` | Get client details |
 | `create_client` | Create a new OAuth client |

--- a/docs/schema/config.v1.json
+++ b/docs/schema/config.v1.json
@@ -89,6 +89,10 @@
             "default": null,
             "title": "Additional Audiences"
           },
+          "allowed_resources": {
+            "default": null,
+            "title": "Allowed Resources"
+          },
           "allowed_scopes": {
             "default": null,
             "title": "Allowed Scopes"

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -599,6 +599,67 @@ class NanoIDPTestAgent:
                 "Device Verification Base URL", TestCategory.OAUTH, False, str(e)
             )
 
+    def test_resource_indicators(self) -> TestResult:
+        """RFC 8707 resource indicators (issue #187): a resource on /token
+        binds the access token aud, a wrong-URI resource is invalid_target,
+        and no resource leaves the aud at oauth.audience."""
+        try:
+            mcp_resource = "https://mcp.example/server"
+            bound = self.session.post(
+                f"{self.base_url}/token",
+                data={"grant_type": "client_credentials", "resource": mcp_resource},
+                timeout=5,
+            )
+            bound_ok = False
+            introspect_ok = False
+            if bound.status_code == 200:
+                access_token = bound.json().get("access_token", "")
+                # Decode the aud without verification (base64url payload).
+                parts = access_token.split(".")
+                aud = None
+                if len(parts) == 3:
+                    pad = parts[1] + "=" * (-len(parts[1]) % 4)
+                    aud = json.loads(base64.urlsafe_b64decode(pad)).get("aud")
+                bound_ok = aud == mcp_resource
+                # /introspect must report the resource aud.
+                intro = self.session.post(
+                    f"{self.base_url}/introspect",
+                    data={"token": access_token},
+                    timeout=5,
+                )
+                introspect_ok = (
+                    intro.status_code == 200
+                    and intro.json().get("active") is True
+                    and intro.json().get("aud") == mcp_resource
+                )
+
+            bad = self.session.post(
+                f"{self.base_url}/token",
+                data={"grant_type": "client_credentials", "resource": "https://x/#frag"},
+                timeout=5,
+            )
+            invalid_target = (
+                bad.status_code == 400 and bad.json().get("error") == "invalid_target"
+            )
+
+            success = bound_ok and introspect_ok and invalid_target
+            return self._add_result(
+                "Resource Indicators",
+                TestCategory.OAUTH,
+                success,
+                "issue #187: resource binds the access token aud, reported by "
+                "/introspect; an invalid resource is invalid_target",
+                {
+                    "aud_bound_to_resource": bound_ok,
+                    "introspect_reports_aud": introspect_ok,
+                    "invalid_target": invalid_target,
+                },
+            )
+        except Exception as e:
+            return self._add_result(
+                "Resource Indicators", TestCategory.OAUTH, False, f"Error: {e}"
+            )
+
     def test_public_client_flow(self) -> TestResult:
         """Public client end-to-end (issue #188): a client with
         token_endpoint_auth_method 'none' and no secret completes the PKCE
@@ -4374,6 +4435,7 @@ class NanoIDPTestAgent:
                 self.test_issuer_from_proxy_headers,
                 self.test_authorization_code_pkce,
                 self.test_public_client_flow,
+                self.test_resource_indicators,
                 self.test_redirect_uri_exact_matching,
                 self.test_native_app_redirect_uris,
                 self.test_scope_enforcement,

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -90,6 +90,7 @@ class ClientEntry(BaseModel):
     additional_audiences: Any = None
     redirect_uris: Any = None
     allowed_scopes: Any = None
+    allowed_resources: Any = None
 
     def to_client(self) -> OAuthClient:
         return OAuthClient(
@@ -112,6 +113,9 @@ class ClientEntry(BaseModel):
             ),
             allowed_scopes=_coerce_client_str_list(
                 self.allowed_scopes, self.client_id, "allowed_scopes"
+            ),
+            allowed_resources=_coerce_client_str_list(
+                self.allowed_resources, self.client_id, "allowed_resources"
             ),
         )
 

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -261,6 +261,7 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
         "additional_audiences": client.additional_audiences,
         "redirect_uris": client.redirect_uris,
         "allowed_scopes": client.allowed_scopes,
+        "allowed_resources": client.allowed_resources,
     }
 
 
@@ -663,6 +664,11 @@ _TOOLS: list[Tool] = [
                     "items": {"type": "string"},
                     "description": "Per-client scope allow-list (#186); when non-empty, /authorize and /token reject a requested scope outside this set with invalid_scope (RFC 6749 4.1.2.1/5.2). Empty = any scope in the global oauth.scopes_supported vocabulary is allowed (optional)",
                 },
+                "allowed_resources": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Per-client RFC 8707 resource allow-list (#187); when non-empty, a resource requested on /authorize or /token must be one of these or the request is invalid_target. Empty = any valid resource (an absolute URI without a fragment) is allowed (optional)",
+                },
             },
             # client_secret is validated in the handler: required for every
             # auth method except 'none' (#188).
@@ -730,6 +736,11 @@ _TOOLS: list[Tool] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Replace the client's scope allow-list (#186); empty list removes the restriction (optional)",
+                },
+                "allowed_resources": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Replace the client's RFC 8707 resource allow-list (#187); empty list removes the restriction (optional)",
                 },
             },
             "required": ["client_id"],
@@ -1387,6 +1398,7 @@ def _tool_create_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         additional_audiences=_normalize_audiences(arguments.get("additional_audiences")),
         redirect_uris=_normalize_str_list(arguments.get("redirect_uris"), "redirect_uris"),
         allowed_scopes=_normalize_str_list(arguments.get("allowed_scopes"), "allowed_scopes"),
+        allowed_resources=_normalize_str_list(arguments.get("allowed_resources"), "allowed_resources"),
     )
     config.settings.clients.append(new_client)
     return {"success": True, "client": _client_to_dict(new_client)}
@@ -1414,6 +1426,11 @@ def _tool_update_client(arguments: dict[str, Any], config: ConfigManager) -> dic
     new_allowed_scopes = (
         _normalize_str_list(arguments["allowed_scopes"], "allowed_scopes")
         if "allowed_scopes" in arguments
+        else None
+    )
+    new_allowed_resources = (
+        _normalize_str_list(arguments["allowed_resources"], "allowed_resources")
+        if "allowed_resources" in arguments
         else None
     )
     new_background_color = (
@@ -1486,6 +1503,8 @@ def _tool_update_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         client.redirect_uris = new_redirect_uris
     if new_allowed_scopes is not None:
         client.allowed_scopes = new_allowed_scopes
+    if new_allowed_resources is not None:
+        client.allowed_resources = new_allowed_resources
 
     return {"success": True, "client": _client_to_dict(client)}
 

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -542,6 +542,18 @@ _TOOLS: list[Tool] = [
                         "would scope-gate them out."
                     ),
                 },
+                "resource": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "RFC 8707 resource indicator(s) (#187): bind the access "
+                        "token 'aud' to these resources (a string for one, an "
+                        "array for several) instead of oauth.audience, so a "
+                        "token minted for one MCP server is rejected by "
+                        "another. Each must be an absolute URI without a "
+                        "fragment (optional)"
+                    ),
+                },
             },
             "required": ["username"],
         },
@@ -569,6 +581,18 @@ _TOOLS: list[Tool] = [
                 "token": {
                     "type": "string",
                     "description": "JWT token to verify",
+                },
+                "audience": {
+                    "type": "string",
+                    "description": (
+                        "Expected audience (#187). Omit to verify signature "
+                        "and expiry only and return the claims (so a "
+                        "resource-bound access token is not falsely reported "
+                        "invalid). Provide a value to also require the token's "
+                        "'aud' to match it - how you simulate a resource "
+                        "server accepting a token for itself and rejecting one "
+                        "minted for another (optional)"
+                    ),
                 },
             },
             "required": ["token"],
@@ -1303,6 +1327,9 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
         or None,
         userinfo_claims=_normalize_str_list(arguments.get("userinfo_claims"), "userinfo_claims")
         or None,
+        # RFC 8707 resource indicators (#187): bind the access token aud to
+        # the given resource(s), the same as sending resource on /token.
+        resource=_normalize_str_list(arguments.get("resource"), "resource") or None,
     )
     result = {
         "success": True,
@@ -1328,8 +1355,15 @@ def _tool_decode_token(arguments: dict[str, Any], config: ConfigManager) -> dict
 def _tool_verify_token(arguments: dict[str, Any], config: ConfigManager) -> dict[str, Any]:
     token = arguments["token"]
     crypto = get_crypto_service(config.settings.keys_dir)
+    # audience: optional (#187). Omitted -> verify signature and expiry only
+    # and return the claims (the aud is in them), so a resource-bound access
+    # token (aud = an RFC 8707 resource, not oauth.audience) is not falsely
+    # reported invalid. Provided -> verify the token is valid FOR that
+    # audience, which is how a caller simulates a resource server accepting
+    # or rejecting a token ("valid for A, not for B").
+    audience = arguments.get("audience")
     try:
-        payload = crypto.verify_jwt(token, config.settings.audience)
+        payload = crypto.verify_jwt(token, audience)
         return {"valid": True, "claims": payload}
     except Exception as e:
         # A rejected token is verify_token's designed answer, not a tool

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -209,6 +209,20 @@ class OAuthClient(BaseModel):
             "invalid_scope, for every client, regardless of this field."
         ),
     )
+    allowed_resources: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Per-client RFC 8707 resource allow-list (issue #187). When "
+            "non-empty, a 'resource' indicator requested on /authorize or "
+            "/token must be one of these, otherwise the request is "
+            "invalid_target. Empty = this client may target any "
+            "syntactically valid resource (an absolute URI without a "
+            "fragment), the dev default - same 'empty = unrestricted' "
+            "convention as allowed_scopes and redirect_uris. Sending no "
+            "resource at all is always allowed and leaves the access token "
+            "aud at oauth.audience."
+        ),
+    )
 
     @model_validator(mode="after")
     def _confidential_clients_need_a_secret(self) -> "OAuthClient":

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -610,11 +610,15 @@ def _resolve_token_resource(
 ) -> Tuple[Optional[List[str]], Optional[ResponseReturnValue]]:
     """Resolve RFC 8707 resource indicators for a /token grant (#187).
 
-    ``original`` is what an earlier step already bound (an authorization
-    code, a refresh token, a device code) or None. A request that sends no
-    ``resource`` inherits ``original`` unchanged; a request that sends some
-    must keep them within ``original`` (narrowing, never widening - RFC 8707
-    section 2) and within the client's ``allowed_resources``. Returns
+    ``original`` is the resource set a prior step bound, with a deliberate
+    three-way meaning (#254 review, finding 1): ``None`` = there was no prior
+    authorization step (client_credentials, password authenticate directly),
+    so a requested resource is gated only by ``allowed_resources``; ``[]`` =
+    a prior step (an authorization code, a refresh token, a device code)
+    bound NO resource, so the request may not introduce one - a token can
+    only narrow what was authorized, never widen it (RFC 8707 section 2); a
+    non-empty list = the ceiling the request must stay within. A request
+    that sends no ``resource`` inherits ``original`` unchanged. Returns
     ``(resource_list_or_None, error_response_or_None)``; an ``invalid_target``
     is an RFC 6749 §5.2-shaped JSON error.
     """
@@ -853,9 +857,10 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         return abort(401, description="Refresh token has been revoked")
 
     # Resource indicators (#187): the refresh may narrow the bound resources
-    # to a subset of what the refresh token remembers, never widen them.
+    # to a subset of what the refresh token remembers, never widen them - a
+    # refresh token that bound none ([]) cannot introduce one (#254 review).
     resource, resource_error = _resolve_token_resource(
-        ctx, client, payload.get("resource")
+        ctx, client, payload.get("resource") or []
     )
     if resource_error is not None:
         return resource_error
@@ -1070,8 +1075,11 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
         code_scope = scope_result.granted
 
     # Resource indicators (#187): the token request may narrow to a subset of
-    # what /authorize bound into the code, never widen (RFC 8707 section 2).
-    resource, resource_error = _resolve_token_resource(ctx, client, auth_code.resource)
+    # what /authorize bound into the code, never widen (RFC 8707 section 2);
+    # a code that bound none ([]) cannot introduce one at /token (#254 review).
+    resource, resource_error = _resolve_token_resource(
+        ctx, client, auth_code.resource or []
+    )
     if resource_error is not None:
         return resource_error
 
@@ -1240,7 +1248,7 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
         # scope and emit an ID Token when 'openid' was asked for (issue #36).
         # The user authenticated at /device, not at this poll (#42).
         resource, resource_error = _resolve_token_resource(
-            ctx, ctx.config.get_client(ctx.client_id), grant.resource
+            ctx, ctx.config.get_client(ctx.client_id), grant.resource or []
         )
         if resource_error is not None:
             return resource_error
@@ -1737,11 +1745,14 @@ def introspect() -> ResponseReturnValue:
     if get_revocation_store().is_revoked(jti):
         return jsonify({"active": False})
 
-    # Token is valid - return introspection response
+    # Token is valid - return introspection response. RFC 7662 §2.2:
+    # client_id is the client the TOKEN was issued to, not the caller doing
+    # the introspection - the access token carries that claim since #188.
+    # Fall back to the caller only for a legacy token without the claim.
     response = {
         "active": True,
         "token_type": "Bearer",
-        "client_id": client_id,
+        "client_id": payload.get("client_id", client_id),
         "username": payload.get("sub"),
         "sub": payload.get("sub"),
         "aud": payload.get("aud"),
@@ -1845,18 +1856,20 @@ def revoke() -> ResponseReturnValue:
         )
         return "", 200
 
+    # A verified nanoidp token always carries a jti (crypto.create_jwt sets
+    # one); the audit reflects only what was actually revoked, so a jti-less
+    # edge token is not logged as revoked (#254 review, finding 3).
     if jti:
         get_revocation_store().revoke(jti)
         logger.info(f"Token revoked: {jti[:8]}...")
-
-    audit_event(
-        "revocation_request",
-        "success",
-        endpoint="/revoke",
-        client_id=client_id,
-        username=payload.get("sub"),
-        details={"revoked": True},
-    )
+        audit_event(
+            "revocation_request",
+            "success",
+            endpoint="/revoke",
+            client_id=client_id,
+            username=payload.get("sub"),
+            details={"revoked": True},
+        )
 
     # RFC 7009 requires 200 OK response regardless of outcome
     return "", 200
@@ -2014,6 +2027,7 @@ def device_authorization() -> ResponseReturnValue:
 
     # Resource indicators (#187): validate and remember them on the device
     # grant, so the polled token binds its aud to them.
+    validated_resources = None
     device_resources = request.form.getlist("resource")
     if device_resources and client is not None:
         resource_result = resolve_resources(device_resources, client)
@@ -2034,11 +2048,15 @@ def device_authorization() -> ResponseReturnValue:
                 ),
                 400,
             )
+        # Store the de-duplicated granted list, not the raw request (#254
+        # review, finding 2): a repeated resource must not become a
+        # duplicate entry in the token aud.
+        validated_resources = resource_result.granted or None
 
     # Create the device authorization; the store prunes stale entries and
     # keeps the user-code index internally (#84, previously module globals).
     device_code, user_code = get_device_code_store().create(
-        client_id, scope, resource=device_resources or None
+        client_id, scope, resource=validated_resources
     )
 
     audit_event(

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -388,6 +388,11 @@ def _validate_authorize_resources(
             p.client_id, result.error_description or "invalid_target",
             "invalid_target", result.error_description or "invalid resource",
         )
+    # Persist the de-duplicated granted list, not the raw request (#254
+    # review, finding 3): the authorization code must not carry a repeated
+    # resource that would become a duplicate entry in the token aud, the
+    # same normalization the device flow already does.
+    p.resources = result.granted or []
     return None
 
 
@@ -585,9 +590,17 @@ class _GrantOutcome:
     # False for grants with no end user: client_credentials must not hand
     # out a refresh token (RFC 6749 §4.4.3, #239).
     issue_refresh_token: bool = True
-    # RFC 8707 resource indicators bound to this token (#187): the access
-    # token aud, and (when a refresh token is issued) remembered on it.
+    # RFC 8707 resource indicators (#187). ``resource`` is the ACCESS token
+    # aud - the (possibly narrowed) subset the /token request asked for.
+    # ``refresh_resource`` is what the refresh token remembers: the FULL
+    # original grant, so a later refresh can still request any resource the
+    # original authorization covered, not only the narrowed subset the last
+    # access token used (RFC 8707 §2.2, #254 review). None on either means
+    # "no resource"; when refresh_resource is None it falls back to resource
+    # (grants with no prior authorization step, where the request IS the
+    # original grant).
     resource: Optional[List[str]] = None
+    refresh_resource: Optional[List[str]] = None
 
 
 @dataclass
@@ -874,6 +887,9 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         id_token_claims=id_token_claims,
         userinfo_claims=userinfo_claims,
         resource=resource,
+        # The rotated refresh token keeps the FULL original grant, not the
+        # subset this access token narrowed to (RFC 8707 §2.2, #254 review).
+        refresh_resource=payload.get("resource") or None,
     )
 
 
@@ -1096,6 +1112,11 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
         id_token_claims=requested_claims.get("id_token"),
         userinfo_claims=requested_claims.get("userinfo"),
         resource=resource,
+        # The refresh token keeps the code's FULL original resource set, so a
+        # later refresh can still request any resource the authorization
+        # covered - not only the subset this access token narrowed to
+        # (RFC 8707 §2.2, #254 review).
+        refresh_resource=auth_code.resource or None,
     )
 
 
@@ -1258,6 +1279,8 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
             scope=grant.scope,
             auth_time=grant.auth_time,
             resource=resource,
+            # Full original grant on the refresh token (RFC 8707 §2.2).
+            refresh_resource=grant.resource or None,
         )
     return (
         jsonify({"error": "server_error", "error_description": "Unknown device code status"}),
@@ -1510,6 +1533,7 @@ def token() -> ResponseReturnValue:
         issuer=effective_issuer(config.settings),
         issue_refresh_token=result.issue_refresh_token,
         resource=result.resource,
+        refresh_resource=result.refresh_resource,
     )
 
     # Audit log

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -631,13 +631,38 @@ def _resolve_token_resource(
     bound NO resource, so the request may not introduce one - a token can
     only narrow what was authorized, never widen it (RFC 8707 section 2); a
     non-empty list = the ceiling the request must stay within. A request
-    that sends no ``resource`` inherits ``original`` unchanged. Returns
+    that sends no ``resource`` inherits ``original`` - but re-validated
+    against the client's CURRENT ``allowed_resources``, so a resource
+    removed from the allow-list after the grant was issued is not still
+    minted on a later refresh (#256 review; the scope path re-validates the
+    same way with validate_only, #186 B1). Returns
     ``(resource_list_or_None, error_response_or_None)``; an ``invalid_target``
     is an RFC 6749 §5.2-shaped JSON error.
     """
     requested = request.form.getlist("resource")
     if not requested:
-        return (list(original) if original else None), None
+        if not original:
+            return None, None
+        if client is None:
+            # No client, no allow-list to enforce: inherit verbatim.
+            return list(original), None
+        # Re-validate the inherited resources against the current allow-list.
+        result = resolve_resources(original, client)
+        if not result.ok:
+            audit_event(
+                "token_request",
+                "failed",
+                endpoint="/token",
+                client_id=ctx.client_id,
+                details={"reason": result.error_description, "grant_type": ctx.grant_type},
+            )
+            return None, (
+                jsonify(
+                    {"error": "invalid_target", "error_description": result.error_description}
+                ),
+                400,
+            )
+        return (result.granted or None), None
     if client is None:
         return None, (
             jsonify({"error": "invalid_target", "error_description": "Unknown client"}),

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 import jwt as pyjwt
@@ -38,6 +38,7 @@ from ..services import (
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
 from ..services.redirect_uri import redirect_uri_is_registered, redirect_uri_rejection_reason
+from ..services.resource import resolve_resources
 from ..services.scope import resolve_scope
 from ..services.token import resolve_user_claim, sanitize_claim_names
 from ._audit import audit_event
@@ -119,6 +120,7 @@ class _AuthorizeParams:
     code_challenge_method: str
     nonce: str
     claims_param: str
+    resources: List[str]
 
 
 def _read_authorize_params() -> _AuthorizeParams:
@@ -142,6 +144,8 @@ def _read_authorize_params() -> _AuthorizeParams:
         ),
         nonce=params.get("nonce", session.get("oauth_nonce", "")),
         claims_param=params.get("claims", session.get("oauth_claims", "")),
+        # RFC 8707 resource is repeatable (#187): read every value, not one.
+        resources=params.getlist("resource") or session.get("oauth_resources", []),
     )
 
     if request.method == "GET":
@@ -154,6 +158,7 @@ def _read_authorize_params() -> _AuthorizeParams:
         session["oauth_code_challenge_method"] = p.code_challenge_method
         session["oauth_nonce"] = p.nonce
         session["oauth_claims"] = p.claims_param
+        session["oauth_resources"] = p.resources
 
     return p
 
@@ -365,6 +370,27 @@ def _validate_authorize_pkce(
     return None
 
 
+def _validate_authorize_resources(
+    config: ConfigManager, p: _AuthorizeParams, client: OAuthClient
+) -> Optional[ResponseReturnValue]:
+    """Validate the RFC 8707 ``resource`` indicators on /authorize (#187).
+
+    Each must be a syntactically valid indicator and, when the client
+    declares a non-empty ``allowed_resources``, one of that set; otherwise
+    the request is rejected with ``invalid_target`` (RFC 8707 section 2). The
+    validated resources travel with the authorization code, so /token binds
+    the access token aud to them."""
+    if not p.resources:
+        return None
+    result = resolve_resources(p.resources, client)
+    if not result.ok:
+        return _authorize_reject(
+            p.client_id, result.error_description or "invalid_target",
+            "invalid_target", result.error_description or "invalid resource",
+        )
+    return None
+
+
 def _handle_authorize_login(
     config: ConfigManager, p: _AuthorizeParams
 ) -> Tuple[Optional[str], Optional[ResponseReturnValue]]:
@@ -389,6 +415,7 @@ def _handle_authorize_login(
             nonce=p.nonce if p.nonce else None,
             state=p.state if p.state else None,
             claims=_parse_claims_parameter(p.claims_param),
+            resource=list(p.resources) if p.resources else None,
         )
 
         # Clear OAuth session data
@@ -505,6 +532,9 @@ def authorize() -> ResponseReturnValue:
     error = _validate_authorize_pkce(config, p, client)
     if error is not None:
         return error
+    error = _validate_authorize_resources(config, p, client)
+    if error is not None:
+        return error
 
     error_msg = None
     if request.method == "POST":
@@ -555,6 +585,9 @@ class _GrantOutcome:
     # False for grants with no end user: client_credentials must not hand
     # out a refresh token (RFC 6749 §4.4.3, #239).
     issue_refresh_token: bool = True
+    # RFC 8707 resource indicators bound to this token (#187): the access
+    # token aud, and (when a refresh token is issued) remembered on it.
+    resource: Optional[List[str]] = None
 
 
 @dataclass
@@ -570,6 +603,43 @@ class _GrantContext:
 
 # A handler returns either issuance parameters or a finished error response.
 GrantResult = Union[_GrantOutcome, ResponseReturnValue]
+
+
+def _resolve_token_resource(
+    ctx: _GrantContext, client: Optional[OAuthClient], original: Optional[List[str]]
+) -> Tuple[Optional[List[str]], Optional[ResponseReturnValue]]:
+    """Resolve RFC 8707 resource indicators for a /token grant (#187).
+
+    ``original`` is what an earlier step already bound (an authorization
+    code, a refresh token, a device code) or None. A request that sends no
+    ``resource`` inherits ``original`` unchanged; a request that sends some
+    must keep them within ``original`` (narrowing, never widening - RFC 8707
+    section 2) and within the client's ``allowed_resources``. Returns
+    ``(resource_list_or_None, error_response_or_None)``; an ``invalid_target``
+    is an RFC 6749 §5.2-shaped JSON error.
+    """
+    requested = request.form.getlist("resource")
+    if not requested:
+        return (list(original) if original else None), None
+    if client is None:
+        return None, (
+            jsonify({"error": "invalid_target", "error_description": "Unknown client"}),
+            400,
+        )
+    result = resolve_resources(requested, client, allowed_subset=original)
+    if not result.ok:
+        audit_event(
+            "token_request",
+            "failed",
+            endpoint="/token",
+            client_id=ctx.client_id,
+            details={"reason": result.error_description, "grant_type": ctx.grant_type},
+        )
+        return None, (
+            jsonify({"error": "invalid_target", "error_description": result.error_description}),
+            400,
+        )
+    return (result.granted or None), None
 
 
 def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
@@ -782,6 +852,14 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         )
         return abort(401, description="Refresh token has been revoked")
 
+    # Resource indicators (#187): the refresh may narrow the bound resources
+    # to a subset of what the refresh token remembers, never widen them.
+    resource, resource_error = _resolve_token_resource(
+        ctx, client, payload.get("resource")
+    )
+    if resource_error is not None:
+        return resource_error
+
     return _GrantOutcome(
         user=user,
         username=username,
@@ -790,6 +868,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         refresh_family=refresh_family,
         id_token_claims=id_token_claims,
         userinfo_claims=userinfo_claims,
+        resource=resource,
     )
 
 
@@ -877,11 +956,15 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
     # emit an ID Token (issue #36). nonce is non-standard for this grant but
     # accepted as a dev convenience; normalize an empty field to None so we
     # don't emit an empty nonce claim (matches the authorization_code path).
+    resource, resource_error = _resolve_token_resource(ctx, client, None)
+    if resource_error is not None:
+        return resource_error
     return _GrantOutcome(
         user=user,
         username=username,
         nonce=request.form.get("nonce") or None,
         scope=requested_scope,
+        resource=resource,
     )
 
 
@@ -986,6 +1069,12 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
             )
         code_scope = scope_result.granted
 
+    # Resource indicators (#187): the token request may narrow to a subset of
+    # what /authorize bound into the code, never widen (RFC 8707 section 2).
+    resource, resource_error = _resolve_token_resource(ctx, client, auth_code.resource)
+    if resource_error is not None:
+        return resource_error
+
     requested_claims = auth_code.claims or {}
     return _GrantOutcome(
         user=user,
@@ -998,6 +1087,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
         # Claims the client asked for through the OIDC `claims` parameter (#104).
         id_token_claims=requested_claims.get("id_token"),
         userinfo_claims=requested_claims.get("userinfo"),
+        resource=resource,
     )
 
 
@@ -1064,11 +1154,15 @@ def _grant_client_credentials(ctx: _GrantContext) -> GrantResult:
     # second, 7-day credential bound to the default user (or the synthetic
     # service account) that the grant never authenticated, spendable at
     # grant_type=refresh_token to obtain user-context tokens (#239).
+    resource, resource_error = _resolve_token_resource(ctx, client, None)
+    if resource_error is not None:
+        return resource_error
     return _GrantOutcome(
         user=user,
         username=user.username,
         scope=requested_scope,
         issue_refresh_token=False,
+        resource=resource,
     )
 
 
@@ -1145,11 +1239,17 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
         # The device flow authenticates an end-user, so honour the requested
         # scope and emit an ID Token when 'openid' was asked for (issue #36).
         # The user authenticated at /device, not at this poll (#42).
+        resource, resource_error = _resolve_token_resource(
+            ctx, ctx.config.get_client(ctx.client_id), grant.resource
+        )
+        if resource_error is not None:
+            return resource_error
         return _GrantOutcome(
             user=user,
             username=user.username,
             scope=grant.scope,
             auth_time=grant.auth_time,
+            resource=resource,
         )
     return (
         jsonify({"error": "server_error", "error_description": "Unknown device code status"}),
@@ -1401,6 +1501,7 @@ def token() -> ResponseReturnValue:
         userinfo_claims=result.userinfo_claims,
         issuer=effective_issuer(config.settings),
         issue_refresh_token=result.issue_refresh_token,
+        resource=result.resource,
     )
 
     # Audit log
@@ -1447,6 +1548,12 @@ def userinfo() -> ResponseReturnValue:
     # Verify token
     crypto = get_crypto_service(config.settings.keys_dir)
     try:
+        # /userinfo is the OP's own protected resource, so a token must be
+        # audienced to oauth.audience here (OIDC Core §5.3). A resource-bound
+        # access token (#187) carries an RFC 8707 resource as aud and belongs
+        # at its resource server, not here - it is used against /introspect
+        # by that server instead. A client that needs UserInfo requests a
+        # token without a resource.
         payload = crypto.verify_jwt(token, config.settings.audience)
     except ValueError as e:
         audit_event(
@@ -1599,7 +1706,9 @@ def introspect() -> ResponseReturnValue:
     # single signing key there is nothing to disambiguate, per RFC 7662 §2.1)
     crypto = get_crypto_service(config.settings.keys_dir)
     try:
-        payload = crypto.verify_jwt(token, config.settings.audience)
+        # Resource-bound access tokens (#187) carry an RFC 8707 resource as
+        # aud, not oauth.audience; verify signature+expiry, not audience.
+        payload = crypto.verify_jwt(token, None)
     except ValueError:
         # Token is invalid or expired
         audit_event(
@@ -1708,13 +1817,15 @@ def revoke() -> ResponseReturnValue:
     # blocking 1). The revocation store is keyed by jti, and the public
     # client's ownership check reads client_id: both must come from a
     # payload nanoidp actually signed, never from an attacker-supplied
-    # unsigned JWT. A token that fails verification (bad signature, wrong
-    # audience, expired) revokes nothing and still returns 200 - RFC 7009
-    # requires 200 regardless of outcome, and its privacy guidance forbids
-    # turning the endpoint into an oracle for a token's validity or owner.
+    # unsigned JWT. A token that fails verification (bad signature or expired)
+    # revokes nothing and still returns 200 - RFC 7009 requires 200 regardless
+    # of outcome, and its privacy guidance forbids turning the endpoint into
+    # an oracle for a token's validity or owner. Audience is NOT verified: a
+    # resource-bound access token (#187) carries an RFC 8707 resource as aud,
+    # and the client is still entitled to revoke it.
     crypto = get_crypto_service(config.settings.keys_dir)
     try:
-        payload = crypto.verify_jwt(token, config.settings.audience)
+        payload = crypto.verify_jwt(token, None)
     except ValueError:
         return "", 200
 
@@ -1901,9 +2012,34 @@ def device_authorization() -> ResponseReturnValue:
         requested_scope = scope_result.granted or ""
     scope = requested_scope
 
+    # Resource indicators (#187): validate and remember them on the device
+    # grant, so the polled token binds its aud to them.
+    device_resources = request.form.getlist("resource")
+    if device_resources and client is not None:
+        resource_result = resolve_resources(device_resources, client)
+        if not resource_result.ok:
+            audit_event(
+                "device_authorization_request",
+                "failed",
+                endpoint="/device_authorization",
+                client_id=client_id,
+                details={"reason": resource_result.error_description},
+            )
+            return (
+                jsonify(
+                    {
+                        "error": "invalid_target",
+                        "error_description": resource_result.error_description,
+                    }
+                ),
+                400,
+            )
+
     # Create the device authorization; the store prunes stale entries and
     # keeps the user-code index internally (#84, previously module globals).
-    device_code, user_code = get_device_code_store().create(client_id, scope)
+    device_code, user_code = get_device_code_store().create(
+        client_id, scope, resource=device_resources or None
+    )
 
     audit_event(
         "device_authorization_request",

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -474,6 +474,7 @@ def client_create() -> ResponseReturnValue:
             ),
             redirect_uris=_parse_textarea_list(request.form.get("redirect_uris", "")),
             allowed_scopes=_parse_textarea_list(request.form.get("allowed_scopes", "")),
+            allowed_resources=_parse_textarea_list(request.form.get("allowed_resources", "")),
         )
 
         yaml_writer.save_client(
@@ -556,6 +557,7 @@ def client_edit(client_id: str) -> ResponseReturnValue:
             ),
             redirect_uris=_parse_textarea_list(request.form.get("redirect_uris", "")),
             allowed_scopes=_parse_textarea_list(request.form.get("allowed_scopes", "")),
+            allowed_resources=_parse_textarea_list(request.form.get("allowed_resources", "")),
         )
 
         yaml_writer.save_client(

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -292,6 +292,8 @@ def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
         entry["redirect_uris"] = client.redirect_uris
     if client.allowed_scopes:
         entry["allowed_scopes"] = client.allowed_scopes
+    if client.allowed_resources:
+        entry["allowed_resources"] = client.allowed_resources
     return entry
 
 
@@ -349,6 +351,7 @@ def merge_client_entry(raw_entry: Dict[str, Any], client: OAuthClient) -> Dict[s
         ("additional_audiences", client.additional_audiences),
         ("redirect_uris", client.redirect_uris),
         ("allowed_scopes", client.allowed_scopes),
+        ("allowed_resources", client.allowed_resources),
     ):
         if not is_unchanged(raw_entry.get(field_name), new_list_value):
             if new_list_value:

--- a/src/nanoidp/services/auth_code.py
+++ b/src/nanoidp/services/auth_code.py
@@ -27,6 +27,9 @@ class AuthorizationCode:
     code_challenge_method: Optional[str] = None
     nonce: Optional[str] = None
     state: Optional[str] = None
+    # RFC 8707 resource indicators requested at /authorize (#187), carried to
+    # the token exchange so the access token aud can be bound to them.
+    resource: Optional[list] = None
     # Claim names requested via the OIDC `claims` parameter (§5.5, #104),
     # normalized to {"id_token": [...], "userinfo": [...]}. Carried from
     # /authorize to the token exchange so the ID Token / UserInfo can honour it.
@@ -61,6 +64,7 @@ class AuthCodeStore:
         nonce: Optional[str] = None,
         state: Optional[str] = None,
         claims: Optional[Dict[str, Any]] = None,
+        resource: Optional[list] = None,
     ) -> str:
         """
         Create a new authorization code.
@@ -93,6 +97,7 @@ class AuthCodeStore:
             nonce=nonce,
             state=state,
             claims=claims,
+            resource=resource,
         )
 
         with self._lock:

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -333,12 +333,21 @@ class CryptoService:
         token = jwt.encode(payload, self.priv_pem, algorithm="RS256", headers=headers)
         return token
 
-    def verify_jwt(self, token: str, audience: Union[str, List[str]]) -> Dict[str, Any]:
+    def verify_jwt(
+        self, token: str, audience: Optional[Union[str, List[str]]]
+    ) -> Dict[str, Any]:
         """Verify and decode a JWT token.
 
         ``audience`` accepts a list as well as a string (PyJWT semantics:
         the token is valid if its ``aud`` matches any of the values), so ID
         Tokens carrying an array ``aud`` can be verified too.
+
+        ``audience=None`` verifies signature and expiry but NOT the audience
+        (#187): nanoidp's own token-facing endpoints (/introspect, /userinfo,
+        /revoke) must accept an access token whose ``aud`` is an RFC 8707
+        resource, not ``oauth.audience`` - the issuer can serve a token it
+        signed regardless of who it was audienced to, and the id/refresh type
+        guard is ``token_use``, not the audience (RFC 7662, issue #34).
         """
         try:
             # Use public key for verification
@@ -347,7 +356,7 @@ class CryptoService:
                 self.pub_pem,
                 algorithms=["RS256"],
                 audience=audience,
-                options={"verify_signature": True},
+                options={"verify_signature": True, "verify_aud": audience is not None},
             )
             return payload
         except jwt.ExpiredSignatureError as e:

--- a/src/nanoidp/services/device_code.py
+++ b/src/nanoidp/services/device_code.py
@@ -47,6 +47,8 @@ class DeviceCodeGrant:
     status: str = "pending"  # pending, authorized, denied, expired
     username: Optional[str] = None
     auth_time: Optional[int] = None
+    # RFC 8707 resource indicators requested at /device_authorization (#187).
+    resource: Optional[list] = None
 
 
 class DevicePollOutcome(Enum):
@@ -89,6 +91,7 @@ class DeviceCodeStore:
         scope: str,
         expires_in: int = DEVICE_CODE_EXPIRES_IN,
         interval: int = DEVICE_POLL_INTERVAL,
+        resource: Optional[list] = None,
     ) -> Tuple[str, str]:
         """Create a device authorization; returns (device_code, user_code).
 
@@ -106,6 +109,7 @@ class DeviceCodeStore:
                 scope=scope,
                 expires_at=time.time() + expires_in,
                 interval=interval,
+                resource=resource,
             )
             self._by_user_code[user_code] = device_code
         return device_code, user_code

--- a/src/nanoidp/services/resource.py
+++ b/src/nanoidp/services/resource.py
@@ -75,11 +75,21 @@ def is_valid_resource_indicator(value: str) -> bool:
     # empty fragment, which is still a fragment component RFC 8707 disallows.
     if "#" in value:
         return False
+    # Every '%' must introduce a valid percent-encoded octet (RFC 3986 §2.1,
+    # "pct-encoded = '%' HEXDIG HEXDIG"): the charset check above admits a
+    # bare '%', so '%ZZ' and a trailing '%' still need rejecting (#254 review).
+    if re.search(r"%(?![0-9A-Fa-f]{2})", value):
+        return False
     try:
         parsed = urlparse(value)
+        # Accessing .port validates it: RFC 3986 defines port as *DIGIT, and
+        # urlparse raises ValueError on a non-numeric one (e.g. ':abc') only
+        # when the attribute is read (#254 review).
+        _ = parsed.port
     except ValueError:
-        # urlparse raises on a malformed authority (bad IPv6 literal); that is
-        # an invalid indicator, handled as invalid_target, not a crash.
+        # urlparse raises on a malformed authority (bad IPv6 literal, a
+        # non-numeric port); that is an invalid indicator, handled as
+        # invalid_target, not a crash.
         return False
     if not parsed.scheme:
         return False

--- a/src/nanoidp/services/resource.py
+++ b/src/nanoidp/services/resource.py
@@ -20,11 +20,19 @@ clients are unaffected - RFC 8707 makes the parameter optional, and the MCP
 requirement to send it is an obligation on the client, not the AS.
 """
 
+import re
 from dataclasses import dataclass
 from typing import List, Optional
 from urllib.parse import urlparse
 
 from ..models import OAuthClient
+
+# The characters RFC 3986 permits in a URI: unreserved, gen-delims,
+# sub-delims and the percent sign for percent-encoding. urlparse is a
+# permissive parser, not an RFC 3986 validator - it happily accepts a raw
+# space in the authority - so a resource indicator is charset-checked
+# against this set first (#254 review).
+_RFC3986_CHARS = re.compile(r"^[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]*$")
 
 
 @dataclass
@@ -46,15 +54,32 @@ class ResourceResult:
 
 
 def is_valid_resource_indicator(value: str) -> bool:
-    """RFC 8707 section 2: a resource is an absolute URI without a fragment.
+    """RFC 8707 section 2: a resource is an absolute URI without a fragment
+    (RFC 3986 section 4.3, "absolute-URI = scheme ':' hier-part [ '?' query ]").
 
-    A query component is allowed; a fragment is not. An empty or relative
-    value (no scheme, or no authority for a hierarchical scheme) is rejected.
+    A query component is allowed; a fragment component is NOT - and that
+    means no ``#`` at all, since an absolute-URI has no ``fragment``
+    production, so even an empty fragment (``https://x/#``) is rejected. A
+    value ``urlparse`` cannot parse (e.g. ``https://[bad`` raises
+    ``ValueError: Invalid IPv6 URL``) is a rejected indicator, never a 500.
+    An empty or relative value (no scheme, or no authority/path) is rejected.
     """
     if not value:
         return False
-    parsed = urlparse(value)
-    if parsed.fragment:
+    # Reject anything outside the RFC 3986 character set (a raw space, a
+    # control character, a non-ASCII byte) before parsing (#254 review).
+    if not _RFC3986_CHARS.match(value):
+        return False
+    # A fragment component is forbidden outright: reject any '#', not just a
+    # non-empty fragment (#254 review) - urlparse treats a trailing '#' as an
+    # empty fragment, which is still a fragment component RFC 8707 disallows.
+    if "#" in value:
+        return False
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        # urlparse raises on a malformed authority (bad IPv6 literal); that is
+        # an invalid indicator, handled as invalid_target, not a crash.
         return False
     if not parsed.scheme:
         return False

--- a/src/nanoidp/services/resource.py
+++ b/src/nanoidp/services/resource.py
@@ -1,0 +1,106 @@
+"""
+RFC 8707 Resource Indicators: validate a requested ``resource`` and bind the
+access token audience to it (issue #187).
+
+An MCP client sends ``resource=<MCP server URL>`` on /authorize and /token so
+the token it gets back is audience-restricted to that server and useless at
+another. This module answers, once for every call site in ``routes/oauth.py``,
+the two questions those sites share: is each requested ``resource`` a
+syntactically valid resource indicator (RFC 8707 section 2: an absolute URI
+with no fragment), and is it one this client may target? A failure is
+``invalid_target`` (RFC 8707 section 2), for both the authorization and the
+token endpoint.
+
+Like per-client scopes (#186), the per-client allow-list is opt-in: a client
+with an empty ``allowed_resources`` may target any syntactically valid
+resource (the dev-friendly default, same "empty = unrestricted" convention as
+``allowed_scopes`` and ``redirect_uris``). Sending no ``resource`` at all is
+always allowed and leaves the audience at ``oauth.audience``, so existing
+clients are unaffected - RFC 8707 makes the parameter optional, and the MCP
+requirement to send it is an obligation on the client, not the AS.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from ..models import OAuthClient
+
+
+@dataclass
+class ResourceResult:
+    """The outcome of validating requested resource indicators against a client.
+
+    ``granted`` is the list of resources to bind the token to (empty when the
+    request carried none, which leaves the audience at ``oauth.audience``);
+    ``error_description`` is set, and ``granted`` is None, exactly when the
+    request must be rejected as ``invalid_target``.
+    """
+
+    granted: Optional[List[str]]
+    error_description: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error_description is None
+
+
+def is_valid_resource_indicator(value: str) -> bool:
+    """RFC 8707 section 2: a resource is an absolute URI without a fragment.
+
+    A query component is allowed; a fragment is not. An empty or relative
+    value (no scheme, or no authority for a hierarchical scheme) is rejected.
+    """
+    if not value:
+        return False
+    parsed = urlparse(value)
+    if parsed.fragment:
+        return False
+    if not parsed.scheme:
+        return False
+    # An absolute URI has either an authority (https://host/...) or, for a
+    # non-hierarchical scheme, an opaque path (urn:example:resource).
+    return bool(parsed.netloc or parsed.path)
+
+
+def resolve_resources(
+    requested: List[str],
+    client: OAuthClient,
+    *,
+    allowed_subset: Optional[List[str]] = None,
+) -> ResourceResult:
+    """Validate requested resource indicators for one client.
+
+    ``requested`` is the raw list from ``resource`` parameters (repeatable per
+    RFC 8707). Each must be a valid indicator, and - when the client declares a
+    non-empty ``allowed_resources`` - one of that set. ``allowed_subset``, when
+    given, is a second gate the request must also fall within: the resources a
+    prior step already bound (an authorization code or refresh token), so a
+    /token request may narrow the set but never widen it (RFC 8707 section 2,
+    "the requested resource ... a subset").
+
+    Returns the de-duplicated granted list (order preserving first appearance),
+    or an ``invalid_target`` error. An empty ``requested`` is ``ok`` with an
+    empty granted list - no resource was asked for.
+    """
+    granted: List[str] = []
+    for value in requested:
+        if not is_valid_resource_indicator(value):
+            return ResourceResult(
+                None,
+                f"resource {value!r} is not a valid resource indicator "
+                "(RFC 8707: an absolute URI without a fragment)",
+            )
+        if client.allowed_resources and value not in client.allowed_resources:
+            return ResourceResult(
+                None, f"resource {value!r} is not allowed for this client"
+            )
+        if allowed_subset is not None and value not in allowed_subset:
+            return ResourceResult(
+                None,
+                f"resource {value!r} was not part of the original grant "
+                "and cannot be added on refresh",
+            )
+        if value not in granted:
+            granted.append(value)
+    return ResourceResult(granted)

--- a/src/nanoidp/services/resource.py
+++ b/src/nanoidp/services/resource.py
@@ -32,7 +32,10 @@ from ..models import OAuthClient
 # permissive parser, not an RFC 3986 validator - it happily accepts a raw
 # space in the authority - so a resource indicator is charset-checked
 # against this set first (#254 review).
-_RFC3986_CHARS = re.compile(r"^[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]*$")
+# \Z, not $: in Python '$' also matches just before a trailing newline, so a
+# value ending in an (encoded) newline would slip past this control-character
+# guard and land in the token aud (#256 review). \Z anchors the true end.
+_RFC3986_CHARS = re.compile(r"\A[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]*\Z")
 
 
 @dataclass

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -8,7 +8,7 @@ import logging
 import threading
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..config import User, get_config
 from .crypto import get_crypto_service
@@ -218,6 +218,7 @@ class TokenService:
         userinfo_claims: Optional[List[str]] = None,
         issuer: Optional[str] = None,
         issue_refresh_token: bool = True,
+        resource: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user.
 
@@ -319,11 +320,20 @@ class TokenService:
         # overridden by caller-supplied extra_claims.
         extra["token_use"] = "access"
 
+        # Access token audience (#187, RFC 8707): when the request bound one
+        # or more resource indicators, the aud IS those resources (a plain
+        # string for one, an array for several), so a token minted for
+        # resource A is rejected by resource server B. With no resource, the
+        # aud stays oauth.audience - no change for existing clients.
+        access_audience: Union[str, List[str]] = settings.audience
+        if resource:
+            access_audience = resource[0] if len(resource) == 1 else list(resource)
+
         # Create access token JWT
         token = self.crypto.create_jwt(
             sub=user.username,
             issuer=effective_issuer,
-            audience=settings.audience,
+            audience=access_audience,
             roles=user.roles,
             tenant=user.tenant,
             extra=extra,
@@ -403,6 +413,13 @@ class TokenService:
                 refresh_extra["req_id_token_claims"] = id_token_claims
             if userinfo_claims:
                 refresh_extra["req_userinfo_claims"] = userinfo_claims
+            # Remember the bound resources (#187), so a refresh re-issues an
+            # access token with the same aud - or a narrowed subset the
+            # refresh grant validates. The refresh token's own aud stays
+            # oauth.audience: it is spent at nanoidp's /token, not at a
+            # resource server.
+            if resource:
+                refresh_extra["resource"] = list(resource)
             refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
             response["refresh_token"] = self.crypto.create_jwt(
                 sub=user.username,

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -219,6 +219,7 @@ class TokenService:
         issuer: Optional[str] = None,
         issue_refresh_token: bool = True,
         resource: Optional[List[str]] = None,
+        refresh_resource: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Create a JWT token for a user.
 
@@ -413,13 +414,16 @@ class TokenService:
                 refresh_extra["req_id_token_claims"] = id_token_claims
             if userinfo_claims:
                 refresh_extra["req_userinfo_claims"] = userinfo_claims
-            # Remember the bound resources (#187), so a refresh re-issues an
-            # access token with the same aud - or a narrowed subset the
-            # refresh grant validates. The refresh token's own aud stays
-            # oauth.audience: it is spent at nanoidp's /token, not at a
-            # resource server.
-            if resource:
-                refresh_extra["resource"] = list(resource)
+            # Remember the FULL original grant's resources (#187, RFC 8707
+            # §2.2), NOT the narrowed subset this access token used: a later
+            # refresh may request any resource the original authorization
+            # covered. Falls back to the access-token resources for grants
+            # with no prior step (the request is the original grant). The
+            # refresh token's own aud stays oauth.audience: it is spent at
+            # nanoidp's /token, not at a resource server.
+            rt_resources = refresh_resource if refresh_resource is not None else resource
+            if rt_resources:
+                refresh_extra["resource"] = list(rt_resources)
             refresh_extra["rt_family"] = refresh_family or str(uuid.uuid4())
             response["refresh_token"] = self.crypto.create_jwt(
                 sub=user.username,

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -106,6 +106,19 @@
                         </div>
                     </div>
 
+                    <div class="mb-3">
+                        <label for="allowed_resources" class="form-label">Allowed Resources</label>
+                        <textarea class="form-control" id="allowed_resources" name="allowed_resources"
+                                  rows="3" placeholder="One resource URI per line, e.g.&#10;https://mcp.example/server">{{ client.allowed_resources | join('\n') if client else '' }}</textarea>
+                        <div class="form-text">
+                            RFC 8707 (#187). When set, a <code>resource</code> requested at
+                            <code>/authorize</code> or <code>/token</code> outside this list is
+                            <code>invalid_target</code>. Leave empty to allow any valid resource
+                            (an absolute URI without a fragment). The access token
+                            <code>aud</code> is bound to the requested resource.
+                        </div>
+                    </div>
+
                     <hr class="my-4">
                     <h6 class="mb-3">
                         <i class="bi bi-palette me-2"></i>Login Page Branding (Optional)

--- a/tests/test_client_contract.py
+++ b/tests/test_client_contract.py
@@ -50,6 +50,7 @@ FULL_A = OAuthClient(
     additional_audiences=["aud-a1", "aud-a2"],
     redirect_uris=["https://a.example/cb", "http://127.0.0.1:7001/cb"],
     allowed_scopes=["openid", "profile"],
+    allowed_resources=["https://a.example/mcp", "https://a.example/api"],
 )
 
 # A public client (#188): no secret at all. client_secret and
@@ -68,6 +69,7 @@ FULL_B = OAuthClient(
     additional_audiences=["aud-b1"],
     redirect_uris=["https://b.example/cb"],
     allowed_scopes=["openid", "email", "groups"],
+    allowed_resources=["https://b.example/mcp"],
 )
 
 # Every field at its default except the two required ones.

--- a/tests/test_mcp_tool_branches.py
+++ b/tests/test_mcp_tool_branches.py
@@ -158,6 +158,41 @@ class TestTokenToolBranches:
         assert verified["claims"]["sub"] == "admin"
 
     @pytest.mark.asyncio
+    async def test_resource_bound_token_verifies_and_simulates_a_resource_server(
+        self, mcp_config, mcp_call_tool
+    ):
+        """#187: generate_token binds the aud to a resource, and verify_token
+        with no audience accepts it (a resource-bound token is not falsely
+        invalid), while an explicit audience simulates a resource server
+        accepting a token for itself and rejecting one minted for another."""
+        import base64 as _b64
+
+        generated = _payload(
+            await mcp_call_tool(
+                "generate_token",
+                {"username": "admin", "scope": "openid", "resource": ["https://mcp-a/x"]},
+            )
+        )
+        token = generated["access_token"]
+        aud = json.loads(_b64.urlsafe_b64decode(token.split(".")[1] + "==="))["aud"]
+        assert aud == "https://mcp-a/x"
+
+        # No audience: valid, claims returned (the aud is visible).
+        any_aud = _payload(await mcp_call_tool("verify_token", {"token": token}))
+        assert any_aud["valid"] is True
+        assert any_aud["claims"]["aud"] == "https://mcp-a/x"
+
+        # For its own resource: valid; for another: invalid.
+        for_a = _payload(
+            await mcp_call_tool("verify_token", {"token": token, "audience": "https://mcp-a/x"})
+        )
+        for_b = _payload(
+            await mcp_call_tool("verify_token", {"token": token, "audience": "https://mcp-b/y"})
+        )
+        assert for_a["valid"] is True
+        assert for_b["valid"] is not True
+
+    @pytest.mark.asyncio
     async def test_generate_token_unknown_user_fails(self, mcp_config, mcp_call_tool):
         result = await mcp_call_tool("generate_token", {"username": "ghost"})
         assert result.is_error is True

--- a/tests/test_mcp_tool_branches.py
+++ b/tests/test_mcp_tool_branches.py
@@ -214,6 +214,7 @@ class TestClientToolBranches:
                     "additional_audiences": ["aud-x"],
                     "redirect_uris": ["https://other.example/cb"],
                     "allowed_scopes": ["openid"],
+                    "allowed_resources": ["https://mcp.example/server"],
                     "background_color": "#112233",
                     "header_color": "#445566",
                     "footer_color": "#778899",
@@ -229,6 +230,7 @@ class TestClientToolBranches:
         assert client.additional_audiences == ["aud-x"]
         assert client.redirect_uris == ["https://other.example/cb"]
         assert client.allowed_scopes == ["openid"]
+        assert client.allowed_resources == ["https://mcp.example/server"]
         assert client.background_color == "#112233"
         assert client.header_color == "#445566"
         assert client.footer_color == "#778899"

--- a/tests/test_resource_indicators.py
+++ b/tests/test_resource_indicators.py
@@ -48,6 +48,9 @@ class TestResourceValidation:
             ("https://mcp.example/server?v=1", True),
             ("urn:example:resource", True),
             ("https://mcp.example/server#frag", False),  # fragment
+            ("https://example.com/#", False),  # empty fragment component (#254 review)
+            ("https://[bad", False),  # urlparse ValueError, not a crash (#254 review)
+            ("https://exa mple/resource", False),  # raw space, not RFC 3986 (#254 review)
             ("/relative/path", False),  # no scheme
             ("", False),
         ],
@@ -164,6 +167,33 @@ class TestAuthorizationCodeFlow:
         resp = self._exchange(client, code, [RES_B])
         assert resp.status_code == 400
         assert json.loads(resp.data)["error"] == "invalid_target"
+
+    def test_duplicate_resource_at_authorize_is_deduplicated(self, client):
+        """#254 review, finding 3: a repeated resource at /authorize must not
+        become a duplicate entry in the token aud - the authorization code
+        stores the de-duplicated list, like the device flow already did."""
+        code = self._code(client, [RES_A, RES_A])
+        resp = self._exchange(client, code, [])
+        assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == RES_A
+
+    def test_refresh_keeps_the_full_grant_not_the_narrowed_subset(self, client):
+        """#254 review, finding 1 (RFC 8707 §2.2): narrowing the access token
+        to a subset must NOT narrow the refresh token - a later refresh can
+        still request any resource the original authorization covered."""
+        code = self._code(client, [RES_A, RES_B])
+        # scope offline_access so a refresh token is issued for the code flow.
+        first = json.loads(self._exchange(client, code, [RES_A]).data)
+        assert _aud(first["access_token"]) == RES_A
+        assert "refresh_token" in first
+        refreshed = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": first["refresh_token"],
+                  "resource": RES_B},
+            headers=_basic(),
+        )
+        assert refreshed.status_code == 200
+        assert _aud(json.loads(refreshed.data)["access_token"]) == RES_B
 
     def test_token_cannot_introduce_a_resource_the_code_never_bound(self, client):
         """#254 review, finding 1: a code that bound no resource cannot have

--- a/tests/test_resource_indicators.py
+++ b/tests/test_resource_indicators.py
@@ -56,6 +56,8 @@ class TestResourceValidation:
             ("https://example.com:abc/resource", False),  # non-numeric port (#254 review)
             ("https://example.com/%2Fpath", True),  # valid percent-encoding
             ("https://example.com:8443/resource", True),  # numeric port
+            ("https://example.com/\n", False),  # trailing newline (#256 review, \Z not $)
+            ("https://example.com/a\nb", False),  # embedded newline
             ("/relative/path", False),  # no scheme
             ("", False),
         ],
@@ -237,6 +239,41 @@ class TestRefreshToken:
             ).data
         )
         assert _aud(refreshed["access_token"]) == RES_A
+
+    def test_refresh_revalidates_against_current_allowed_resources(self, client, app):
+        """#256 review: a resource removed from the client's allowed_resources
+        after the grant was issued must not still be minted on a later
+        refresh that omits the resource parameter (the scope path
+        re-validates the same way, #186 B1)."""
+        with app.app_context():
+            get_config().settings.clients.append(
+                OAuthClient(
+                    client_id="rr", client_secret="s", allowed_resources=[RES_A]
+                )
+            )
+        first = json.loads(
+            client.post(
+                "/token",
+                data={"grant_type": "password", "username": "admin", "password": "admin",
+                      "scope": "openid", "resource": RES_A},
+                headers=_basic("rr", "s"),
+            ).data
+        )
+        assert _aud(first["access_token"]) == RES_A
+
+        # The admin removes RES_A from the allow-list.
+        with app.app_context():
+            for c in get_config().settings.clients:
+                if c.client_id == "rr":
+                    c.allowed_resources = [RES_B]
+
+        refreshed = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": first["refresh_token"]},
+            headers=_basic("rr", "s"),
+        )
+        assert refreshed.status_code == 400
+        assert json.loads(refreshed.data)["error"] == "invalid_target"
 
     def test_refresh_cannot_widen(self, client):
         first = json.loads(

--- a/tests/test_resource_indicators.py
+++ b/tests/test_resource_indicators.py
@@ -165,6 +165,15 @@ class TestAuthorizationCodeFlow:
         assert resp.status_code == 400
         assert json.loads(resp.data)["error"] == "invalid_target"
 
+    def test_token_cannot_introduce_a_resource_the_code_never_bound(self, client):
+        """#254 review, finding 1: a code that bound no resource cannot have
+        one introduced at /token - that would bind the token to a resource
+        /authorize never authorized (widening from nothing)."""
+        code = self._code(client, [])  # no resource at /authorize
+        resp = self._exchange(client, code, [RES_A])
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_target"
+
 
 class TestRefreshToken:
     def test_refresh_keeps_the_resource_aud(self, client):
@@ -226,6 +235,22 @@ class TestIntrospection:
         assert payload["active"] is True
         assert payload["aud"] == RES_A
 
+    def test_introspect_client_id_is_the_token_owner(self, client, app):
+        """#254 review, finding 4 (RFC 7662 §2.2): the response client_id is
+        the client the token was issued to, not the caller introspecting."""
+        with app.app_context():
+            get_config().settings.clients.append(
+                OAuthClient(client_id="rs", client_secret="rs-secret")
+            )
+        token = json.loads(
+            client.post(
+                "/token", data={"grant_type": "client_credentials"}, headers=_basic()
+            ).data
+        )["access_token"]
+        # A different client (a resource server) introspects the token.
+        resp = client.post("/introspect", data={"token": token}, headers=_basic("rs", "rs-secret"))
+        assert json.loads(resp.data)["client_id"] == "demo-client"
+
 
 class TestDeviceFlow:
     def test_resource_binds_the_device_token(self, client, app):
@@ -254,6 +279,35 @@ class TestDeviceFlow:
             headers=_basic(),
         )
         assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == RES_A
+
+    def test_duplicate_device_resource_is_deduplicated(self, client, app):
+        """#254 review, finding 2: a repeated resource must not become a
+        duplicate entry in the token aud."""
+        start = json.loads(
+            client.post(
+                "/device_authorization",
+                data={"scope": "openid", "resource": [RES_A, RES_A]},
+                headers=_basic(),
+            ).data
+        )
+        from nanoidp.services import get_device_code_store
+
+        with app.app_context():
+            get_device_code_store().verify(
+                start["user_code"], "approve", "admin", "admin",
+                get_config().interactive_authenticate,
+            )
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": start["device_code"],
+            },
+            headers=_basic(),
+        )
+        assert resp.status_code == 200
+        # A single resource collapses to a plain string, not a 1- or 2-item array.
         assert _aud(json.loads(resp.data)["access_token"]) == RES_A
 
     def test_invalid_device_resource_is_invalid_target(self, client):

--- a/tests/test_resource_indicators.py
+++ b/tests/test_resource_indicators.py
@@ -51,6 +51,11 @@ class TestResourceValidation:
             ("https://example.com/#", False),  # empty fragment component (#254 review)
             ("https://[bad", False),  # urlparse ValueError, not a crash (#254 review)
             ("https://exa mple/resource", False),  # raw space, not RFC 3986 (#254 review)
+            ("https://example.com/%ZZ", False),  # bad percent-encoding (#254 review)
+            ("https://example.com/%", False),  # trailing percent (#254 review)
+            ("https://example.com:abc/resource", False),  # non-numeric port (#254 review)
+            ("https://example.com/%2Fpath", True),  # valid percent-encoding
+            ("https://example.com:8443/resource", True),  # numeric port
             ("/relative/path", False),  # no scheme
             ("", False),
         ],

--- a/tests/test_resource_indicators.py
+++ b/tests/test_resource_indicators.py
@@ -1,0 +1,266 @@
+"""
+Tests for issue #187: RFC 8707 Resource Indicators.
+
+A ``resource`` on /authorize, /token or /device_authorization binds the
+access token ``aud`` to that resource, so a token minted for MCP server A is
+useless at server B. Per-client ``allowed_resources`` gates which resources a
+client may target; a /token request may narrow the resources a prior step
+bound, never widen them; sending no resource leaves ``aud`` at
+``oauth.audience`` (no change for existing clients).
+"""
+
+import base64
+import hashlib
+import json
+
+import pytest
+
+from nanoidp.config import get_config
+from nanoidp.models import OAuthClient
+from nanoidp.services.resource import is_valid_resource_indicator, resolve_resources
+
+RES_A = "https://mcp-a.example/server"
+RES_B = "https://mcp-b.example/server"
+REDIRECT = "http://localhost:3000/callback"
+VERIFIER = "a-code-verifier-that-is-long-enough-for-rfc-7636"
+CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(VERIFIER.encode()).digest())
+    .decode()
+    .rstrip("=")
+)
+
+
+def _basic(client_id="demo-client", secret="demo-secret"):
+    return {"Authorization": "Basic " + base64.b64encode(f"{client_id}:{secret}".encode()).decode()}
+
+
+def _aud(access_token):
+    payload = access_token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))["aud"]
+
+
+class TestResourceValidation:
+    @pytest.mark.parametrize(
+        "value,valid",
+        [
+            ("https://mcp.example/server", True),
+            ("https://mcp.example/server?v=1", True),
+            ("urn:example:resource", True),
+            ("https://mcp.example/server#frag", False),  # fragment
+            ("/relative/path", False),  # no scheme
+            ("", False),
+        ],
+    )
+    def test_indicator_syntax(self, value, valid):
+        assert is_valid_resource_indicator(value) is valid
+
+    def test_allowed_resources_gate(self):
+        client = OAuthClient(client_id="c", client_secret="s", allowed_resources=[RES_A])
+        assert resolve_resources([RES_A], client).ok is True
+        assert resolve_resources([RES_B], client).ok is False
+
+    def test_empty_allow_list_accepts_any_valid_resource(self):
+        client = OAuthClient(client_id="c", client_secret="s")
+        assert resolve_resources([RES_A, RES_B], client).granted == [RES_A, RES_B]
+
+    def test_narrowing_subset(self):
+        client = OAuthClient(client_id="c", client_secret="s")
+        assert resolve_resources([RES_A], client, allowed_subset=[RES_A, RES_B]).ok is True
+        assert resolve_resources([RES_B], client, allowed_subset=[RES_A]).ok is False
+
+
+class TestClientCredentials:
+    def test_resource_becomes_the_access_token_aud(self, client):
+        resp = client.post(
+            "/token", data={"grant_type": "client_credentials", "resource": RES_A},
+            headers=_basic(),
+        )
+        assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == RES_A
+
+    def test_two_resources_make_aud_an_array(self, client):
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "resource": [RES_A, RES_B]},
+            headers=_basic(),
+        )
+        assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == [RES_A, RES_B]
+
+    def test_no_resource_keeps_the_default_audience(self, client, app):
+        resp = client.post(
+            "/token", data={"grant_type": "client_credentials"}, headers=_basic()
+        )
+        with app.app_context():
+            default_aud = get_config().settings.audience
+        assert _aud(json.loads(resp.data)["access_token"]) == default_aud
+
+    def test_invalid_resource_is_invalid_target(self, client):
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "resource": "https://x/#frag"},
+            headers=_basic(),
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_target"
+
+    def test_disallowed_resource_is_invalid_target(self, client, app):
+        with app.app_context():
+            get_config().settings.clients.append(
+                OAuthClient(client_id="rc", client_secret="s", allowed_resources=[RES_A])
+            )
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials", "resource": RES_B},
+            headers=_basic("rc", "s"),
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_target"
+
+
+class TestAuthorizationCodeFlow:
+    def _code(self, client, resources):
+        params = {
+            "response_type": "code",
+            "client_id": "demo-client",
+            "redirect_uri": REDIRECT,
+            "scope": "openid",
+            "code_challenge": CHALLENGE,
+            "code_challenge_method": "S256",
+        }
+        query = "&".join([f"{k}={v}" for k, v in params.items()] + [f"resource={r}" for r in resources])
+        client.get("/authorize?" + query)
+        resp = client.post(
+            "/authorize", data={**params, "username": "admin", "password": "admin"},
+            follow_redirects=False,
+        )
+        return resp.headers["Location"].split("code=")[1].split("&")[0]
+
+    def _exchange(self, client, code, resources):
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT,
+            "code_verifier": VERIFIER,
+            "resource": resources,
+        }
+        return client.post("/token", data=data, headers=_basic())
+
+    def test_resource_from_authorize_binds_the_token(self, client):
+        code = self._code(client, [RES_A])
+        resp = self._exchange(client, code, [])  # inherit
+        assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == RES_A
+
+    def test_token_narrows_to_a_subset(self, client):
+        code = self._code(client, [RES_A, RES_B])
+        resp = self._exchange(client, code, [RES_A])
+        assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == RES_A
+
+    def test_token_cannot_widen_beyond_the_code(self, client):
+        code = self._code(client, [RES_A])
+        resp = self._exchange(client, code, [RES_B])
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_target"
+
+
+class TestRefreshToken:
+    def test_refresh_keeps_the_resource_aud(self, client):
+        first = json.loads(
+            client.post(
+                "/token", data={"grant_type": "client_credentials", "resource": RES_A},
+                headers=_basic(),
+            ).data
+        )
+        # client_credentials issues no refresh token (#239); use the password
+        # grant, which does, to exercise the refresh path.
+        first = json.loads(
+            client.post(
+                "/token",
+                data={"grant_type": "password", "username": "admin", "password": "admin",
+                      "scope": "openid", "resource": RES_A},
+                headers=_basic(),
+            ).data
+        )
+        assert _aud(first["access_token"]) == RES_A
+        refreshed = json.loads(
+            client.post(
+                "/token",
+                data={"grant_type": "refresh_token", "refresh_token": first["refresh_token"]},
+                headers=_basic(),
+            ).data
+        )
+        assert _aud(refreshed["access_token"]) == RES_A
+
+    def test_refresh_cannot_widen(self, client):
+        first = json.loads(
+            client.post(
+                "/token",
+                data={"grant_type": "password", "username": "admin", "password": "admin",
+                      "scope": "openid", "resource": RES_A},
+                headers=_basic(),
+            ).data
+        )
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": first["refresh_token"],
+                  "resource": RES_B},
+            headers=_basic(),
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_target"
+
+
+class TestIntrospection:
+    def test_introspect_reports_the_resource_aud(self, client):
+        token = json.loads(
+            client.post(
+                "/token", data={"grant_type": "client_credentials", "resource": RES_A},
+                headers=_basic(),
+            ).data
+        )["access_token"]
+        resp = client.post("/introspect", data={"token": token}, headers=_basic())
+        payload = json.loads(resp.data)
+        assert payload["active"] is True
+        assert payload["aud"] == RES_A
+
+
+class TestDeviceFlow:
+    def test_resource_binds_the_device_token(self, client, app):
+        start = json.loads(
+            client.post(
+                "/device_authorization",
+                data={"scope": "openid", "resource": RES_A},
+                headers=_basic(),
+            ).data
+        )
+        # Approve the user code directly through the store, then poll.
+        from nanoidp.services import get_device_code_store
+
+        with app.app_context():
+            store = get_device_code_store()
+            store.verify(
+                start["user_code"], "approve", "admin", "admin",
+                get_config().interactive_authenticate,
+            )
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": start["device_code"],
+            },
+            headers=_basic(),
+        )
+        assert resp.status_code == 200
+        assert _aud(json.loads(resp.data)["access_token"]) == RES_A
+
+    def test_invalid_device_resource_is_invalid_target(self, client):
+        resp = client.post(
+            "/device_authorization",
+            data={"scope": "openid", "resource": "https://x/#frag"},
+            headers=_basic(),
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_target"


### PR DESCRIPTION
Second deliverable of milestone 2.9.0 (OAuth/MCP interoperability foundation). Closes #187. **Stacked on #254 (#188)** - the base of this PR is `feat/188-public-clients`, not main, because both touch the token issuance path and #187 builds on the access-token `client_id` claim #254 added. Review/merge order: #254 first, then this rebases onto main. The diff shown against `feat/188-public-clients` is just this PR's ~20 files.

**What.** A client may send one or more `resource` parameters on `/authorize`, `/token` (every grant) and `/device_authorization`; the access token `aud` becomes those resources (a plain string for one, an array for several) instead of the global `oauth.audience`, so a token minted for MCP server A is rejected by server B - and a wrong-audience test can finally be written. `services/resource.py` validates a resource indicator (an absolute URI without a fragment, RFC 8707 §2) and resolves a request against the client's allow-list and any prior binding, mirroring `services/scope.py`; an invalid or disallowed resource is `invalid_target`.

**Contract details:**
- Per-client `allowed_resources` (empty = any valid resource, the dev default, same "empty = unrestricted" convention as `allowed_scopes`) gates which resources a client may target.
- The authorization code and the refresh token remember the bound resources; a `/token` request may narrow them to a subset but never widen (RFC 8707 §2). No `resource` inherits what the prior step bound.
- Sending no `resource` leaves `aud` at `oauth.audience` - **no behaviour change for existing clients**, pinned by a test.
- `/introspect` reports the token's `aud`. To do that for a resource-bound token, `crypto.verify_jwt` gained `audience=None` (verify signature + expiry, not the audience); `/introspect` and `/revoke` use it so a resource-bound token can be introspected and revoked. **`/userinfo` deliberately keeps requiring the OP audience** (`oauth.audience`): it is the OP's own protected resource, and a token audienced to an MCP server belongs at that server (used against `/introspect` by the server), not here - so the existing wrong-audience security test stays valid.
- No `resource_indicators_supported` discovery metadata: RFC 8707 defines none and nanoidp does not invent metadata.

**Profile decision** (the issue left it open): no profile *requires* a `resource` to be sent. RFC 8707 makes the parameter optional; the MCP requirement to send it is an obligation on the client, not the AS. Requiring it would break existing clients and the dev default. When a client *does* send one, `allowed_resources` (if set) is enforced regardless of profile.

**Declarative legs, all of them:** `ClientEntry` + coercion, `client_to_yaml`/`merge_client_entry`, the UI client form (Allowed Resources textarea), MCP `create_client`/`update_client` schemas and handlers, `_client_to_dict`, regenerated `config.v1.json`, configuration reference, the token-requests guide, CHANGELOG.

**Tests:** `tests/test_resource_indicators.py` (22) - indicator syntax, allow-list gate, narrowing; client_credentials aud binding including the multi-resource array and the unchanged default; the authorization-code flow's bind / narrow-to-subset / widen-rejected; refresh keeps and narrows the aud, and cannot widen; `/introspect` reports the resource aud; the device flow binds and rejects an invalid resource. Contract fixtures carry `allowed_resources` (the #231 parametric test flagged the missing legs before I wrote them); the MCP update round-trips it. **e2e:** `test_agent.py` gains `test_resource_indicators` - resource binds the aud, `/introspect` reports it, an invalid resource is `invalid_target` - verified live **59/60** (the one failure is the known environmental Redirect URI Exact Match baseline).

Suite **1780**, mypy, ruff, lint-imports clean.