### PR TITLE
feat: mock protected MCP server as an e2e fixture (RFC 9728) (#191)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,6 +103,41 @@ jobs:
           python examples/test_agent.py --saml-signed --url http://localhost:8002 \
             --sp-key e2e-saml/sp-key.pem --sp-cert e2e-saml/sp-cert.pem
 
+      - name: Prepare MCP-interop config
+        # nanoidp needs the three tool scopes in its vocabulary, and its
+        # issuer must equal the URL it actually runs at, because the mock MCP
+        # server derives the JWKS URL from the issuer (#191).
+        run: |
+          cp -r config e2e-mcp-config
+          python - <<'EOF'
+          import yaml
+          path = "e2e-mcp-config/settings.yaml"
+          doc = yaml.safe_load(open(path))
+          oauth = doc.setdefault("oauth", {})
+          oauth["issuer"] = "http://localhost:8003"
+          oauth["scopes_supported"] = [
+              "openid", "profile", "email", "offline_access",
+              "documents:read", "documents:write", "admin",
+          ]
+          yaml.safe_dump(doc, open(path, "w"), sort_keys=False)
+          EOF
+
+      - name: Start MCP-interop nanoidp and mock MCP server
+        run: |
+          PORT=8003 NANOIDP_CONFIG_DIR=e2e-mcp-config python -m nanoidp > server-mcp.log 2>&1 &
+          python examples/mock_mcp_server.py             --issuer http://localhost:8003             --resource http://localhost:9100/mcp             --port 9100 > mock-mcp.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8003/api/health               && curl -sf http://localhost:9100/.well-known/oauth-protected-resource/mcp               && exit 0
+            sleep 1
+          done
+          echo "MCP-interop servers did not become healthy" >&2
+          cat server-mcp.log mock-mcp.log >&2
+          exit 1
+
+      - name: Run OAuth/MCP interoperability suite
+        run: |
+          python examples/test_agent.py --url http://localhost:8003             --mcp http://localhost:9100/mcp
+
       - name: Server log on failure
         if: failure()
         run: |
@@ -111,6 +146,10 @@ jobs:
           cat server-oauth21.log 2>/dev/null || true
           echo "===== signed-SAML server ====="
           cat server-saml.log 2>/dev/null || true
+          echo "===== MCP-interop nanoidp ====="
+          cat server-mcp.log 2>/dev/null || true
+          echo "===== mock MCP server ====="
+          cat mock-mcp.log 2>/dev/null || true
 
   mcp-e2e:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,14 +53,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `iss`, `aud` == its own resource URL, `exp`, scopes), serves the RFC 9728
   `/.well-known/oauth-protected-resource` document naming nanoidp as its
   authorization server, and answers an unauthenticated call with `401` +
-  `WWW-Authenticate` pointing at that metadata. `examples/test_agent.py`
-  gains an `--mcp` suite that drives the whole loop deterministically as the
-  MCP client (401 -> RFC 9728 discovery -> `/authorize` with PKCE and
-  `resource=` -> `/token` -> `tools/call`): resource-bound token accepted,
-  wrong-audience token rejected, insufficient-scope tool call refused,
-  client_credentials workload, a token revoked at nanoidp still accepted by
-  the JWKS-only server until `exp` (asserted as the documented consequence of
-  self-contained tokens), and a token surviving a key rotation. New guide
+  `WWW-Authenticate` pointing at that metadata. It demonstrates two
+  authorization layers, kept distinct: a resource-level scope floor
+  (`documents:read`), enforced by the SDK's bearer middleware, which returns
+  the conformant MCP/RFC 9728 `403` `WWW-Authenticate: Bearer
+  error="insufficient_scope"` + `resource_metadata` challenge before any tool
+  runs; and an application-level per-tool check inside each tool for the finer
+  `documents:write` / `admin` operations, which surfaces as an in-band MCP
+  tool error. `examples/test_agent.py` gains an `--mcp` suite that drives the
+  whole loop deterministically as the MCP client (401 -> RFC 9728 discovery ->
+  `/authorize` with PKCE and `resource=` -> `/token` -> `tools/call`):
+  delegated login as a PUBLIC client (PKCE, no secret) yielding a
+  resource-bound token accepted for a scoped tool; a wrong-audience token
+  rejected with `401` at the transport (asserted at the HTTP layer); the
+  conformant `403` insufficient-scope challenge; the application-level
+  per-tool refusal; a refresh token that cannot be widened in scope on refresh
+  (RFC 6749 §6); a client_credentials workload; a token revoked at nanoidp
+  still accepted by the JWKS-only server until `exp` (the documented
+  consequence of self-contained tokens); and a pre-rotation token still
+  verifying after a key rotation, with the test asserting nanoidp retains the
+  previous key's `kid` in its published JWKS. Adds the `mcp-public-client`
+  (`token_endpoint_auth_method: none`) to the example config. New guide
   "Testing an MCP client against nanoidp". This is the deliverable that ties
   #186 (scopes), #187 (resource indicators) and #188 (public clients)
   together into a demonstrable OAuth/MCP round trip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only the secret, so every field (present and future) is carried.
 
 ### Added
+- **Mock protected MCP server as an e2e fixture** (#191). `examples/mock_mcp_server.py`
+  is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
+  resource-server mode) with three scope-gated tools (`read_document` /
+  `documents:read`, `delete_document` / `documents:write`, `admin_operation`
+  / `admin`). It validates bearer tokens JWKS-only against nanoidp (signature,
+  `iss`, `aud` == its own resource URL, `exp`, scopes), serves the RFC 9728
+  `/.well-known/oauth-protected-resource` document naming nanoidp as its
+  authorization server, and answers an unauthenticated call with `401` +
+  `WWW-Authenticate` pointing at that metadata. `examples/test_agent.py`
+  gains an `--mcp` suite that drives the whole loop deterministically as the
+  MCP client (401 -> RFC 9728 discovery -> `/authorize` with PKCE and
+  `resource=` -> `/token` -> `tools/call`): resource-bound token accepted,
+  wrong-audience token rejected, insufficient-scope tool call refused,
+  client_credentials workload, a token revoked at nanoidp still accepted by
+  the JWKS-only server until `exp` (asserted as the documented consequence of
+  self-contained tokens), and a token surviving a key rotation. New guide
+  "Testing an MCP client against nanoidp". This is the deliverable that ties
+  #186 (scopes), #187 (resource indicators) and #188 (public clients)
+  together into a demonstrable OAuth/MCP round trip.
 - **RFC 9207: `iss` on the authorization response** (#189). `/authorize`
   returns `iss=<effective issuer>` on every response delivered through a
   validated `redirect_uri` - success and error alike - so a client can

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Running behind a reverse proxy](guides/reverse-proxy.md)
 - [Extending nanoidp: hooks and plugins](guides/extending.md)
 - [MCP with Claude Code](guides/MCP_WORKFLOW.md)
+- [Testing an MCP client against nanoidp](guides/testing-an-mcp-client.md)
 - [Security guide](guides/SECURITY.md)
 
 # Reference

--- a/book/src/guides/testing-an-mcp-client.md
+++ b/book/src/guides/testing-an-mcp-client.md
@@ -35,14 +35,30 @@ resulting audience-bound access token.
 | `delete_document` | `documents:write` |
 | `admin_operation` | `admin` |
 
-A token missing a tool's scope is refused with `insufficient_scope`; a token
-whose `aud` is a different resource is rejected at the transport with `401`.
+Authorization happens in two distinct layers, and the fixture shows both:
+
+- **Resource-level scope floor** (`documents:read`), enforced by the SDK's
+  bearer middleware before any tool runs. A token that lacks it gets the
+  conformant MCP/RFC 9728 challenge: `403` with `WWW-Authenticate: Bearer
+  error="insufficient_scope", ..., resource_metadata="<the RFC 9728 URL>"`.
+  This is the transport-level response an MCP client keys off.
+- **Application-level per-tool check** for the finer `documents:write` /
+  `admin` operations, made inside each tool. A caller past the floor but
+  lacking the elevated scope gets an in-band MCP tool error (`isError`), not
+  an HTTP challenge - a second, application-defined authorization decision.
+
+A token whose `aud` is a different resource is rejected at the transport with
+`401` + `WWW-Authenticate: Bearer` before any tool runs (RFC 8707 audience
+binding).
 
 ## Running it
 
 nanoidp must advertise the three scopes in its vocabulary, and its issuer
 must equal the URL it actually serves (the mock derives the JWKS URL from the
-issuer):
+issuer). The delegated leg logs in as a PUBLIC client (PKCE, no secret): the
+bundled config registers `mcp-public-client` with
+`token_endpoint_auth_method: none` for exactly this, since a real MCP client
+holds no client secret.
 
 ```yaml
 # settings.yaml

--- a/book/src/guides/testing-an-mcp-client.md
+++ b/book/src/guides/testing-an-mcp-client.md
@@ -1,0 +1,90 @@
+# Testing an MCP client against nanoidp
+
+nanoidp is an OAuth 2.1 / OIDC authorization server. To test a real MCP
+client's authorization code against it end to end, you need a protected MCP
+*resource* server for the client to call. The repository ships a fixture for
+exactly this: [`examples/mock_mcp_server.py`](https://github.com/cdelmonte-zg/nanoidp/blob/main/examples/mock_mcp_server.py),
+a minimal MCP Streamable HTTP server that validates bearer tokens against
+nanoidp and exposes three scope-gated tools.
+
+## The loop
+
+```text
+agent host / MCP client
+     |  tools/call without a token
+     v
+mock MCP server  -- 401 + RFC 9728 metadata --> authorization_servers: nanoidp
+     |
+     |  /authorize (PKCE, resource=mcp-server) -> /token -> access token aud=mcp-server
+     v
+tools/call with the bearer -> scope check -> result
+```
+
+The client discovers the authorization server from the `401`'s
+`WWW-Authenticate: Bearer resource_metadata="..."` header, fetches the
+RFC 9728 `/.well-known/oauth-protected-resource` document (which names
+nanoidp in `authorization_servers`), runs the authorization code flow with
+PKCE and `resource=<mcp server URL>` (RFC 8707), and calls the tool with the
+resulting audience-bound access token.
+
+## The tools and their scopes
+
+| Tool | Scope required |
+| --- | --- |
+| `read_document` | `documents:read` |
+| `delete_document` | `documents:write` |
+| `admin_operation` | `admin` |
+
+A token missing a tool's scope is refused with `insufficient_scope`; a token
+whose `aud` is a different resource is rejected at the transport with `401`.
+
+## Running it
+
+nanoidp must advertise the three scopes in its vocabulary, and its issuer
+must equal the URL it actually serves (the mock derives the JWKS URL from the
+issuer):
+
+```yaml
+# settings.yaml
+oauth:
+  issuer: "http://localhost:8003"
+  scopes_supported:
+    - openid
+    - profile
+    - email
+    - offline_access
+    - documents:read
+    - documents:write
+    - admin
+```
+
+```bash
+# nanoidp
+PORT=8003 python -m nanoidp
+
+# the mock resource server
+python examples/mock_mcp_server.py \
+  --issuer http://localhost:8003 \
+  --resource http://localhost:9100/mcp \
+  --port 9100
+
+# drive the whole loop deterministically (no LLM)
+python examples/test_agent.py --url http://localhost:8003 \
+  --mcp http://localhost:9100/mcp
+```
+
+`examples/test_agent.py --mcp` acts as the MCP client itself, through the
+`mcp` SDK, so a failure means PKCE, discovery, `resource`, audience, scope or
+MCP framing is wrong - never that a model chose not to call a tool.
+
+## Validation is JWKS-only
+
+The mock validates each token against nanoidp's JWKS (signature, `iss`,
+`aud`, `exp`, scopes) and never calls `/introspect`. A self-contained JWT
+carries no live revocation state, so **a token revoked at nanoidp stays valid
+at the resource server until it expires** - the e2e asserts this, showing the
+token reported inactive by nanoidp's `/introspect` while the mock still
+accepts it. This is the difference between self-contained and introspected
+tokens; the fixture demonstrates the self-contained side. A token still
+verifies across a nanoidp key rotation, because nanoidp keeps the previous
+keys in its JWKS.

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -45,6 +45,11 @@ oauth:
     allowed_scopes:
     - openid
     - profile
+  - client_id: mcp-public-client
+    token_endpoint_auth_method: none
+    description: 'Public MCP client (PKCE, no secret) for the OAuth/MCP interop suite (issue #191)'
+    redirect_uris:
+    - http://localhost:3000/callback
   issuer_from_request: false
   issuer_from_proxy_headers: false
   # logos_dir: ./static/logos  # optional override; defaults to src/nanoidp/static/logos

--- a/examples/mock_mcp_server.py
+++ b/examples/mock_mcp_server.py
@@ -40,6 +40,7 @@ from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 # One scope per tool (issue #191).
 TOOL_SCOPES = {
@@ -49,10 +50,12 @@ TOOL_SCOPES = {
 }
 
 
-class InsufficientScope(Exception):
-    """Raised by a tool when the bearer token lacks the tool's scope. The MCP
-    client sees it as a tool error naming the missing scope - the resource
-    server equivalent of a 403 insufficient_scope (RFC 6750 §3.1 / MCP)."""
+class InsufficientScope(ToolError):
+    """Raised by a tool when the bearer token lacks the tool's scope. Subclasses
+    the SDK's ToolError so it surfaces as a clean tool error (is_error result
+    the client reliably sees) instead of an UnexpectedToolError with a server
+    traceback - the resource server equivalent of a 403 insufficient_scope
+    (RFC 6750 §3.1 / MCP)."""
 
 
 class MockTokenVerifier(TokenVerifier):

--- a/examples/mock_mcp_server.py
+++ b/examples/mock_mcp_server.py
@@ -14,6 +14,22 @@ exposing three tools, each gated on one scope:
     delete_document  -> documents:write
     admin_operation  -> admin
 
+Two authorization layers, deliberately kept distinct so the e2e can show
+each one:
+
+  * A RESOURCE-level scope floor (``documents:read``), enforced by the SDK's
+    bearer-auth middleware BEFORE any tool runs. A token that lacks it gets a
+    real MCP/RFC 9728 challenge: HTTP 403 with
+    ``WWW-Authenticate: Bearer error="insufficient_scope", ...,
+    resource_metadata="<the RFC 9728 URL>"``. This is the conformant,
+    transport-level insufficient_scope response an MCP client keys off.
+  * An APPLICATION-level per-tool check inside each tool for the finer
+    ``documents:write`` / ``admin`` operations. A caller past the read floor
+    but lacking the elevated scope gets an MCP tool error (``isError``), the
+    in-band way a tool refuses an operation. This is NOT the RFC challenge -
+    it is a second, application-defined authorization decision, and the e2e
+    labels it as such.
+
 Bearer tokens are validated JWKS-only (self-contained JWT): the server
 fetches nanoidp's JWKS once, verifies the RS256 signature, and checks `iss`,
 `aud` (which must equal this server's own resource URL), `exp` and the
@@ -50,12 +66,22 @@ TOOL_SCOPES = {
 }
 
 
+# The resource-level scope floor: the SDK's bearer-auth middleware requires
+# it on every request and, when absent, returns the conformant HTTP 403
+# insufficient_scope challenge (WWW-Authenticate + RFC 9728 resource_metadata)
+# BEFORE a tool runs. The finer per-tool scopes below are checked in-band.
+RESOURCE_SCOPE_FLOOR = "documents:read"
+
+
 class InsufficientScope(ToolError):
-    """Raised by a tool when the bearer token lacks the tool's scope. Subclasses
-    the SDK's ToolError so it surfaces as a clean tool error (is_error result
-    the client reliably sees) instead of an UnexpectedToolError with a server
-    traceback - the resource server equivalent of a 403 insufficient_scope
-    (RFC 6750 §3.1 / MCP)."""
+    """Raised by a tool for the APPLICATION-level per-tool check, when a caller
+    past the resource scope floor still lacks the finer scope an operation
+    needs (documents:write / admin). Subclasses the SDK's ToolError so it
+    surfaces as a clean tool error (an isError result the client reliably sees)
+    rather than an UnexpectedToolError with a server traceback. This is NOT the
+    RFC 9728 insufficient_scope challenge (that is the transport-level 403 the
+    middleware sends for the resource floor) - it is a second, in-band
+    authorization decision the tool makes for itself."""
 
 
 class MockTokenVerifier(TokenVerifier):
@@ -124,7 +150,9 @@ def build_server(issuer: str, resource: str) -> MCPServer:
         auth=AuthSettings(
             issuer_url=issuer,  # type: ignore[arg-type]
             resource_server_url=resource,  # type: ignore[arg-type]
-            required_scopes=[],
+            # Resource-level floor: the SDK 403s any request lacking it with
+            # the conformant insufficient_scope challenge, before a tool runs.
+            required_scopes=[RESOURCE_SCOPE_FLOOR],
         ),
     )
 

--- a/examples/mock_mcp_server.py
+++ b/examples/mock_mcp_server.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Mock protected MCP server: an e2e fixture for issue #191 (RFC 9728).
+
+This is a FIXTURE, not a product. It exists so the OAuth/MCP interoperability
+milestone can be demonstrated end to end: the 401 -> protected-resource
+metadata -> /authorize (PKCE, resource=) -> /token -> tools/call round trip,
+plus the "wrong audience" and "insufficient scope" rejections a real MCP
+resource server performs.
+
+It is an MCP Streamable HTTP server (the `mcp` SDK's resource-server mode)
+exposing three tools, each gated on one scope:
+
+    read_document    -> documents:read
+    delete_document  -> documents:write
+    admin_operation  -> admin
+
+Bearer tokens are validated JWKS-only (self-contained JWT): the server
+fetches nanoidp's JWKS once, verifies the RS256 signature, and checks `iss`,
+`aud` (which must equal this server's own resource URL), `exp` and the
+requested tool's scope. It never calls nanoidp's /introspect. A DELIBERATE
+consequence: a token revoked at nanoidp stays valid HERE until it expires,
+because a self-contained JWT carries no live revocation state. Revocation is
+demonstrated in the e2e through /introspect against nanoidp, not against this
+server - that is the difference between self-contained and introspected
+tokens, and this fixture only shows the self-contained side.
+
+Run:
+    python examples/mock_mcp_server.py \
+        --issuer http://localhost:8000 \
+        --resource http://localhost:9100/mcp \
+        --host 127.0.0.1 --port 9100
+"""
+
+import argparse
+import os
+
+import jwt
+from jwt import PyJWKClient
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.mcpserver import MCPServer
+
+# One scope per tool (issue #191).
+TOOL_SCOPES = {
+    "read_document": "documents:read",
+    "delete_document": "documents:write",
+    "admin_operation": "admin",
+}
+
+
+class InsufficientScope(Exception):
+    """Raised by a tool when the bearer token lacks the tool's scope. The MCP
+    client sees it as a tool error naming the missing scope - the resource
+    server equivalent of a 403 insufficient_scope (RFC 6750 §3.1 / MCP)."""
+
+
+class MockTokenVerifier(TokenVerifier):
+    """Validate a bearer JWT against nanoidp's JWKS (issue #191).
+
+    JWKS-only: signature (RS256), issuer, audience == this resource, and
+    expiry. The requested resource's tokens carry ``aud`` = the resource URL
+    (RFC 8707, #187), so a token minted for a different resource - or an
+    ordinary token with ``aud`` = the global oauth.audience - fails the
+    audience check and is rejected here. Scopes come from the space-separated
+    ``scope`` claim. Any failure returns None, which the SDK turns into a 401
+    carrying the RFC 9728 metadata URL.
+    """
+
+    def __init__(self, issuer: str, resource: str) -> None:
+        self.issuer = issuer.rstrip("/")
+        self.resource = resource
+        # PyJWKClient caches keys and refetches on an unknown kid, so a token
+        # signed by a rotated key still validates as long as nanoidp keeps the
+        # previous keys in its JWKS (it does) - which the e2e asserts.
+        self._jwks = PyJWKClient(f"{self.issuer}/.well-known/jwks.json")
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            signing_key = self._jwks.get_signing_key_from_jwt(token)
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                audience=self.resource,
+                issuer=self.issuer,
+                options={"require": ["exp", "iss", "aud"]},
+            )
+        except Exception:
+            return None
+        scopes = (claims.get("scope") or "").split()
+        return AccessToken(
+            token=token,
+            client_id=claims.get("client_id", claims.get("sub", "")),
+            scopes=scopes,
+            expires_at=claims.get("exp"),
+            resource=self.resource,
+            subject=claims.get("sub"),
+            claims=claims,
+        )
+
+
+def _require_scope(tool: str) -> AccessToken:
+    """The bearer token for the current request, asserting the tool's scope."""
+    token = get_access_token()
+    if token is None:  # pragma: no cover - the SDK 401s before a tool runs
+        raise InsufficientScope("no access token on the request")
+    required = TOOL_SCOPES[tool]
+    if required not in token.scopes:
+        raise InsufficientScope(
+            f"insufficient_scope: '{tool}' requires the '{required}' scope; "
+            f"the token has [{', '.join(token.scopes) or 'none'}]"
+        )
+    return token
+
+
+def build_server(issuer: str, resource: str) -> MCPServer:
+    server: MCPServer = MCPServer(
+        name="mock-mcp-server",
+        token_verifier=MockTokenVerifier(issuer, resource),
+        auth=AuthSettings(
+            issuer_url=issuer,  # type: ignore[arg-type]
+            resource_server_url=resource,  # type: ignore[arg-type]
+            required_scopes=[],
+        ),
+    )
+
+    @server.tool()
+    def read_document(document_id: str) -> str:
+        """Read a document (requires the documents:read scope)."""
+        _require_scope("read_document")
+        return f"contents of document {document_id!r}"
+
+    @server.tool()
+    def delete_document(document_id: str) -> str:
+        """Delete a document (requires the documents:write scope)."""
+        _require_scope("delete_document")
+        return f"deleted document {document_id!r}"
+
+    @server.tool()
+    def admin_operation(action: str) -> str:
+        """Perform an admin operation (requires the admin scope)."""
+        token = _require_scope("admin_operation")
+        return f"admin action {action!r} performed by {token.subject!r}"
+
+    return server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--issuer",
+        default=os.environ.get("MOCK_MCP_ISSUER", "http://localhost:8000"),
+        help="nanoidp issuer base URL (default: http://localhost:8000)",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9100)
+    parser.add_argument(
+        "--resource",
+        default=os.environ.get("MOCK_MCP_RESOURCE"),
+        help="this server's own resource URL, the token audience it accepts "
+        "(default: http://<host>:<port>/mcp)",
+    )
+    args = parser.parse_args()
+    resource = args.resource or f"http://{args.host}:{args.port}/mcp"
+
+    server = build_server(args.issuer, resource)
+    print(f"mock MCP server: resource={resource} issuer={args.issuer}")
+    import asyncio
+
+    asyncio.run(
+        server.run_streamable_http_async(
+            host=args.host, port=args.port, stateless_http=True
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -4533,10 +4533,18 @@ class NanoIDPTestAgent:
                         text = result.content[0].text if result.content else ""
                         return ("tool_error" if result.is_error else "ok"), text
 
-        try:
-            return asyncio.run(run())
-        except Exception as e:  # transport-level rejection (401 wrong aud/token)
-            return "unauthorized", type(e).__name__
+        # A transport error (a 401 on a bad token, or a transient connect/read
+        # under CI load with several servers on one runner) raises out of the
+        # async client. Retry once for the transient case; keep the exception
+        # text as the detail so a genuine failure is diagnosable in the log
+        # rather than an opaque "unauthorized".
+        last_exc = ""
+        for _attempt in range(2):
+            try:
+                return asyncio.run(run())
+            except Exception as e:
+                last_exc = f"{type(e).__name__}: {e}"
+        return "unauthorized", last_exc
 
     def _mcp_test_rfc9728_discovery(self, mcp_url: str) -> None:
         """Unauthenticated tools/call -> 401 with WWW-Authenticate naming the
@@ -4624,7 +4632,7 @@ class NanoIDPTestAgent:
             self._add_result(
                 "MCP Insufficient Scope Rejected", TestCategory.MCP, success,
                 "delete_document (documents:write) refused to a documents:read "
-                "token with insufficient_scope", {"outcome": outcome},
+                "token with insufficient_scope", {"outcome": outcome, "detail": detail},
             )
         except Exception as e:
             self._add_result("MCP Insufficient Scope Rejected", TestCategory.MCP, False, f"Error: {e}")

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -4452,10 +4452,18 @@ class NanoIDPTestAgent:
 
     # ==================== MCP resource-server suite (issue #191) ====================
 
-    def _mcp_pkce_resource_token(self, resource: str, scope: str) -> Optional[str]:
-        """Delegated user login through the full PKCE + resource flow, returning
-        an access token whose aud is `resource` (RFC 8707). Mirrors what an MCP
-        client does after reading the RFC 9728 metadata."""
+    # A real MCP client is a PUBLIC OAuth client: it authenticates the user
+    # through PKCE and holds no client secret (issue #191, finding on #260).
+    # The e2e config registers mcp-public-client with
+    # token_endpoint_auth_method 'none'.
+    MCP_PUBLIC_CLIENT = "mcp-public-client"
+
+    def _mcp_pkce_token_response(self, resource: str, scope: str) -> Optional[dict]:
+        """Delegated user login through the full PKCE + resource flow as a
+        PUBLIC client (no client secret, client_id in the token body). Mirrors
+        what an MCP client does after reading the RFC 9728 metadata. Returns
+        the raw /token JSON (access_token, and refresh_token when offline_access
+        was requested), or None if any step fails."""
         verifier = secrets.token_urlsafe(32)
         challenge = base64.urlsafe_b64encode(
             hashlib.sha256(verifier.encode()).digest()
@@ -4463,7 +4471,7 @@ class NanoIDPTestAgent:
         redirect_uri = "http://localhost:3000/callback"
         params = {
             "response_type": "code",
-            "client_id": self.client_id,
+            "client_id": self.MCP_PUBLIC_CLIENT,
             "redirect_uri": redirect_uri,
             "scope": scope,
             "state": secrets.token_urlsafe(16),
@@ -4483,6 +4491,7 @@ class NanoIDPTestAgent:
         code = parse_qs(urlparse(resp.headers.get("Location", "")).query).get("code", [None])[0]
         if not code:
             return None
+        # Public client: no HTTP Basic, client_id travels in the body.
         token_resp = sess.post(
             f"{self.base_url}/token",
             data={
@@ -4491,13 +4500,19 @@ class NanoIDPTestAgent:
                 "redirect_uri": redirect_uri,
                 "code_verifier": verifier,
                 "resource": resource,
+                "client_id": self.MCP_PUBLIC_CLIENT,
             },
-            auth=(self.client_id, self.client_secret),
             timeout=5,
         )
         if token_resp.status_code != 200:
             return None
-        return token_resp.json().get("access_token")
+        return token_resp.json()
+
+    def _mcp_pkce_resource_token(self, resource: str, scope: str) -> Optional[str]:
+        """The access token from a delegated public-client PKCE flow (aud =
+        `resource`, RFC 8707)."""
+        body = self._mcp_pkce_token_response(resource, scope)
+        return body.get("access_token") if body else None
 
     def _mcp_cc_resource_token(self, resource: str, scope: str) -> Optional[str]:
         """A client_credentials workload token bound to `resource`."""
@@ -4609,33 +4624,128 @@ class NanoIDPTestAgent:
             self._add_result("MCP Client Credentials Workload", TestCategory.MCP, False, f"Error: {e}")
 
     def _mcp_test_wrong_audience(self, mcp_url: str) -> None:
-        """A token minted for a DIFFERENT resource is rejected (aud mismatch)."""
+        """A token minted for a DIFFERENT resource is rejected at the transport
+        with a 401 (aud mismatch, RFC 8707). Asserted at the HTTP layer so a
+        vacuous pass (no token, or a swallowed exception read as
+        "unauthorized") cannot hide a real regression."""
         try:
             other = "http://localhost:9999/other-mcp"
             token = self._mcp_cc_resource_token(other, "documents:read")
-            outcome, detail = self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d1"})
-            success = outcome == "unauthorized"
+            # The token MUST have been issued for the wrong-audience check to
+            # mean anything; a None token would 401 for the wrong reason.
+            assert token is not None, "could not mint a token for the other resource"
+            resp = requests.post(
+                mcp_url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                timeout=5,
+            )
+            www = resp.headers.get("WWW-Authenticate", "")
+            success = resp.status_code == 401 and "Bearer" in www
             self._add_result(
                 "MCP Wrong Audience Rejected", TestCategory.MCP, success,
-                "a token whose aud is another resource is rejected by this MCP "
-                "server (RFC 8707 audience binding)", {"outcome": outcome, "detail": detail},
+                "a token whose aud is another resource is rejected with 401 + "
+                "WWW-Authenticate: Bearer (RFC 8707 audience binding)",
+                {"status": resp.status_code, "www_authenticate": www},
             )
         except Exception as e:
             self._add_result("MCP Wrong Audience Rejected", TestCategory.MCP, False, f"Error: {e}")
 
-    def _mcp_test_insufficient_scope(self, mcp_url: str) -> None:
-        """A token with documents:read only is refused delete_document."""
+    def _mcp_test_insufficient_scope_challenge(self, mcp_url: str) -> None:
+        """A token lacking the resource scope floor gets the CONFORMANT MCP
+        insufficient_scope challenge: HTTP 403 with WWW-Authenticate: Bearer
+        error="insufficient_scope" and the RFC 9728 resource_metadata pointer
+        (MCP 2026-07-28). Asserted at the HTTP layer - this is the transport
+        response an MCP client keys off, not an in-band tool error."""
+        try:
+            # aud = this resource (passes the audience check) but scope lacks
+            # documents:read (the resource floor) -> the SDK 403s before a tool.
+            token = self._mcp_cc_resource_token(mcp_url, "documents:write")
+            assert token is not None, "could not mint a documents:write-only token"
+            resp = requests.post(
+                mcp_url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                timeout=5,
+            )
+            www = resp.headers.get("WWW-Authenticate", "")
+            success = (
+                resp.status_code == 403
+                and 'error="insufficient_scope"' in www
+                and "resource_metadata=" in www
+            )
+            self._add_result(
+                "MCP Insufficient Scope Challenge (403)", TestCategory.MCP, success,
+                "a token lacking the resource scope floor gets a conformant 403 "
+                'WWW-Authenticate: Bearer error="insufficient_scope" + '
+                "resource_metadata (RFC 9728 / MCP 2026-07-28)",
+                {"status": resp.status_code, "www_authenticate": www},
+            )
+        except Exception as e:
+            self._add_result(
+                "MCP Insufficient Scope Challenge (403)", TestCategory.MCP, False, f"Error: {e}"
+            )
+
+    def _mcp_test_per_tool_scope(self, mcp_url: str) -> None:
+        """The APPLICATION-level layer: a caller past the resource floor
+        (documents:read) but lacking a tool's elevated scope (delete_document
+        needs documents:write) is refused in-band with an MCP tool error. This
+        is a second, application-defined authorization decision, distinct from
+        the transport-level 403 challenge above."""
         try:
             token = self._mcp_cc_resource_token(mcp_url, "documents:read")
             outcome, detail = self._mcp_call_tool(mcp_url, token, "delete_document", {"document_id": "d1"})
             success = outcome == "tool_error" and "insufficient_scope" in detail
             self._add_result(
-                "MCP Insufficient Scope Rejected", TestCategory.MCP, success,
+                "MCP Per-Tool Scope (application-level)", TestCategory.MCP, success,
                 "delete_document (documents:write) refused to a documents:read "
-                "token with insufficient_scope", {"outcome": outcome, "detail": detail},
+                "token with an in-band tool error", {"outcome": outcome, "detail": detail},
             )
         except Exception as e:
-            self._add_result("MCP Insufficient Scope Rejected", TestCategory.MCP, False, f"Error: {e}")
+            self._add_result("MCP Per-Tool Scope (application-level)", TestCategory.MCP, False, f"Error: {e}")
+
+    def _mcp_test_refresh_scope_escalation(self, mcp_url: str) -> None:
+        """A public MCP client cannot widen scope on refresh: a refresh token
+        issued for documents:read, replayed asking for documents:write, is
+        refused (RFC 6749 §6 - refresh must not grant additional scope)."""
+        try:
+            body = self._mcp_pkce_token_response(mcp_url, "offline_access documents:read")
+            assert body is not None, "delegated PKCE flow returned no token"
+            refresh_token = body.get("refresh_token")
+            assert refresh_token, "no refresh_token issued (offline_access)"
+            resp = requests.post(
+                f"{self.base_url}/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "scope": "documents:read documents:write",
+                    "resource": mcp_url,
+                    "client_id": self.MCP_PUBLIC_CLIENT,
+                },
+                timeout=5,
+            )
+            # Either the request is rejected (invalid_scope), or the token is
+            # issued but NOT widened - documents:write must never appear.
+            granted = resp.json().get("scope", "") if resp.status_code == 200 else ""
+            success = resp.status_code == 400 or "documents:write" not in granted.split()
+            self._add_result(
+                "MCP Refresh Scope Escalation Rejected", TestCategory.MCP, success,
+                "a refresh token for documents:read cannot be widened to "
+                "documents:write on refresh (RFC 6749 §6)",
+                {"status": resp.status_code, "granted_scope": granted},
+            )
+        except Exception as e:
+            self._add_result(
+                "MCP Refresh Scope Escalation Rejected", TestCategory.MCP, False, f"Error: {e}"
+            )
 
     def _mcp_test_revoked_still_valid_until_exp(self, mcp_url: str) -> None:
         """A token revoked at nanoidp is reported inactive by /introspect but
@@ -4660,18 +4770,42 @@ class NanoIDPTestAgent:
                 "MCP Revoked Token Still Valid At Resource", TestCategory.MCP, False, f"Error: {e}"
             )
 
+    @staticmethod
+    def _jwt_kid(token: str) -> Optional[str]:
+        """The `kid` from a JWT header, without verifying the token."""
+        try:
+            header_b64 = token.split(".")[0]
+            header_b64 += "=" * (-len(header_b64) % 4)
+            return json.loads(base64.urlsafe_b64decode(header_b64)).get("kid")
+        except Exception:
+            return None
+
     def _mcp_test_key_rotation(self, mcp_url: str) -> None:
-        """A token minted before a key rotation stays valid: nanoidp keeps the
-        previous keys in its JWKS, so the MCP server can still verify it."""
+        """A token minted before a key rotation stays valid because nanoidp
+        RETAINS the previous key in its published JWKS. Asserted at the source:
+        the pre-rotation token's kid must still appear in nanoidp's
+        /.well-known/jwks.json after the rotation (not merely be served from the
+        MCP server's PyJWKClient cache), AND the token must still verify."""
         try:
             token = self._mcp_cc_resource_token(mcp_url, "documents:read")
+            assert token is not None, "could not mint a pre-rotation token"
+            old_kid = self._jwt_kid(token)
+            assert old_kid, "pre-rotation token carries no kid"
             rotate = self.session.post(f"{self.base_url}/api/keys/rotate", timeout=5)
+            jwks = requests.get(f"{self.base_url}/.well-known/jwks.json", timeout=5).json()
+            published_kids = {k.get("kid") for k in jwks.get("keys", [])}
+            old_kid_retained = old_kid in published_kids
             outcome, _ = self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d1"})
-            success = rotate.status_code == 200 and outcome == "ok"
+            success = rotate.status_code == 200 and old_kid_retained and outcome == "ok"
             self._add_result(
                 "MCP Token Survives Key Rotation", TestCategory.MCP, success,
-                "a pre-rotation token still verifies at the MCP server "
-                "(previous keys retained in the JWKS)", {"mcp_outcome": outcome},
+                "after rotation the pre-rotation kid is still in nanoidp's "
+                "published JWKS and the token still verifies at the MCP server",
+                {
+                    "rotate_status": rotate.status_code,
+                    "old_kid_retained": old_kid_retained,
+                    "mcp_outcome": outcome,
+                },
             )
         except Exception as e:
             self._add_result("MCP Token Survives Key Rotation", TestCategory.MCP, False, f"Error: {e}")
@@ -4691,7 +4825,9 @@ class NanoIDPTestAgent:
         self._mcp_test_delegated_pkce(mcp_url)
         self._mcp_test_client_credentials(mcp_url)
         self._mcp_test_wrong_audience(mcp_url)
-        self._mcp_test_insufficient_scope(mcp_url)
+        self._mcp_test_insufficient_scope_challenge(mcp_url)
+        self._mcp_test_per_tool_scope(mcp_url)
+        self._mcp_test_refresh_scope_escalation(mcp_url)
         self._mcp_test_revoked_still_valid_until_exp(mcp_url)
         self._mcp_test_key_rotation(mcp_url)
         print("\n" + "-" * 70)

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -82,6 +82,7 @@ class TestCategory(Enum):
     KEYS = "Key Management"
     API = "REST API"
     MANAGEMENT = "Management Secret"
+    MCP = "MCP"
 
 
 @dataclass
@@ -4449,6 +4450,247 @@ class NanoIDPTestAgent:
         )
         return ok_all
 
+    # ==================== MCP resource-server suite (issue #191) ====================
+
+    def _mcp_pkce_resource_token(self, resource: str, scope: str) -> Optional[str]:
+        """Delegated user login through the full PKCE + resource flow, returning
+        an access token whose aud is `resource` (RFC 8707). Mirrors what an MCP
+        client does after reading the RFC 9728 metadata."""
+        verifier = secrets.token_urlsafe(32)
+        challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode()).digest()
+        ).decode().rstrip("=")
+        redirect_uri = "http://localhost:3000/callback"
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "state": secrets.token_urlsafe(16),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "resource": resource,
+        }
+        sess = requests.Session()
+        sess.get(f"{self.base_url}/authorize", params=params, allow_redirects=False, timeout=5)
+        resp = sess.post(
+            f"{self.base_url}/authorize",
+            data={**params, "username": self.username, "password": self.password},
+            allow_redirects=False, timeout=5,
+        )
+        if resp.status_code != 302:
+            return None
+        code = parse_qs(urlparse(resp.headers.get("Location", "")).query).get("code", [None])[0]
+        if not code:
+            return None
+        token_resp = sess.post(
+            f"{self.base_url}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "code_verifier": verifier,
+                "resource": resource,
+            },
+            auth=(self.client_id, self.client_secret),
+            timeout=5,
+        )
+        if token_resp.status_code != 200:
+            return None
+        return token_resp.json().get("access_token")
+
+    def _mcp_cc_resource_token(self, resource: str, scope: str) -> Optional[str]:
+        """A client_credentials workload token bound to `resource`."""
+        resp = self.session.post(
+            f"{self.base_url}/token",
+            data={"grant_type": "client_credentials", "resource": resource, "scope": scope},
+            timeout=5,
+        )
+        if resp.status_code != 200:
+            return None
+        return resp.json().get("access_token")
+
+    def _mcp_call_tool(self, mcp_url, token, tool, args):
+        """Drive one tools/call over Streamable HTTP as an MCP client.
+
+        Returns (outcome, detail): outcome is "ok" (tool ran),
+        "tool_error" (tool ran but returned isError, e.g. insufficient_scope),
+        or "unauthorized" (the transport rejected the token, e.g. wrong
+        audience -> 401). detail is the text / exception type."""
+        import asyncio
+
+        from mcp import ClientSession
+        from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
+
+        async def run():
+            headers = {"Authorization": f"Bearer {token}"} if token else {}
+            hc = create_mcp_http_client(headers=headers)
+            async with hc:
+                async with streamable_http_client(url=mcp_url, http_client=hc) as (read, write, *_):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        result = await session.call_tool(tool, args)
+                        text = result.content[0].text if result.content else ""
+                        return ("tool_error" if result.is_error else "ok"), text
+
+        try:
+            return asyncio.run(run())
+        except Exception as e:  # transport-level rejection (401 wrong aud/token)
+            return "unauthorized", type(e).__name__
+
+    def _mcp_test_rfc9728_discovery(self, mcp_url: str) -> None:
+        """Unauthenticated tools/call -> 401 with WWW-Authenticate naming the
+        RFC 9728 metadata, whose authorization_servers points at nanoidp."""
+        try:
+            resp = requests.post(
+                mcp_url,
+                headers={"Content-Type": "application/json",
+                         "Accept": "application/json, text/event-stream"},
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                timeout=5,
+            )
+            www = resp.headers.get("WWW-Authenticate", "")
+            match = re.search(r'resource_metadata="([^"]+)"', www)
+            metadata = requests.get(match.group(1), timeout=5).json() if match else {}
+            auth_servers = metadata.get("authorization_servers", [])
+            success = (
+                resp.status_code == 401
+                and "Bearer" in www
+                and self.base_url in [s.rstrip("/") for s in auth_servers]
+            )
+            self._add_result(
+                "MCP RFC 9728 Discovery", TestCategory.MCP, success,
+                "unauthenticated tools/call -> 401 + protected-resource metadata "
+                "naming nanoidp as the authorization server",
+                {"status": resp.status_code, "authorization_servers": auth_servers},
+            )
+        except Exception as e:
+            self._add_result("MCP RFC 9728 Discovery", TestCategory.MCP, False, f"Error: {e}")
+
+    def _mcp_test_delegated_pkce(self, mcp_url: str) -> None:
+        try:
+            token = self._mcp_pkce_resource_token(mcp_url, "openid documents:read")
+            outcome, detail = (
+                self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d1"})
+                if token else ("no_token", "PKCE flow returned no token")
+            )
+            success = outcome == "ok" and "d1" in detail
+            self._add_result(
+                "MCP Delegated PKCE Flow", TestCategory.MCP, success,
+                "delegated user login (PKCE, resource=) -> resource-bound token "
+                "accepted by the MCP server for a scoped tool",
+                {"outcome": outcome},
+            )
+        except Exception as e:
+            self._add_result("MCP Delegated PKCE Flow", TestCategory.MCP, False, f"Error: {e}")
+
+    def _mcp_test_client_credentials(self, mcp_url: str) -> None:
+        try:
+            token = self._mcp_cc_resource_token(mcp_url, "documents:read")
+            outcome, detail = (
+                self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d2"})
+                if token else ("no_token", "no cc token")
+            )
+            success = outcome == "ok"
+            self._add_result(
+                "MCP Client Credentials Workload", TestCategory.MCP, success,
+                "a client_credentials workload token bound to the resource is "
+                "accepted by the MCP server", {"outcome": outcome},
+            )
+        except Exception as e:
+            self._add_result("MCP Client Credentials Workload", TestCategory.MCP, False, f"Error: {e}")
+
+    def _mcp_test_wrong_audience(self, mcp_url: str) -> None:
+        """A token minted for a DIFFERENT resource is rejected (aud mismatch)."""
+        try:
+            other = "http://localhost:9999/other-mcp"
+            token = self._mcp_cc_resource_token(other, "documents:read")
+            outcome, detail = self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d1"})
+            success = outcome == "unauthorized"
+            self._add_result(
+                "MCP Wrong Audience Rejected", TestCategory.MCP, success,
+                "a token whose aud is another resource is rejected by this MCP "
+                "server (RFC 8707 audience binding)", {"outcome": outcome, "detail": detail},
+            )
+        except Exception as e:
+            self._add_result("MCP Wrong Audience Rejected", TestCategory.MCP, False, f"Error: {e}")
+
+    def _mcp_test_insufficient_scope(self, mcp_url: str) -> None:
+        """A token with documents:read only is refused delete_document."""
+        try:
+            token = self._mcp_cc_resource_token(mcp_url, "documents:read")
+            outcome, detail = self._mcp_call_tool(mcp_url, token, "delete_document", {"document_id": "d1"})
+            success = outcome == "tool_error" and "insufficient_scope" in detail
+            self._add_result(
+                "MCP Insufficient Scope Rejected", TestCategory.MCP, success,
+                "delete_document (documents:write) refused to a documents:read "
+                "token with insufficient_scope", {"outcome": outcome},
+            )
+        except Exception as e:
+            self._add_result("MCP Insufficient Scope Rejected", TestCategory.MCP, False, f"Error: {e}")
+
+    def _mcp_test_revoked_still_valid_until_exp(self, mcp_url: str) -> None:
+        """A token revoked at nanoidp is reported inactive by /introspect but
+        STILL accepted by the JWKS-validating MCP server until exp - the
+        documented consequence of self-contained tokens (#191)."""
+        try:
+            token = self._mcp_cc_resource_token(mcp_url, "documents:read")
+            self.session.post(f"{self.base_url}/revoke", data={"token": token}, timeout=5)
+            introspect = self.session.post(
+                f"{self.base_url}/introspect", data={"token": token}, timeout=5
+            ).json()
+            outcome, _ = self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d1"})
+            success = introspect.get("active") is False and outcome == "ok"
+            self._add_result(
+                "MCP Revoked Token Still Valid At Resource", TestCategory.MCP, success,
+                "revoked at nanoidp -> /introspect inactive, but the "
+                "JWKS-only MCP server still accepts it until exp (documented)",
+                {"introspect_active": introspect.get("active"), "mcp_outcome": outcome},
+            )
+        except Exception as e:
+            self._add_result(
+                "MCP Revoked Token Still Valid At Resource", TestCategory.MCP, False, f"Error: {e}"
+            )
+
+    def _mcp_test_key_rotation(self, mcp_url: str) -> None:
+        """A token minted before a key rotation stays valid: nanoidp keeps the
+        previous keys in its JWKS, so the MCP server can still verify it."""
+        try:
+            token = self._mcp_cc_resource_token(mcp_url, "documents:read")
+            rotate = self.session.post(f"{self.base_url}/api/keys/rotate", timeout=5)
+            outcome, _ = self._mcp_call_tool(mcp_url, token, "read_document", {"document_id": "d1"})
+            success = rotate.status_code == 200 and outcome == "ok"
+            self._add_result(
+                "MCP Token Survives Key Rotation", TestCategory.MCP, success,
+                "a pre-rotation token still verifies at the MCP server "
+                "(previous keys retained in the JWKS)", {"mcp_outcome": outcome},
+            )
+        except Exception as e:
+            self._add_result("MCP Token Survives Key Rotation", TestCategory.MCP, False, f"Error: {e}")
+
+    def run_mcp_tests(self, mcp_url: str) -> bool:
+        """Dedicated suite for the OAuth/MCP interoperability loop (#191).
+
+        Requires a running nanoidp (whose oauth.scopes_supported includes
+        documents:read, documents:write, admin) AND the mock MCP server
+        (examples/mock_mcp_server.py) reachable at `mcp_url`."""
+        print("\n" + "=" * 70)
+        print("  NanoIDP OAuth/MCP Interoperability Suite (#191)")
+        print("=" * 70)
+        print(f"\n  nanoidp:    {self.base_url}")
+        print(f"  MCP server: {mcp_url}")
+        self._mcp_test_rfc9728_discovery(mcp_url)
+        self._mcp_test_delegated_pkce(mcp_url)
+        self._mcp_test_client_credentials(mcp_url)
+        self._mcp_test_wrong_audience(mcp_url)
+        self._mcp_test_insufficient_scope(mcp_url)
+        self._mcp_test_revoked_still_valid_until_exp(mcp_url)
+        self._mcp_test_key_rotation(mcp_url)
+        print("\n" + "-" * 70)
+        ok = self.suite.failed == 0
+        print(f"  MCP suite: {self.suite.passed}/{self.suite.total} passed" + ("" if ok else "  [FAILED]"))
+        return ok
+
     def run_all_tests(self) -> bool:
         """Esegue tutti i test organizzati per categoria."""
         print("\n" + "=" * 70)
@@ -4663,6 +4905,13 @@ Examples:
         default="sp-cert.pem",
         help="SP certificate PEM for --saml-signed (default: sp-cert.pem)"
     )
+    parser.add_argument(
+        "--mcp",
+        metavar="MCP_URL",
+        help="Run only the OAuth/MCP interoperability suite (#191) against the "
+        "mock MCP server at MCP_URL, e.g. http://localhost:9100/mcp. nanoidp "
+        "must be configured with the documents:read/documents:write/admin scopes."
+    )
 
     args = parser.parse_args()
 
@@ -4680,6 +4929,8 @@ Examples:
         success = agent.run_oauth21_tests()
     elif args.saml_signed:
         success = agent.run_saml_signed_tests(args.sp_key, args.sp_cert)
+    elif args.mcp:
+        success = agent.run_mcp_tests(args.mcp)
     else:
         success = agent.run_all_tests()
 

--- a/examples/test_agent.py
+++ b/examples/test_agent.py
@@ -4732,15 +4732,17 @@ class NanoIDPTestAgent:
                 },
                 timeout=5,
             )
-            # Either the request is rejected (invalid_scope), or the token is
-            # issued but NOT widened - documents:write must never appear.
-            granted = resp.json().get("scope", "") if resp.status_code == 200 else ""
-            success = resp.status_code == 400 or "documents:write" not in granted.split()
+            # nanoidp's precise contract (RFC 6749 §6): a refresh must not add a
+            # scope the original grant lacked -> 400 invalid_scope. Asserting the
+            # exact status AND error means a 500/401/etc. can no longer pass
+            # vacuously the way an "any non-200" check would.
+            body = resp.json()
+            success = resp.status_code == 400 and body.get("error") == "invalid_scope"
             self._add_result(
                 "MCP Refresh Scope Escalation Rejected", TestCategory.MCP, success,
                 "a refresh token for documents:read cannot be widened to "
-                "documents:write on refresh (RFC 6749 §6)",
-                {"status": resp.status_code, "granted_scope": granted},
+                "documents:write on refresh -> 400 invalid_scope (RFC 6749 §6)",
+                {"status": resp.status_code, "error": body.get("error")},
             )
         except Exception as e:
             self._add_result(


### PR DESCRIPTION
Fourth and final feature deliverable of milestone 2.9.0 - the one that gives the release its identity: **nanoidp can act as the authorization server for a real OAuth-protected MCP resource**, with public clients (#188), resource-bound tokens (#187) and RFC 9728 discovery, proven end to end. Closes #191. **Stacked on #189 (#258) -> #187 (#256) -> #188 (#254)**; base is `stack/189-iss-authorization-response` so CI runs and the diff is this PR's own (a new fixture + e2e + CI + docs + one example client, no `src/` changes).

**The fixture.** `examples/mock_mcp_server.py` is a minimal MCP Streamable HTTP resource server using the `mcp` SDK 2.0 resource-server mode (`MCPServer` + `TokenVerifier` + `AuthSettings`), with three scope-gated tools: `read_document` (`documents:read`), `delete_document` (`documents:write`), `admin_operation` (`admin`). `MockTokenVerifier` validates a bearer JWT **JWKS-only** against nanoidp: RS256 signature via `PyJWKClient` (fetch + kid + rotation), `iss`, `aud` == its own resource URL (string or array), `exp`, scopes from the `scope` claim. Any failure returns `None`, which the SDK turns into a `401` with `WWW-Authenticate: Bearer ... resource_metadata=...`; the SDK also serves `/.well-known/oauth-protected-resource` naming nanoidp in `authorization_servers`.

**Two authorization layers, kept distinct** (a review correction on this PR). A resource-level scope floor `documents:read` is declared through the SDK's `AuthSettings.required_scopes`, so the bearer middleware returns the **conformant MCP/RFC 9728 challenge** - HTTP `403` with `WWW-Authenticate: Bearer error="insufficient_scope", ..., resource_metadata=...` - **before any tool runs**. The finer `documents:write` / `admin` operations are checked **inside** each tool via `get_access_token()` and surface as an in-band MCP tool error (`isError`): a second, application-defined authorization decision, not an HTTP challenge. The e2e tests and labels both, so neither is mistaken for the other.

**A real MCP client is a public client.** The delegated leg now logs in as a **public** OAuth client (PKCE, no secret): the example config registers `mcp-public-client` with `token_endpoint_auth_method: none`, and `/token` is driven with `client_id` in the body and no HTTP Basic, the way an MCP client with no stored secret actually authenticates. `client_credentials` (which IS client authentication) keeps using a confidential client.

**JWKS-only by design** (documented in the module and the guide): a token revoked at nanoidp stays valid at the resource server until `exp` - a self-contained-JWT resource server does not call back to the AS. Revocation is demonstrated through `/introspect` in the e2e, not at the mock. An introspection variant is intentionally out of scope.

**Deterministic conformance, no LLM.** `examples/test_agent.py` gains a `TestCategory.MCP` and a `--mcp <url>` suite (mirrors `--saml-signed` / `--oauth21`) that acts as the MCP client through the SDK and drives the loop itself. A failure means PKCE, discovery, `resource`, audience, scope or MCP framing is wrong, never that a model chose not to call a tool. **Nine assertions**, each written to fail loudly rather than pass vacuously (a review theme: preconditions are asserted, negative cases are checked at the HTTP layer):
- RFC 9728 discovery (the 401's metadata URL resolves and names nanoidp)
- delegated user login as a **public client** through the full PKCE + resource flow, token accepted for a scoped tool
- `client_credentials` workload token accepted
- a token minted for a **different** resource is rejected with `401` + `WWW-Authenticate: Bearer`, **asserted at the HTTP layer** with a token-was-minted precondition (the anti-mix-up property #187 exists for)
- a token lacking the resource scope floor gets the **conformant `403` `insufficient_scope`** challenge with `resource_metadata`, asserted at the HTTP layer
- the **application-level per-tool** refusal (a `documents:read` token is refused `delete_document` with an in-band tool error)
- a refresh token for `documents:read` **cannot be widened** to `documents:write` on refresh (RFC 6749 §6)
- a token revoked at nanoidp is reported inactive by `/introspect` but still accepted by the JWKS mock until `exp` (the documented behaviour, asserted)
- a pre-rotation token still validates after a key rotation, **and** the pre-rotation `kid` is asserted still present in nanoidp's published JWKS (the source of truth, not merely the mock's `PyJWKClient` cache)

**CI.** `e2e.yml` runs a third server (like the SAML SP): an MCP-interop nanoidp on 8003 with its issuer matched to its URL (the mock derives the JWKS URL from the issuer) and the three tool scopes added to `scopes_supported` (so #186 enforcement admits them), plus the mock on 9100, then the `--mcp` suite.

**Docs.** Guide `Testing an MCP client against nanoidp` (in SUMMARY) with the sequence diagram, the two-layer authorization model, the public-client note, and the JWKS-only / revoke-until-exp note; CHANGELOG entry.

**Verification.** MCP suite **9/9** live against the exact CI config; the raw `403` and `401` challenges independently inspected (both carry `WWW-Authenticate: Bearer` + `resource_metadata`). Unit suite **1812**, mypy, ruff clean, no `src/` changes.
