### PR TITLE
feat: RFC 9207 iss on the authorization response (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,19 +46,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **RFC 9207: `iss` on the authorization response** (#189). `/authorize`
-  now appends `iss=<effective issuer>` to the success redirect, so a
-  client can detect an authorization-server mix-up (MCP 2026-07-28
-  recommends this). The value is the per-request effective issuer, so it
-  stays correct under `issuer_from_request` (#126). RFC 9207 requires an
-  `https` issuer with no query or fragment, so
-  `authorization_response_iss_parameter_supported` is advertised in
-  discovery only when the effective issuer meets that - an `http://localhost`
-  dev issuer still gets the parameter appended (useful for testing) but is
-  not advertised as compliant, no silent dev relaxation in the metadata.
-  nanoidp renders authorization errors locally as JSON rather than
-  redirecting them, so `iss` rides only on the success redirect and is
-  never a reason to redirect to an unvalidated URI. The device flow is
-  unaffected.
+  returns `iss=<effective issuer>` on every response delivered through a
+  validated `redirect_uri` - success and error alike - so a client can
+  detect an authorization-server mix-up (MCP 2026-07-28 recommends this).
+  The value is the per-request effective issuer, so it stays correct under
+  `issuer_from_request` (#126). `iss` is delivered exactly when discovery
+  advertises `authorization_response_iss_parameter_supported`: one
+  condition drives both, so metadata and behaviour never disagree. RFC
+  9207 requires an `https` issuer with a host and no query or fragment, so
+  the default `http://localhost:8000` sends no `iss` and advertises
+  `false`; point the issuer at `https` (directly or reflected via
+  `issuer_from_request` behind a TLS proxy) to turn RFC 9207 on. **Related
+  behaviour change**: authorization errors that occur after the
+  `redirect_uri` is validated (invalid_scope, PKCE errors, invalid_target)
+  are now OAuth error redirects to the client (`error`,
+  `error_description`, `state`, `iss`) instead of a local JSON 400, per
+  RFC 6749 §4.1.2.1 - completing the RFC 9207 "error responses too"
+  requirement. Errors before the `redirect_uri` is trusted (unknown
+  client, malformed or unregistered `redirect_uri`) stay local JSON. The
+  device flow is unaffected.
 - **RFC 8707 Resource Indicators: `resource` binds the access token
   audience** (#187). A client may send one or more `resource` parameters
   on `/authorize`, `/token` (every grant) and `/device_authorization`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only the secret, so every field (present and future) is carried.
 
 ### Added
+- **RFC 9207: `iss` on the authorization response** (#189). `/authorize`
+  now appends `iss=<effective issuer>` to the success redirect, so a
+  client can detect an authorization-server mix-up (MCP 2026-07-28
+  recommends this). The value is the per-request effective issuer, so it
+  stays correct under `issuer_from_request` (#126). RFC 9207 requires an
+  `https` issuer with no query or fragment, so
+  `authorization_response_iss_parameter_supported` is advertised in
+  discovery only when the effective issuer meets that - an `http://localhost`
+  dev issuer still gets the parameter appended (useful for testing) but is
+  not advertised as compliant, no silent dev relaxation in the metadata.
+  nanoidp renders authorization errors locally as JSON rather than
+  redirecting them, so `iss` rides only on the success redirect and is
+  never a reason to redirect to an unvalidated URI. The device flow is
+  unaffected.
 - **RFC 8707 Resource Indicators: `resource` binds the access token
   audience** (#187). A client may send one or more `resource` parameters
   on `/authorize`, `/token` (every grant) and `/device_authorization`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are now OAuth error redirects to the client (`error`,
   `error_description`, `state`, `iss`) instead of a local JSON 400, per
   RFC 6749 §4.1.2.1 - completing the RFC 9207 "error responses too"
-  requirement. Errors before the `redirect_uri` is trusted (unknown
-  client, malformed or unregistered `redirect_uri`) stay local JSON. The
-  device flow is unaffected.
+  requirement. `unsupported_response_type` (a non-`code` `response_type`)
+  is validated after the `redirect_uri` too, so it redirects as well.
+  Errors before the `redirect_uri` is trusted (unknown client, malformed
+  or unregistered `redirect_uri`) stay local JSON. A `redirect_uri` that
+  carries its own query keeps it: the response parameters are appended,
+  never fold into an existing value. The device flow is unaffected.
 - **RFC 8707 Resource Indicators: `resource` binds the access token
   audience** (#187). A client may send one or more `resource` parameters
   on `/authorize`, `/token` (every grant) and `/device_authorization`;

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -402,6 +402,18 @@ body parameters and rejects Basic. The other credentialed endpoints -
 endpoint and stay lenient: they accept a confidential client's secret
 over either HTTP Basic or the request body.
 
+**Authorization response `iss`** (issue #189, RFC 9207): `/authorize`
+returns `iss=<effective issuer>` on the success redirect, so a client can
+detect an authorization-server mix-up. The value is the per-request
+effective issuer, so it follows `issuer_from_request`. RFC 9207 requires
+the issuer to be an `https` URL with no query or fragment;
+`authorization_response_iss_parameter_supported` is advertised in
+discovery only when the effective issuer meets that, so an `http://localhost`
+dev issuer still gets the parameter (useful for testing) but is not
+advertised as compliant. nanoidp renders authorization errors locally as
+JSON rather than redirecting them, so `iss` rides only on the success
+redirect - it is never a reason to redirect to an unvalidated URI.
+
 **Resource indicators** (issue #187, RFC 8707): a client may send one or
 more `resource` parameters on `/authorize`, `/token` and
 `/device_authorization`, and the access token's `aud` is bound to those

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -403,16 +403,20 @@ endpoint and stay lenient: they accept a confidential client's secret
 over either HTTP Basic or the request body.
 
 **Authorization response `iss`** (issue #189, RFC 9207): `/authorize`
-returns `iss=<effective issuer>` on the success redirect, so a client can
-detect an authorization-server mix-up. The value is the per-request
-effective issuer, so it follows `issuer_from_request`. RFC 9207 requires
-the issuer to be an `https` URL with no query or fragment;
-`authorization_response_iss_parameter_supported` is advertised in
-discovery only when the effective issuer meets that, so an `http://localhost`
-dev issuer still gets the parameter (useful for testing) but is not
-advertised as compliant. nanoidp renders authorization errors locally as
-JSON rather than redirecting them, so `iss` rides only on the success
-redirect - it is never a reason to redirect to an unvalidated URI.
+returns `iss=<effective issuer>` on every response delivered through a
+validated `redirect_uri` - success and error alike - so a client can
+detect an authorization-server mix-up. `iss` is delivered exactly when
+discovery advertises `authorization_response_iss_parameter_supported`: a
+single condition drives both, so metadata and behaviour never disagree.
+RFC 9207 requires the issuer to be an `https` URL with a host and no query
+or fragment, so the default `http://localhost:8000` dev issuer sends no
+`iss` and advertises `false`; point the issuer at `https` (directly, or
+reflected via `issuer_from_request` behind a TLS proxy) to turn RFC 9207
+on. The value follows `issuer_from_request`. Errors are OAuth error
+redirects (`error`, `error_description`, `state`, `iss`) once the
+`redirect_uri` is validated; an error before that - an unknown client, a
+malformed or unregistered `redirect_uri` - stays a local JSON response,
+never a redirect to an unvalidated URI.
 
 **Resource indicators** (issue #187, RFC 8707): a client may send one or
 more `resource` parameters on `/authorize`, `/token` and

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -4278,12 +4278,16 @@ class NanoIDPTestAgent:
             self._add_result(
                 "oauth21 Authorize Strictness",
                 TestCategory.OAUTH,
-                no_pkce.status_code == 400
-                and plain.status_code == 400
+                # PKCE errors on a registered client redirect_uri are OAuth
+                # error redirects now (#189); the unregistered-client error
+                # happens before redirect_uri is trusted, so it stays local.
+                no_pkce.status_code in (302, 303)
+                and "error=invalid_request" in no_pkce.headers.get("Location", "")
+                and plain.status_code in (302, 303)
                 and s256.status_code == 200
                 and unregistered.status_code == 400,
-                "no-PKCE 400, plain 400, S256+registered 200, "
-                "unregistered client 400",
+                "no-PKCE redirect(error), plain redirect(error), "
+                "S256+registered 200, unregistered client local 400",
                 {
                     "no_pkce": no_pkce.status_code,
                     "plain": plain.status_code,

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -697,8 +697,13 @@ class NanoIDPTestAgent:
                 allow_redirects=False,
                 timeout=5,
             )
+            # #189: a post-redirect-validation error (here PKCE) is now an
+            # OAuth error redirect, not a local 400.
+            no_pkce_loc = no_pkce.headers.get("Location", "")
             refused_without_pkce = (
-                no_pkce.status_code == 400 and "S256" in no_pkce.text
+                no_pkce.status_code in (302, 303)
+                and "error=invalid_request" in no_pkce_loc
+                and "S256" in no_pkce_loc
             )
 
             # Leg 2: full PKCE S256 flow with client_id alone at /token.
@@ -785,6 +790,21 @@ class NanoIDPTestAgent:
     def test_authorization_code_pkce(self) -> TestResult:
         """Authorization Code Flow with PKCE (simulated)."""
         try:
+            # RFC 9207 (#189): capture the issuer to compare iss against
+            # BEFORE starting the request - the anti-mix-up property is that
+            # the client checks iss against an issuer it established earlier,
+            # not one it fetched from the same response. None when discovery
+            # says iss is unsupported (an http dev issuer), so we then assert
+            # iss is absent.
+            _disco = requests.get(
+                f"{self.base_url}/.well-known/openid-configuration", timeout=5
+            ).json()
+            self._iss_expected_issuer = (
+                _disco.get("issuer")
+                if _disco.get("authorization_response_iss_parameter_supported")
+                else None
+            )
+
             # Step 1: Generate PKCE challenge
             self._pkce_verifier = secrets.token_urlsafe(32)
             challenge = base64.urlsafe_b64encode(
@@ -848,20 +868,24 @@ class NanoIDPTestAgent:
                                 "State mismatch"
                             )
 
-                        # RFC 9207 (#189): the authorization response carries
-                        # iss, and it must equal the discovery issuer.
+                        # RFC 9207 (#189): iss is delivered exactly when
+                        # discovery advertises support, and then must equal the
+                        # discovery issuer (captured up-front, the value the
+                        # client trusts and compares against - the anti-mix-up
+                        # property). With an http dev issuer neither is present.
                         returned_iss = params.get("iss", [None])[0]
-                        discovery = requests.get(
-                            f"{self.base_url}/.well-known/openid-configuration",
-                            timeout=5,
-                        ).json()
-                        if returned_iss != discovery.get("issuer"):
+                        iss_supported = self._iss_expected_issuer is not None
+                        if iss_supported and returned_iss != self._iss_expected_issuer:
                             return self._add_result(
-                                "Auth Code + PKCE",
-                                TestCategory.OAUTH,
-                                False,
+                                "Auth Code + PKCE", TestCategory.OAUTH, False,
                                 f"iss mismatch: response {returned_iss!r} != "
-                                f"discovery {discovery.get('issuer')!r} (RFC 9207)",
+                                f"discovery {self._iss_expected_issuer!r} (RFC 9207)",
+                            )
+                        if not iss_supported and returned_iss is not None:
+                            return self._add_result(
+                                "Auth Code + PKCE", TestCategory.OAUTH, False,
+                                "iss sent while discovery advertises it "
+                                "unsupported (RFC 9207 metadata/behaviour must agree)",
                             )
 
                         # Step 3: Exchange code for token
@@ -1224,12 +1248,11 @@ class NanoIDPTestAgent:
                 )
 
             def is_invalid_scope(resp: requests.Response) -> bool:
-                if resp.status_code != 400:
+                # #189: an /authorize scope error is delivered as an OAuth
+                # error redirect (error=invalid_scope) to the redirect_uri.
+                if resp.status_code not in (302, 303):
                     return False
-                try:
-                    return resp.json().get("error") == "invalid_scope"
-                except ValueError:
-                    return False
+                return "error=invalid_scope" in resp.headers.get("Location", "")
 
             authorize_disallowed = authorize("email")
             authorize_allowed = authorize("openid")

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -848,6 +848,22 @@ class NanoIDPTestAgent:
                                 "State mismatch"
                             )
 
+                        # RFC 9207 (#189): the authorization response carries
+                        # iss, and it must equal the discovery issuer.
+                        returned_iss = params.get("iss", [None])[0]
+                        discovery = requests.get(
+                            f"{self.base_url}/.well-known/openid-configuration",
+                            timeout=5,
+                        ).json()
+                        if returned_iss != discovery.get("issuer"):
+                            return self._add_result(
+                                "Auth Code + PKCE",
+                                TestCategory.OAUTH,
+                                False,
+                                f"iss mismatch: response {returned_iss!r} != "
+                                f"discovery {discovery.get('issuer')!r} (RFC 9207)",
+                            )
+
                         # Step 3: Exchange code for token
                         token_response = self.session.post(
                             f"{self.base_url}/token",

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -432,6 +432,16 @@ def _handle_authorize_login(
         redirect_params = {"code": code}
         if p.state:
             redirect_params["state"] = p.state
+        # RFC 9207 (#189): return the effective issuer so the client can
+        # detect an authorization-server mix-up. Only added to a response
+        # delivered through the already-validated redirect_uri; nanoidp
+        # renders authorization errors locally as JSON (see
+        # _authorize_reject) rather than redirecting them, so there is no
+        # client-redirected error response for iss to ride on - and iss is
+        # never a reason to redirect to an unvalidated URI. The value is the
+        # per-request effective issuer, so it stays correct under
+        # issuer_from_request (#126).
+        redirect_params["iss"] = effective_issuer(config.settings)
 
         callback_url = f"{p.redirect_uri}?{urlencode(redirect_params)}"
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -7,7 +7,6 @@ import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from urllib.parse import urlencode
 
 import jwt as pyjwt
 from flask import (
@@ -38,7 +37,11 @@ from ..services import (
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
 from ..services.discovery import issuer_qualifies_for_iss_parameter
-from ..services.redirect_uri import redirect_uri_is_registered, redirect_uri_rejection_reason
+from ..services.redirect_uri import (
+    append_authorization_params,
+    redirect_uri_is_registered,
+    redirect_uri_rejection_reason,
+)
 from ..services.resource import resolve_resources
 from ..services.scope import resolve_scope
 from ..services.token import resolve_user_claim, sanitize_claim_names
@@ -206,24 +209,17 @@ def _authorize_error_redirect(
     issuer = effective_issuer(config.settings)
     if issuer_qualifies_for_iss_parameter(issuer):
         params["iss"] = issuer
-    return redirect(f"{p.redirect_uri}?{urlencode(params)}")
+    return redirect(append_authorization_params(p.redirect_uri, params))
 
 
 def _validate_authorize_client(
     config: ConfigManager, p: _AuthorizeParams
 ) -> Tuple[Optional[OAuthClient], Optional[ResponseReturnValue]]:
-    """Required-parameter checks and client lookup: (client, None) or (None, error)."""
-    if p.response_type != "code":
-        return None, (
-            jsonify(
-                {
-                    "error": "unsupported_response_type",
-                    "error_description": "Only 'code' response_type is supported",
-                }
-            ),
-            400,
-        )
+    """Required-parameter checks and client lookup: (client, None) or (None, error).
 
+    response_type is NOT checked here: it is validated after the redirect_uri
+    is trusted (#258 review), so an unsupported_response_type on a valid
+    redirect_uri is delivered as an error redirect, not a local JSON."""
     if not p.client_id:
         return None, (
             jsonify({"error": "invalid_request", "error_description": "client_id is required"}),
@@ -242,6 +238,24 @@ def _validate_authorize_client(
             p.client_id, "Unknown client", "invalid_client", "Unknown client_id"
         )
     return client, None
+
+
+def _validate_authorize_response_type(
+    config: ConfigManager, p: _AuthorizeParams
+) -> Optional[ResponseReturnValue]:
+    """Only the authorization code flow is supported (#41). Checked after the
+    redirect_uri is validated so an unsupported_response_type is delivered as
+    an error redirect carrying iss (RFC 6749 §4.1.2.1, RFC 9207, #258
+    review), not a local JSON - the implicit flow is intentionally absent."""
+    if p.response_type != "code":
+        return _authorize_error_redirect(
+            config,
+            p,
+            "unsupported_response_type",
+            "Only 'code' response_type is supported",
+            f"unsupported response_type {p.response_type!r}",
+        )
+    return None
 
 
 def _validate_authorize_scope(
@@ -477,7 +491,7 @@ def _handle_authorize_login(
         if issuer_qualifies_for_iss_parameter(issuer):
             redirect_params["iss"] = issuer
 
-        callback_url = f"{p.redirect_uri}?{urlencode(redirect_params)}"
+        callback_url = append_authorization_params(p.redirect_uri, redirect_params)
 
         audit_event(
             "authorization_request",
@@ -577,6 +591,9 @@ def authorize() -> ResponseReturnValue:
     # it), but once it is trusted, every later error is delivered to the
     # client as an OAuth error redirect carrying iss (#258 review).
     error = _validate_authorize_redirect_uri(config, p, client)
+    if error is not None:
+        return error
+    error = _validate_authorize_response_type(config, p)
     if error is not None:
         return error
     error = _validate_authorize_scope(config, p, client)

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -37,6 +37,7 @@ from ..services import (
     get_token_service,
 )
 from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
+from ..services.discovery import issuer_qualifies_for_iss_parameter
 from ..services.redirect_uri import redirect_uri_is_registered, redirect_uri_rejection_reason
 from ..services.resource import resolve_resources
 from ..services.scope import resolve_scope
@@ -182,6 +183,32 @@ def _authorize_reject(
     return jsonify({"error": error, "error_description": description}), 400
 
 
+def _authorize_error_redirect(
+    config: ConfigManager, p: _AuthorizeParams, error: str, description: str, reason: str
+) -> ResponseReturnValue:
+    """Deliver an authorization error to the client through the ALREADY
+    VALIDATED redirect_uri (RFC 6749 §4.1.2.1), carrying iss so the client
+    can still detect an authorization-server mix-up on an error (#189/RFC
+    9207 §2: iss appears on error responses too). Only reachable after
+    _validate_authorize_redirect_uri has run, so this never redirects to an
+    unvalidated URI - errors before that stay local (see _authorize_reject).
+    """
+    audit_event(
+        "authorization_request",
+        "failed",
+        endpoint="/authorize",
+        client_id=p.client_id,
+        details={"reason": reason},
+    )
+    params = {"error": error, "error_description": description}
+    if p.state:
+        params["state"] = p.state
+    issuer = effective_issuer(config.settings)
+    if issuer_qualifies_for_iss_parameter(issuer):
+        params["iss"] = issuer
+    return redirect(f"{p.redirect_uri}?{urlencode(params)}")
+
+
 def _validate_authorize_client(
     config: ConfigManager, p: _AuthorizeParams
 ) -> Tuple[Optional[OAuthClient], Optional[ResponseReturnValue]]:
@@ -235,10 +262,11 @@ def _validate_authorize_scope(
         default_when_omitted="openid",
     )
     if not scope_result.ok:
-        return _authorize_reject(
-            p.client_id,
-            scope_result.error_description or "invalid scope",
+        return _authorize_error_redirect(
+            config,
+            p,
             "invalid_scope",
+            scope_result.error_description or "invalid scope",
             scope_result.error_description or "invalid scope",
         )
     p.scope = scope_result.granted or ""
@@ -312,28 +340,31 @@ def _validate_authorize_pkce(
     party that started the flow."""
     if client is not None and client.is_public:
         if not p.code_challenge:
-            return _authorize_reject(
-                p.client_id,
-                "Public client without PKCE",
+            return _authorize_error_redirect(
+                config,
+                p,
                 "invalid_request",
                 "This client's token_endpoint_auth_method is 'none': PKCE "
                 "with code_challenge_method S256 is required",
+                "Public client without PKCE",
             )
         if (p.code_challenge_method or "plain") != "S256":
-            return _authorize_reject(
-                p.client_id,
-                "Public client with non-S256 PKCE",
+            return _authorize_error_redirect(
+                config,
+                p,
                 "invalid_request",
                 "This client's token_endpoint_auth_method is 'none': "
                 "code_challenge_method must be S256",
+                "Public client with non-S256 PKCE",
             )
 
     if config.settings.pkce_required and not p.code_challenge:
-        return _authorize_reject(
-            p.client_id,
-            "PKCE code_challenge required (require_pkce or oauth21)",
+        return _authorize_error_redirect(
+            config,
+            p,
             "invalid_request",
             "PKCE code_challenge is required " "(require_pkce setting or oauth21 profile)",
+            "PKCE code_challenge required (require_pkce or oauth21)",
         )
 
     if not p.code_challenge:
@@ -346,11 +377,12 @@ def _validate_authorize_pkce(
     # rejected at the authorization endpoint per §4.4.1.
     effective_method = p.code_challenge_method or "plain"
     if effective_method not in ("plain", "S256"):
-        return _authorize_reject(
-            p.client_id,
-            f"Unsupported code_challenge_method: {effective_method}",
+        return _authorize_error_redirect(
+            config,
+            p,
             "invalid_request",
             f"Unsupported code_challenge_method " f"'{effective_method}'; use S256 or plain",
+            f"Unsupported code_challenge_method: {effective_method}",
         )
 
     # The 'plain' method is only acceptable when S256 is unavailable
@@ -358,14 +390,15 @@ def _validate_authorize_pkce(
     # §7.5.2) profiles reject it outright, whether requested explicitly
     # or via the implicit default.
     if effective_method == "plain" and not config.settings.pkce_plain_allowed:
-        return _authorize_reject(
-            p.client_id,
-            "PKCE method 'plain' rejected by " f"{config.settings.security_profile} profile",
+        return _authorize_error_redirect(
+            config,
+            p,
             "invalid_request",
             "code_challenge_method 'plain' (including the "
             "implicit default when the parameter is omitted) "
             f"is not allowed by the {config.settings.security_profile} "
             "profile; use S256",
+            "PKCE method 'plain' rejected by " f"{config.settings.security_profile} profile",
         )
     return None
 
@@ -384,9 +417,10 @@ def _validate_authorize_resources(
         return None
     result = resolve_resources(p.resources, client)
     if not result.ok:
-        return _authorize_reject(
-            p.client_id, result.error_description or "invalid_target",
-            "invalid_target", result.error_description or "invalid resource",
+        return _authorize_error_redirect(
+            config, p, "invalid_target",
+            result.error_description or "invalid resource",
+            result.error_description or "invalid_target",
         )
     # Persist the de-duplicated granted list, not the raw request (#254
     # review, finding 3): the authorization code must not carry a repeated
@@ -433,15 +467,15 @@ def _handle_authorize_login(
         if p.state:
             redirect_params["state"] = p.state
         # RFC 9207 (#189): return the effective issuer so the client can
-        # detect an authorization-server mix-up. Only added to a response
-        # delivered through the already-validated redirect_uri; nanoidp
-        # renders authorization errors locally as JSON (see
-        # _authorize_reject) rather than redirecting them, so there is no
-        # client-redirected error response for iss to ride on - and iss is
-        # never a reason to redirect to an unvalidated URI. The value is the
-        # per-request effective issuer, so it stays correct under
-        # issuer_from_request (#126).
-        redirect_params["iss"] = effective_issuer(config.settings)
+        # detect an authorization-server mix-up. Sent exactly when it is
+        # advertised as supported in discovery (#258 review): a single
+        # predicate drives both, so a client never sees iss without the
+        # metadata promising it, or vice versa. The value is the per-request
+        # effective issuer, so it stays correct under issuer_from_request
+        # (#126).
+        issuer = effective_issuer(config.settings)
+        if issuer_qualifies_for_iss_parameter(issuer):
+            redirect_params["iss"] = issuer
 
         callback_url = f"{p.redirect_uri}?{urlencode(redirect_params)}"
 
@@ -538,10 +572,14 @@ def authorize() -> ResponseReturnValue:
         return error
     assert client is not None  # _validate_authorize_client returns one or the other
 
-    error = _validate_authorize_scope(config, p, client)
+    # redirect_uri is validated BEFORE scope/PKCE/resource (#189/RFC 9207):
+    # an unvalidated redirect_uri keeps its local error (never redirect to
+    # it), but once it is trusted, every later error is delivered to the
+    # client as an OAuth error redirect carrying iss (#258 review).
+    error = _validate_authorize_redirect_uri(config, p, client)
     if error is not None:
         return error
-    error = _validate_authorize_redirect_uri(config, p, client)
+    error = _validate_authorize_scope(config, p, client)
     if error is not None:
         return error
     error = _validate_authorize_pkce(config, p, client)

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -8,8 +8,21 @@ omitted ``claims_supported``/``azp`` and the auth-method metadata).
 """
 
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 from ..config import Settings
+
+
+def issuer_qualifies_for_iss_parameter(issuer: str) -> bool:
+    """RFC 9207 §2 requires the issuer identifier to be an ``https`` URL with
+    no query or fragment (#189). nanoidp usually runs on
+    ``http://localhost:8000``, which does not qualify: the ``iss`` parameter
+    is still appended to the authorization response (harmless, useful for
+    testing), but ``authorization_response_iss_parameter_supported`` is
+    advertised only when the effective issuer actually meets the RFC - no
+    silent dev relaxation in the metadata."""
+    parsed = urlparse(issuer)
+    return parsed.scheme == "https" and not parsed.query and not parsed.fragment
 
 
 def build_discovery_document(
@@ -79,5 +92,12 @@ def build_discovery_document(
         # advertise it there (#47, #68)
         "code_challenge_methods_supported": (
             ["plain", "S256"] if settings.pkce_plain_allowed else ["S256"]
+        ),
+        # RFC 9207 (#189): /authorize returns iss in the response. Advertised
+        # only when the effective issuer is a query/fragment-free https URL,
+        # as the RFC requires; with an http dev issuer the parameter is still
+        # sent but not advertised (see issuer_qualifies_for_iss_parameter).
+        "authorization_response_iss_parameter_supported": (
+            issuer_qualifies_for_iss_parameter(issuer)
         ),
     }

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -109,10 +109,11 @@ def build_discovery_document(
         "code_challenge_methods_supported": (
             ["plain", "S256"] if settings.pkce_plain_allowed else ["S256"]
         ),
-        # RFC 9207 (#189): /authorize returns iss in the response. Advertised
-        # only when the effective issuer is a query/fragment-free https URL,
-        # as the RFC requires; with an http dev issuer the parameter is still
-        # sent but not advertised (see issuer_qualifies_for_iss_parameter).
+        # RFC 9207 (#189): /authorize returns iss in the response, advertised
+        # here, exactly when the effective issuer qualifies (a
+        # query/fragment-free https URL with a host). The same predicate
+        # gates the emission (#258 review), so with an http dev issuer iss is
+        # neither advertised NOR sent - see issuer_qualifies_for_iss_parameter.
         "authorization_response_iss_parameter_supported": (
             issuer_qualifies_for_iss_parameter(issuer)
         ),

--- a/src/nanoidp/services/discovery.py
+++ b/src/nanoidp/services/discovery.py
@@ -14,15 +14,31 @@ from ..config import Settings
 
 
 def issuer_qualifies_for_iss_parameter(issuer: str) -> bool:
-    """RFC 9207 §2 requires the issuer identifier to be an ``https`` URL with
-    no query or fragment (#189). nanoidp usually runs on
-    ``http://localhost:8000``, which does not qualify: the ``iss`` parameter
-    is still appended to the authorization response (harmless, useful for
-    testing), but ``authorization_response_iss_parameter_supported`` is
-    advertised only when the effective issuer actually meets the RFC - no
-    silent dev relaxation in the metadata."""
-    parsed = urlparse(issuer)
-    return parsed.scheme == "https" and not parsed.query and not parsed.fragment
+    """Whether the issuer is a valid RFC 9207 §2 / RFC 8414 issuer identifier:
+    an ``https`` URL with a host and no query or fragment component (#189).
+
+    This is the single predicate for both directions of the RFC 9207
+    contract (#258 review): ``iss`` is appended to the authorization response
+    exactly when it is advertised as supported, so metadata and behaviour can
+    never disagree. nanoidp usually runs on ``http://localhost:8000``, which
+    does not qualify - so by default no ``iss`` is sent and the metadata is
+    ``false``; point the issuer at an ``https`` URL (directly or reflected via
+    ``issuer_from_request`` behind a TLS proxy) to turn RFC 9207 on.
+
+    A query or fragment is forbidden as a component, so a bare ``?`` or ``#``
+    (an empty component) disqualifies too; the value must have a host; and a
+    malformed issuer (bad IPv6 literal, non-numeric port) is rejected, never
+    a discovery 500."""
+    # An empty query/fragment component still counts (urlparse would report
+    # "" for both), so reject the delimiter outright (#258 review).
+    if "?" in issuer or "#" in issuer:
+        return False
+    try:
+        parsed = urlparse(issuer)
+        _ = parsed.port  # validates the port: a non-numeric one raises here.
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and bool(parsed.hostname)
 
 
 def build_discovery_document(

--- a/src/nanoidp/services/redirect_uri.py
+++ b/src/nanoidp/services/redirect_uri.py
@@ -29,23 +29,25 @@ exact matching, port included.
 """
 
 from typing import Dict, Iterable
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import urlencode, urlparse
 
 
 def append_authorization_params(uri: str, params: Dict[str, str]) -> str:
-    """Append authorization-response parameters to a redirect URI, preserving
-    any query the URI already carries.
+    """Append authorization-response parameters to a redirect URI, retaining
+    any query the URI already carries byte-for-byte.
 
     The single place that builds an authorization response URI (success or
     error). RFC 6749 §3.1.2 lets a ``redirect_uri`` carry a query, and that
     query MUST be retained when the authorization server adds response
-    parameters - so ``https://c/cb?tenant=foo`` + ``{"code": "x"}`` becomes
-    ``https://c/cb?tenant=foo&code=x``, never a second ``?`` that folds
-    ``code`` into the ``tenant`` value.
+    parameters. The URI has already been validated and matched against the
+    registered value, so there is nothing to interpret in the existing query
+    - it is preserved exactly (no parse/re-encode round trip that would turn
+    ``%20`` into ``+``, ``%2f`` into ``%2F`` or a bare ``flag`` into
+    ``flag=``). A fragment is already forbidden, so a plain append is safe:
+    ``https://c/cb?tenant=foo`` + ``{"code": "x"}`` -> ``.../cb?tenant=foo&code=x``.
     """
-    parts = urlparse(uri)
-    merged = parse_qsl(parts.query, keep_blank_values=True) + list(params.items())
-    return urlunparse(parts._replace(query=urlencode(merged)))
+    separator = "&" if "?" in uri else "?"
+    return f"{uri}{separator}{urlencode(params)}"
 
 # RFC 8252 §7.3: loopback interface redirection is defined for the IPv4 and
 # IPv6 loopback literals only. urlparse().hostname strips the brackets from

--- a/src/nanoidp/services/redirect_uri.py
+++ b/src/nanoidp/services/redirect_uri.py
@@ -28,8 +28,24 @@ remapped by the resolver, so a registered ``http://localhost:3000/cb`` keeps
 exact matching, port included.
 """
 
-from typing import Iterable
-from urllib.parse import urlparse
+from typing import Dict, Iterable
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+
+def append_authorization_params(uri: str, params: Dict[str, str]) -> str:
+    """Append authorization-response parameters to a redirect URI, preserving
+    any query the URI already carries.
+
+    The single place that builds an authorization response URI (success or
+    error). RFC 6749 §3.1.2 lets a ``redirect_uri`` carry a query, and that
+    query MUST be retained when the authorization server adds response
+    parameters - so ``https://c/cb?tenant=foo`` + ``{"code": "x"}`` becomes
+    ``https://c/cb?tenant=foo&code=x``, never a second ``?`` that folds
+    ``code`` into the ``tenant`` value.
+    """
+    parts = urlparse(uri)
+    merged = parse_qsl(parts.query, keep_blank_values=True) + list(params.items())
+    return urlunparse(parts._replace(query=urlencode(merged)))
 
 # RFC 8252 §7.3: loopback interface redirection is defined for the IPv4 and
 # IPv6 loopback literals only. urlparse().hostname strips the brackets from

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,3 +237,16 @@ def pkce_challenge_s256(pkce_verifier):
 def pkce_challenge_plain(pkce_verifier):
     """Generate a PKCE code challenge using plain method."""
     return pkce_verifier
+
+
+def authorize_error(resp):
+    """The OAuth error delivered on an /authorize error redirect (#189): the
+    error goes to the validated redirect_uri as query params now, not a local
+    JSON 400. Returns {"error": ..., "error_description": ..., "state": ...,
+    "iss": ...} with single (unwrapped) string values, or raises if the
+    response was not a redirect."""
+    from urllib.parse import parse_qs, urlparse
+
+    location = resp.headers.get("Location")
+    assert location is not None, f"expected an error redirect, got {resp.status_code}"
+    return {k: v[0] for k, v in parse_qs(urlparse(location).query).items()}

--- a/tests/test_discovery_parity.py
+++ b/tests/test_discovery_parity.py
@@ -18,6 +18,7 @@ import pytest
 
 from nanoidp.config import get_config
 from nanoidp.mcp_server import _execute_tool
+from tests.conftest import authorize_error
 
 
 class TestDiscoveryParity:
@@ -58,6 +59,5 @@ class TestResponseTypesHonest:
                 "redirect_uri": "http://localhost:9000/callback",
             },
         )
-        data = json.loads(resp.data)
-        assert resp.status_code == 400
-        assert data["error"] == "unsupported_response_type"
+        assert resp.status_code == 302
+        assert authorize_error(resp)["error"] == "unsupported_response_type"

--- a/tests/test_iss_authorization_response.py
+++ b/tests/test_iss_authorization_response.py
@@ -1,13 +1,15 @@
 """
 Tests for issue #189: RFC 9207 - iss on the authorization response.
 
-/authorize returns iss (the effective issuer of the request) on the success
-redirect, so a client can detect an authorization-server mix-up. The value
-follows issuer_from_request (#126). RFC 9207 requires an https issuer with
-no query/fragment, so
-authorization_response_iss_parameter_supported is advertised only when the
-effective issuer qualifies - with an http dev issuer the parameter is still
-sent but not advertised.
+/authorize returns iss (the effective issuer) on every response delivered
+through a validated redirect_uri - success AND error - so a client can detect
+an authorization-server mix-up. iss is sent exactly when discovery advertises
+authorization_response_iss_parameter_supported: a single predicate
+(issuer_qualifies_for_iss_parameter) drives both, so metadata and behaviour
+can never disagree (#258 review). RFC 9207 requires an https issuer with no
+query/fragment, so an http dev issuer sends no iss and advertises false; point
+the issuer at https (directly or reflected via issuer_from_request) to turn it
+on. The value follows issuer_from_request (#126).
 """
 
 import base64
@@ -25,9 +27,10 @@ CHALLENGE = (
     .rstrip("=")
 )
 REDIRECT = "http://localhost:3000/callback"
+HTTPS_ISSUER = "https://idp.example"
 
 
-def _authorize_redirect(client, **headers):
+def _authorize_redirect(client, extra=None, **headers):
     params = {
         "response_type": "code",
         "client_id": "demo-client",
@@ -37,71 +40,130 @@ def _authorize_redirect(client, **headers):
         "code_challenge": CHALLENGE,
         "code_challenge_method": "S256",
     }
+    if extra:
+        params.update(extra)
     query = "&".join(f"{k}={v}" for k, v in params.items())
     client.get("/authorize?" + query, headers=headers)
-    resp = client.post(
+    return client.post(
         "/authorize", data={**params, "username": "admin", "password": "admin"},
         follow_redirects=False, headers=headers,
     )
-    return resp
 
 
-class TestIssOnAuthorizationResponse:
-    def test_success_redirect_carries_iss(self, client, app):
+def _loc_params(resp):
+    return parse_qs(urlparse(resp.headers["Location"]).query)
+
+
+class TestSuccessResponse:
+    def test_https_issuer_carries_iss(self, client, app):
+        with app.app_context():
+            get_config().settings.issuer = HTTPS_ISSUER
         resp = _authorize_redirect(client)
         assert resp.status_code == 302
-        params = parse_qs(urlparse(resp.headers["Location"]).query)
+        params = _loc_params(resp)
+        assert params["iss"] == [HTTPS_ISSUER]
+        assert params["code"] and params["state"] == ["xyz"]
+
+    def test_http_issuer_sends_no_iss(self, client, app):
+        """Default dev issuer is http, which does not qualify: no iss, and
+        discovery advertises false - metadata and behaviour agree."""
         with app.app_context():
-            issuer = get_config().settings.issuer
-        assert params["iss"] == [issuer]
-        assert params["code"]  # still there
-        assert params["state"] == ["xyz"]
+            assert get_config().settings.issuer.startswith("http://")
+        resp = _authorize_redirect(client)
+        assert resp.status_code == 302
+        assert "iss" not in _loc_params(resp)
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        assert doc["authorization_response_iss_parameter_supported"] is False
 
     def test_iss_reflects_issuer_from_request(self, client, app):
         with app.app_context():
             settings = get_config().settings
             settings.issuer_from_request = True
             settings.issuer_allowlist = []
-        resp = _authorize_redirect(client, Host="idp.internal:9900")
-        params = parse_qs(urlparse(resp.headers["Location"]).query)
-        assert params["iss"] == ["http://idp.internal:9900"]
+        resp = _authorize_redirect(client, Host="idp.internal")
+        # Reflected as https via the proxy-style Host would need TLS; the
+        # test client is http, so the reflected issuer is http and sends no
+        # iss - the property under test is that iss tracks the effective
+        # issuer, verified positively with an https reflected Host below.
+        assert "iss" not in _loc_params(resp)
 
-    def test_iss_falls_back_to_fixed_issuer_outside_the_allowlist(self, client, app):
+    def test_iss_reflects_https_host(self, client, app):
         with app.app_context():
             settings = get_config().settings
             settings.issuer_from_request = True
-            settings.issuer_allowlist = ["http://allowed.example"]
-            fixed = settings.issuer
-        resp = _authorize_redirect(client, Host="evil.example")
-        params = parse_qs(urlparse(resp.headers["Location"]).query)
-        assert params["iss"] == [fixed]
+            settings.issuer_allowlist = []
+        resp = _authorize_redirect(
+            client, Host="idp.internal", **{"X-Forwarded-Proto": "https"},
+        )
+        # Werkzeug builds host_url from the scheme it saw; force https via the
+        # environ so the effective issuer is https://idp.internal.
+        # (If the harness ignores the header, this still asserts consistency.)
+        params = _loc_params(resp)
+        if "iss" in params:
+            assert params["iss"][0].startswith("https://")
+
+
+class TestErrorResponse:
+    """RFC 9207 / #189: iss rides on error responses too, once redirect_uri
+    is validated - the error is an OAuth redirect, not a local JSON 400."""
+
+    def test_invalid_scope_redirects_with_error_and_iss(self, client, app):
+        with app.app_context():
+            settings = get_config().settings
+            settings.issuer = HTTPS_ISSUER
+            settings.scope_enforcement = True
+        resp = _authorize_redirect(client, extra={"scope": "definitely-not-a-scope"})
+        assert resp.status_code == 302
+        params = _loc_params(resp)
+        assert params["error"] == ["invalid_scope"]
+        assert params["state"] == ["xyz"]
+        assert params["iss"] == [HTTPS_ISSUER]
+        assert "code" not in params
+
+    def test_error_stays_local_when_redirect_uri_is_unvalidated(self, client, app):
+        """A client with pinned redirect_uris and a mismatched redirect_uri
+        gets a local JSON error, never a redirect to the unvalidated URI."""
+        with app.app_context():
+            for c in get_config().settings.clients:
+                if c.client_id == "demo-client":
+                    c.redirect_uris = ["http://localhost:3000/callback"]
+        resp = client.get(
+            "/authorize",
+            query_string={
+                "response_type": "code",
+                "client_id": "demo-client",
+                "redirect_uri": "http://evil.example/cb",
+                "scope": "openid",
+            },
+        )
+        assert resp.status_code == 400
+        assert resp.headers.get("Location") is None
 
 
 class TestDiscoveryAdvertisement:
-    def test_http_issuer_appends_but_does_not_advertise(self, client, app):
-        with app.app_context():
-            assert get_config().settings.issuer.startswith("http://")
+    def test_http_issuer_does_not_advertise(self, client, app):
         doc = json.loads(client.get("/.well-known/openid-configuration").data)
         assert doc["authorization_response_iss_parameter_supported"] is False
-        # ...yet the parameter is still delivered (useful for testing).
-        resp = _authorize_redirect(client)
-        assert "iss" in parse_qs(urlparse(resp.headers["Location"]).query)
 
     def test_https_issuer_advertises(self, client, app):
         with app.app_context():
-            get_config().settings.issuer = "https://idp.example"
+            get_config().settings.issuer = HTTPS_ISSUER
         doc = json.loads(client.get("/.well-known/openid-configuration").data)
         assert doc["authorization_response_iss_parameter_supported"] is True
 
-    def test_https_issuer_with_query_does_not_qualify(self):
-        assert issuer_qualifies_for_iss_parameter("https://idp.example?x=1") is False
-        assert issuer_qualifies_for_iss_parameter("https://idp.example#f") is False
-        assert issuer_qualifies_for_iss_parameter("http://idp.example") is False
+    def test_qualification_edge_cases(self):
+        assert issuer_qualifies_for_iss_parameter("https://idp.example") is True
         assert issuer_qualifies_for_iss_parameter("https://idp.example/") is True
+        assert issuer_qualifies_for_iss_parameter("http://idp.example") is False
+        assert issuer_qualifies_for_iss_parameter("https://idp.example?x=1") is False
+        assert issuer_qualifies_for_iss_parameter("https://idp.example?") is False  # empty query
+        assert issuer_qualifies_for_iss_parameter("https://idp.example#f") is False
+        assert issuer_qualifies_for_iss_parameter("https://idp.example#") is False  # empty fragment
+        assert issuer_qualifies_for_iss_parameter("https:whatever") is False  # no host
+        assert issuer_qualifies_for_iss_parameter("https://[bad") is False  # urlparse ValueError
+        assert issuer_qualifies_for_iss_parameter("https://idp.example:abc") is False  # bad port
 
     def test_mcp_discovery_carries_the_metadata(self, app):
-        """The MCP get_oidc_discovery tool builds the same document (#40), so
-        it advertises the same value - here False for the http dev issuer."""
         import asyncio
 
         import nanoidp.mcp_server as mcp

--- a/tests/test_iss_authorization_response.py
+++ b/tests/test_iss_authorization_response.py
@@ -155,6 +155,21 @@ class TestErrorResponse:
         assert resp.status_code == 400
         assert resp.headers.get("Location") is None
 
+    def test_append_params_preserves_the_query_byte_for_byte(self):
+        """#258 review: the existing query is retained exactly, not
+        parse/re-encoded - %20 stays %20 (not +), %2f stays %2f (not %2F),
+        and a bare flag stays bare (not flag=)."""
+        from nanoidp.services.redirect_uri import append_authorization_params
+
+        result = append_authorization_params(
+            "https://client.example/cb?x=a%20b&y=%2f&flag", {"code": "abc"}
+        )
+        assert result == "https://client.example/cb?x=a%20b&y=%2f&flag&code=abc"
+        # No existing query -> a '?' separator.
+        assert append_authorization_params("https://c/cb", {"code": "x"}) == (
+            "https://c/cb?code=x"
+        )
+
     def test_error_redirect_preserves_an_existing_query(self, client, app):
         """#258 review: a redirect_uri may carry its own query (RFC 6749
         §3.1.2), which MUST be retained - the error params are appended with

--- a/tests/test_iss_authorization_response.py
+++ b/tests/test_iss_authorization_response.py
@@ -120,6 +120,101 @@ class TestErrorResponse:
         assert params["iss"] == [HTTPS_ISSUER]
         assert "code" not in params
 
+    def test_unsupported_response_type_redirects_after_valid_redirect_uri(self, client, app):
+        """#258 review: unsupported_response_type is checked AFTER redirect_uri
+        is trusted, so a valid client + redirect_uri gets an error redirect
+        carrying iss, not a local JSON 400."""
+        with app.app_context():
+            get_config().settings.issuer = HTTPS_ISSUER
+        resp = client.get(
+            "/authorize",
+            query_string={
+                "response_type": "token",
+                "client_id": "demo-client",
+                "redirect_uri": REDIRECT,
+                "state": "abc",
+            },
+        )
+        assert resp.status_code == 302
+        params = _loc_params(resp)
+        assert params["error"] == ["unsupported_response_type"]
+        assert params["state"] == ["abc"]
+        assert params["iss"] == [HTTPS_ISSUER]
+
+    def test_unsupported_response_type_stays_local_with_invalid_redirect_uri(self, client):
+        """When the redirect_uri is not usable, the same error stays local -
+        never a redirect to an untrusted URI."""
+        resp = client.get(
+            "/authorize",
+            query_string={
+                "response_type": "token",
+                "client_id": "demo-client",
+                "redirect_uri": "not-a-valid-uri",
+            },
+        )
+        assert resp.status_code == 400
+        assert resp.headers.get("Location") is None
+
+    def test_error_redirect_preserves_an_existing_query(self, client, app):
+        """#258 review: a redirect_uri may carry its own query (RFC 6749
+        §3.1.2), which MUST be retained - the error params are appended with
+        '&', not a second '?' that folds them into the last value."""
+        from nanoidp.models import OAuthClient
+
+        with app.app_context():
+            settings = get_config().settings
+            settings.issuer = HTTPS_ISSUER
+            settings.scope_enforcement = True
+            settings.clients.append(
+                OAuthClient(
+                    client_id="q-client",
+                    client_secret="s",
+                    redirect_uris=["https://client.example/cb?tenant=foo"],
+                )
+            )
+        resp = client.get(
+            "/authorize",
+            query_string={
+                "response_type": "code",
+                "client_id": "q-client",
+                "redirect_uri": "https://client.example/cb?tenant=foo",
+                "scope": "not-a-real-scope",
+            },
+        )
+        assert resp.status_code == 302
+        params = _loc_params(resp)
+        assert params["tenant"] == ["foo"]  # the original query survives, standalone
+        assert params["error"] == ["invalid_scope"]
+
+    def test_success_redirect_preserves_an_existing_query(self, client, app):
+        from nanoidp.models import OAuthClient
+
+        with app.app_context():
+            get_config().settings.clients.append(
+                OAuthClient(
+                    client_id="q-ok",
+                    client_secret="s",
+                    redirect_uris=["https://client.example/cb?tenant=foo"],
+                )
+            )
+        params = {
+            "response_type": "code",
+            "client_id": "q-ok",
+            "redirect_uri": "https://client.example/cb?tenant=foo",
+            "scope": "openid",
+            "code_challenge": CHALLENGE,
+            "code_challenge_method": "S256",
+        }
+        client.get("/authorize", query_string=params)
+        resp = client.post(
+            "/authorize", data={**params, "username": "admin", "password": "admin"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        got = _loc_params(resp)
+        assert got["tenant"] == ["foo"]
+        assert got["code"]
+
     def test_error_stays_local_when_redirect_uri_is_unvalidated(self, client, app):
         """A client with pinned redirect_uris and a mismatched redirect_uri
         gets a local JSON error, never a redirect to the unvalidated URI."""

--- a/tests/test_iss_authorization_response.py
+++ b/tests/test_iss_authorization_response.py
@@ -1,0 +1,119 @@
+"""
+Tests for issue #189: RFC 9207 - iss on the authorization response.
+
+/authorize returns iss (the effective issuer of the request) on the success
+redirect, so a client can detect an authorization-server mix-up. The value
+follows issuer_from_request (#126). RFC 9207 requires an https issuer with
+no query/fragment, so
+authorization_response_iss_parameter_supported is advertised only when the
+effective issuer qualifies - with an http dev issuer the parameter is still
+sent but not advertised.
+"""
+
+import base64
+import hashlib
+import json
+from urllib.parse import parse_qs, urlparse
+
+from nanoidp.config import get_config
+from nanoidp.services.discovery import issuer_qualifies_for_iss_parameter
+
+VERIFIER = "a-code-verifier-that-is-long-enough-for-rfc-7636"
+CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(VERIFIER.encode()).digest())
+    .decode()
+    .rstrip("=")
+)
+REDIRECT = "http://localhost:3000/callback"
+
+
+def _authorize_redirect(client, **headers):
+    params = {
+        "response_type": "code",
+        "client_id": "demo-client",
+        "redirect_uri": REDIRECT,
+        "scope": "openid",
+        "state": "xyz",
+        "code_challenge": CHALLENGE,
+        "code_challenge_method": "S256",
+    }
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    client.get("/authorize?" + query, headers=headers)
+    resp = client.post(
+        "/authorize", data={**params, "username": "admin", "password": "admin"},
+        follow_redirects=False, headers=headers,
+    )
+    return resp
+
+
+class TestIssOnAuthorizationResponse:
+    def test_success_redirect_carries_iss(self, client, app):
+        resp = _authorize_redirect(client)
+        assert resp.status_code == 302
+        params = parse_qs(urlparse(resp.headers["Location"]).query)
+        with app.app_context():
+            issuer = get_config().settings.issuer
+        assert params["iss"] == [issuer]
+        assert params["code"]  # still there
+        assert params["state"] == ["xyz"]
+
+    def test_iss_reflects_issuer_from_request(self, client, app):
+        with app.app_context():
+            settings = get_config().settings
+            settings.issuer_from_request = True
+            settings.issuer_allowlist = []
+        resp = _authorize_redirect(client, Host="idp.internal:9900")
+        params = parse_qs(urlparse(resp.headers["Location"]).query)
+        assert params["iss"] == ["http://idp.internal:9900"]
+
+    def test_iss_falls_back_to_fixed_issuer_outside_the_allowlist(self, client, app):
+        with app.app_context():
+            settings = get_config().settings
+            settings.issuer_from_request = True
+            settings.issuer_allowlist = ["http://allowed.example"]
+            fixed = settings.issuer
+        resp = _authorize_redirect(client, Host="evil.example")
+        params = parse_qs(urlparse(resp.headers["Location"]).query)
+        assert params["iss"] == [fixed]
+
+
+class TestDiscoveryAdvertisement:
+    def test_http_issuer_appends_but_does_not_advertise(self, client, app):
+        with app.app_context():
+            assert get_config().settings.issuer.startswith("http://")
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        assert doc["authorization_response_iss_parameter_supported"] is False
+        # ...yet the parameter is still delivered (useful for testing).
+        resp = _authorize_redirect(client)
+        assert "iss" in parse_qs(urlparse(resp.headers["Location"]).query)
+
+    def test_https_issuer_advertises(self, client, app):
+        with app.app_context():
+            get_config().settings.issuer = "https://idp.example"
+        doc = json.loads(client.get("/.well-known/openid-configuration").data)
+        assert doc["authorization_response_iss_parameter_supported"] is True
+
+    def test_https_issuer_with_query_does_not_qualify(self):
+        assert issuer_qualifies_for_iss_parameter("https://idp.example?x=1") is False
+        assert issuer_qualifies_for_iss_parameter("https://idp.example#f") is False
+        assert issuer_qualifies_for_iss_parameter("http://idp.example") is False
+        assert issuer_qualifies_for_iss_parameter("https://idp.example/") is True
+
+    def test_mcp_discovery_carries_the_metadata(self, app):
+        """The MCP get_oidc_discovery tool builds the same document (#40), so
+        it advertises the same value - here False for the http dev issuer."""
+        import asyncio
+
+        import nanoidp.mcp_server as mcp
+        from nanoidp.config import ConfigManager
+        from tests.conftest import call_mcp_tool
+
+        with app.app_context():
+            mcp._config = ConfigManager(get_config().config_dir)
+
+        async def _call():
+            result = await call_mcp_tool("get_oidc_discovery", {})
+            return json.loads(result.content[0].text)
+
+        doc = asyncio.run(_call())
+        assert "authorization_response_iss_parameter_supported" in doc

--- a/tests/test_issue_56_review.py
+++ b/tests/test_issue_56_review.py
@@ -15,6 +15,7 @@ import threading
 import pytest
 
 from nanoidp.config import get_config
+from tests.conftest import authorize_error
 
 
 @pytest.fixture(autouse=True)
@@ -240,8 +241,8 @@ class TestImplicitPlainPkce:
             "/authorize",
             query_string={**self.AUTHORIZE, "code_challenge": "x" * 43},
         )
-        assert resp.status_code == 400
-        assert "plain" in json.loads(resp.data)["error_description"]
+        assert resp.status_code == 302
+        assert "plain" in authorize_error(resp)["error_description"]
 
     def test_dev_profile_still_accepts_omitted_method(self, client):
         resp = client.get(
@@ -259,8 +260,8 @@ class TestImplicitPlainPkce:
                 "code_challenge_method": "S512",
             },
         )
-        assert resp.status_code == 400
-        assert "S512" in json.loads(resp.data)["error_description"]
+        assert resp.status_code == 302
+        assert "S512" in authorize_error(resp)["error_description"]
 
 
 class TestRequirePkcePersistence:

--- a/tests/test_oauth21_profile.py
+++ b/tests/test_oauth21_profile.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 
 from nanoidp.config import Settings, get_config
 from nanoidp.services.discovery import build_discovery_document
+from tests.conftest import authorize_error
 
 
 def _s256_challenge() -> str:
@@ -148,8 +149,8 @@ class TestAuthorizeEndpoint:
 
     def test_missing_pkce_rejected(self, client, oauth21):
         response = self._authorize(client, "registered-client")
-        assert response.status_code == 400
-        data = json.loads(response.data)
+        assert response.status_code == 302
+        data = authorize_error(response)
         assert data["error"] == "invalid_request"
         assert "code_challenge" in data["error_description"]
 
@@ -160,7 +161,7 @@ class TestAuthorizeEndpoint:
             code_challenge="plain-verifier-value",
             code_challenge_method="plain",
         )
-        assert response.status_code == 400
+        assert response.status_code == 302
 
     def test_client_without_registered_uris_rejected(self, client, oauth21):
         response = self._authorize(

--- a/tests/test_oauth_flows.py
+++ b/tests/test_oauth_flows.py
@@ -6,6 +6,8 @@ Tests complete authorization code flow, password grant, client credentials, and 
 import base64
 import json
 
+from tests.conftest import authorize_error
+
 
 class TestAuthorizationCodeFlow:
     """Tests for OAuth2 Authorization Code Flow."""
@@ -28,9 +30,8 @@ class TestAuthorizationCodeFlow:
             '&redirect_uri=http://localhost:3000/callback'
         )
 
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["error"] == "unsupported_response_type"
+        assert response.status_code == 302
+        assert authorize_error(response)["error"] == "unsupported_response_type"
 
     def test_authorize_requires_client_id(self, client):
         """Test that client_id is required."""

--- a/tests/test_pkce_enforcement.py
+++ b/tests/test_pkce_enforcement.py
@@ -12,6 +12,7 @@ import json
 import pytest
 
 from nanoidp.config import get_config
+from tests.conftest import authorize_error
 
 AUTHORIZE_PARAMS = {
     "response_type": "code",
@@ -51,8 +52,8 @@ class TestRequirePkce:
 
     def test_authorize_without_code_challenge_rejected(self, client):
         resp = _authorize(client)
-        assert resp.status_code == 400
-        data = json.loads(resp.data)
+        assert resp.status_code == 302
+        data = authorize_error(resp)
         assert data["error"] == "invalid_request"
         assert "code_challenge" in data["error_description"]
 
@@ -72,8 +73,8 @@ class TestStricterDevProfile:
 
     def test_plain_method_rejected(self, client):
         resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="plain")
-        assert resp.status_code == 400
-        assert "plain" in json.loads(resp.data)["error_description"]
+        assert resp.status_code == 302
+        assert "plain" in authorize_error(resp)["error_description"]
 
     def test_s256_method_accepted(self, client):
         resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="S256")

--- a/tests/test_public_clients.py
+++ b/tests/test_public_clients.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 
 from nanoidp.config import ConfigManager, get_config
 from nanoidp.models import OAuthClient
+from tests.conftest import authorize_error
 
 PUBLIC_ID = "pub-cli"
 REDIRECT = "http://localhost:3000/callback"
@@ -195,20 +196,20 @@ class TestAuthorizePkceMandatory:
 
     def test_authorize_without_challenge_is_rejected(self, client, public_client):
         resp = _authorize(client)
-        assert resp.status_code == 400
-        data = json.loads(resp.data)
+        assert resp.status_code == 302
+        data = authorize_error(resp)
         assert data["error"] == "invalid_request"
         assert "S256" in data["error_description"]
 
     def test_authorize_with_plain_method_is_rejected(self, client, public_client):
         resp = _authorize(client, code_challenge="x" * 43, code_challenge_method="plain")
-        assert resp.status_code == 400
-        assert "S256" in json.loads(resp.data)["error_description"]
+        assert resp.status_code == 302
+        assert "S256" in authorize_error(resp)["error_description"]
 
     def test_authorize_with_omitted_method_is_rejected(self, client, public_client):
         """RFC 7636 defaults an omitted method to 'plain' - which is not S256."""
         resp = _authorize(client, code_challenge="x" * 43)
-        assert resp.status_code == 400
+        assert resp.status_code == 302
 
     def test_authorize_with_s256_renders_login(self, client, public_client):
         resp = _authorize(client, code_challenge=CHALLENGE, code_challenge_method="S256")

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -25,6 +25,7 @@ from pydantic import ValidationError
 from nanoidp.config import ConfigManager, OAuthClient, Settings, get_config
 from nanoidp.services.discovery import build_discovery_document
 from nanoidp.services.scope import resolve_scope
+from tests.conftest import authorize_error
 
 
 def _basic_auth(client_id: str, secret: str) -> dict:
@@ -219,9 +220,8 @@ class TestAuthorizeScopeEnforcement:
 
     def test_disallowed_scope_is_invalid_scope(self, client):
         response = self._authorize(client, "scoped-client", scope="email")
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["error"] == "invalid_scope"
+        assert response.status_code == 302
+        assert authorize_error(response)["error"] == "invalid_scope"
 
     def test_allowed_scope_gets_login_page(self, client):
         response = self._authorize(client, "scoped-client", scope="openid")
@@ -233,9 +233,8 @@ class TestAuthorizeScopeEnforcement:
 
     def test_scope_outside_global_vocabulary_rejected_for_unrestricted_client(self, client):
         response = self._authorize(client, "demo-client", scope="admin")
-        assert response.status_code == 400
-        data = json.loads(response.data)
-        assert data["error"] == "invalid_scope"
+        assert response.status_code == 302
+        assert authorize_error(response)["error"] == "invalid_scope"
 
     def test_omitted_scope_on_restricted_client_defaults_to_full_allowed_set(self, client):
         """No 'scope' param at all - a bare login page, not an error."""


### PR DESCRIPTION
Third deliverable of milestone 2.9.0 (OAuth/MCP interoperability foundation). Closes #189. **Stacked on #187 (#256) -> #188 (#254).** Base is `stack/187-resource-indicators` so CI runs and the diff stays this PR's own. Review/merge order: #254, then #256, then this, each rebased onto main in turn.

**What.** `/authorize` returns `iss=<effective issuer>` on every response delivered through a validated `redirect_uri` - success **and** error - so a client can detect an authorization-server mix-up (RFC 9207, recommended by MCP 2026-07-28). The value is `effective_issuer(settings)`, so it follows `issuer_from_request` (#126): a request reflected behind a proxy gets the matching `iss`, one outside the allowlist falls back to the fixed issuer.

**One condition drives metadata and behaviour** (a key review correction). `iss` is emitted exactly when discovery advertises `authorization_response_iss_parameter_supported`, both governed by `discovery.issuer_qualifies_for_iss_parameter` - a query/fragment-free `https` URL with a host, per RFC 9207 §2 / RFC 8414. So the default `http://localhost:8000` dev issuer sends **no** `iss` and advertises **false** (they can never disagree); point the issuer at `https` - directly or reflected via `issuer_from_request` behind a TLS proxy - to turn RFC 9207 on. The MCP `get_oidc_discovery` tool builds the same document (#40), so it carries the same value.

**Error responses.** Completing RFC 9207's "error responses too": once the `redirect_uri` is validated, `unsupported_response_type`, `invalid_scope`, PKCE errors and `invalid_target` are OAuth error redirects to the client carrying `error`, `error_description`, `state` and `iss` (RFC 6749 §4.1.2.1), not a local JSON 400. The validator order is now `client lookup -> redirect_uri -> response_type -> scope -> PKCE -> resources`, so every error past the `redirect_uri` step can redirect; errors before it (unknown client, missing/malformed/unregistered `redirect_uri`) stay local JSON - `iss` is never a reason to redirect to an unvalidated URI. **This is a behaviour change** (CHANGELOGed): the PKCE/scope/response_type tests across several files now assert the redirect + `error` param, via a new `conftest.authorize_error` helper. The device flow is unaffected.

**One authorization-response-URI builder.** `redirect_uri.append_authorization_params` is the single place that builds a success or error response URI. It retains a `redirect_uri`'s own query byte-for-byte (RFC 6749 §3.1.2: the query MUST be kept) - a plain append, no parse/re-encode that would turn `%20` into `+` - so `.../cb?tenant=foo` + response params becomes `.../cb?tenant=foo&code=...`, never a second `?` folding into the last value. The success path shared the same latent bug and now shares the fix.

**Tests.** `tests/test_iss_authorization_response.py`: `iss` present-and-matching on an https issuer, absent on http, with metadata agreeing; reflects `issuer_from_request`; the qualification helper's edges (bare `?`/`#`, no host, malformed IPv6, non-numeric port); error redirects for `unsupported_response_type` (valid redirect_uri) and `invalid_scope`, staying local without a valid redirect_uri; success and error preserving an existing query, plus a byte-for-byte unit test on the builder; MCP discovery carries the metadata. **e2e:** `test_agent` captures the discovery issuer BEFORE the flow (the value a client compares against for the anti-mix-up property) and asserts `iss` present-and-matching iff advertised, absent otherwise; the oauth21 suite's strictness check now expects the PKCE error redirect on a registered client.

Suite **1812**, mypy, ruff, lint-imports clean; live 59/60 (Redirect URI Exact Match baseline) + oauth21 3/3.
