### PR TITLE
refactor: move the e2e harness from examples/ to e2e/ (2.9 arch review)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
           NANOIDP_E2E_HOOK_LOG: ${{ github.workspace }}/hooks.log
           NANOIDP_E2E_PLUGIN: echo
           NANOIDP_E2E_PLUGIN_RECORD: ${{ github.workspace }}/echo-record.jsonl
-        run: python examples/test_agent.py
+        run: python e2e/test_agent.py
 
       - name: Start oauth21 server
         run: |
@@ -70,11 +70,11 @@ jobs:
           exit 1
 
       - name: Run oauth21 profile suite
-        run: python examples/test_agent.py --oauth21 --url http://localhost:8001
+        run: python e2e/test_agent.py --oauth21 --url http://localhost:8001
 
       - name: Prepare signed-SAML config
         run: |
-          python examples/gen_sp_keypair.py --out e2e-saml
+          python e2e/gen_sp_keypair.py --out e2e-saml
           cp -r config e2e-saml/config
           python - <<'EOF'
           import yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run signed-AuthnRequests suite
         run: |
-          python examples/test_agent.py --saml-signed --url http://localhost:8002 \
+          python e2e/test_agent.py --saml-signed --url http://localhost:8002 \
             --sp-key e2e-saml/sp-key.pem --sp-cert e2e-saml/sp-cert.pem
 
       - name: Prepare MCP-interop config
@@ -125,7 +125,7 @@ jobs:
       - name: Start MCP-interop nanoidp and mock MCP server
         run: |
           PORT=8003 NANOIDP_CONFIG_DIR=e2e-mcp-config python -m nanoidp > server-mcp.log 2>&1 &
-          python examples/mock_mcp_server.py             --issuer http://localhost:8003             --resource http://localhost:9100/mcp             --port 9100 > mock-mcp.log 2>&1 &
+          python e2e/mock_mcp_server.py             --issuer http://localhost:8003             --resource http://localhost:9100/mcp             --port 9100 > mock-mcp.log 2>&1 &
           for i in $(seq 1 30); do
             curl -sf http://localhost:8003/api/health               && curl -sf http://localhost:9100/.well-known/oauth-protected-resource/mcp               && exit 0
             sleep 1
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run OAuth/MCP interoperability suite
         run: |
-          python examples/test_agent.py --url http://localhost:8003             --mcp http://localhost:9100/mcp
+          python e2e/test_agent.py --url http://localhost:8003             --mcp http://localhost:9100/mcp
 
       - name: Server log on failure
         if: failure()
@@ -174,4 +174,4 @@ jobs:
           NANOIDP_BOOTSTRAP_PLUGIN: echo
           NANOIDP_PLUGIN_ECHO_RECORD: ${{ github.workspace }}/echo-record-mcp.jsonl
           NANOIDP_E2E_PLUGIN: echo
-        run: python examples/mcp_smoke_test.py --config ./config
+        run: python e2e/mcp_smoke_test.py --config ./config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only the secret, so every field (present and future) is carried.
 
 ### Added
-- **Mock protected MCP server as an e2e fixture** (#191). `examples/mock_mcp_server.py`
+- **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`
   is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
   resource-server mode) with three scope-gated tools (`read_document` /
   `documents:read`, `delete_document` / `documents:write`, `admin_operation`
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error="insufficient_scope"` + `resource_metadata` challenge before any tool
   runs; and an application-level per-tool check inside each tool for the finer
   `documents:write` / `admin` operations, which surfaces as an in-band MCP
-  tool error. `examples/test_agent.py` gains an `--mcp` suite that drives the
+  tool error. `e2e/test_agent.py` gains an `--mcp` suite that drives the
   whole loop deterministically as the MCP client (401 -> RFC 9728 discovery ->
   `/authorize` with PKCE and `resource=` -> `/token` -> `tools/call`):
   delegated login as a PUBLIC client (PKCE, no secret) yielding a
@@ -308,6 +308,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the dashboard's own buttons (generate token, clear audit log) keep working
   after one unlock; and the MCP check now always reads the `ConfigManager`
   actually serving the request.
+
+### Changed
+- **The end-to-end test harness moved from `examples/` to a dedicated `e2e/`
+  directory.** `test_agent.py`, `mock_mcp_server.py`, `mcp_smoke_test.py` and
+  `gen_sp_keypair.py` now live under `e2e/`; `examples/` keeps only the real
+  usage examples (client integrations, plugins). The harness was never a
+  usage example - it is the CI end-to-end suite - and mixing the two made the
+  repository harder to read. Invocations change from `python examples/...` to
+  `python e2e/...` (CI, CONTRIBUTING and the docs are updated); no behaviour
+  and no packaged code changed.
 
 ## [2.7.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `expected_revision` at all (an old cached page, a script, the e2e
   test agent) keeps today's unconditional last-write-wins - nothing
   about this requires an existing caller to opt in.
+- **The end-to-end test harness moved from `examples/` to a dedicated `e2e/`
+  directory.** `test_agent.py`, `mock_mcp_server.py`, `mcp_smoke_test.py` and
+  `gen_sp_keypair.py` now live under `e2e/`; `examples/` keeps only the real
+  usage examples (client integrations, plugins). The harness was never a
+  usage example - it is the CI end-to-end suite - and mixing the two made the
+  repository harder to read. Invocations change from `python examples/...` to
+  `python e2e/...` (CI, CONTRIBUTING and the docs are updated); no behaviour
+  and no packaged code changed.
 
 ### Security
 - **Opt-in `management_secret` mutation gate** (#163): one shared secret that
@@ -308,16 +316,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the dashboard's own buttons (generate token, clear audit log) keep working
   after one unlock; and the MCP check now always reads the `ConfigManager`
   actually serving the request.
-
-### Changed
-- **The end-to-end test harness moved from `examples/` to a dedicated `e2e/`
-  directory.** `test_agent.py`, `mock_mcp_server.py`, `mcp_smoke_test.py` and
-  `gen_sp_keypair.py` now live under `e2e/`; `examples/` keeps only the real
-  usage examples (client integrations, plugins). The harness was never a
-  usage example - it is the CI end-to-end suite - and mixing the two made the
-  repository harder to read. Invocations change from `python examples/...` to
-  `python e2e/...` (CI, CONTRIBUTING and the docs are updated); no behaviour
-  and no packaged code changed.
 
 ## [2.7.0] - 2026-08-25
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,16 +72,16 @@ NanoIDP includes a comprehensive test agent that validates all functionality aga
 
 ```bash
 # Run against local server (default: http://localhost:8000)
-python examples/test_agent.py
+python e2e/test_agent.py
 
 # Run against custom URL
-python examples/test_agent.py --url http://localhost:9000
+python e2e/test_agent.py --url http://localhost:9000
 
 # Verbose output
-python examples/test_agent.py --verbose
+python e2e/test_agent.py --verbose
 
 # JSON output
-python examples/test_agent.py --json
+python e2e/test_agent.py --json
 ```
 
 The test agent covers:

--- a/VISION.md
+++ b/VISION.md
@@ -51,7 +51,7 @@ implicitly throughout the project's history; this writes them down.
    authorization redirects, SAML SSO, UserInfo, are exercised over HTTP,
    as a real client would.
 5. **Features ship whole.** A feature lands together with its MCP exposure
-   (where applicable), its `examples/test_agent.py` e2e coverage and its
+   (where applicable), its `e2e/test_agent.py` e2e coverage and its
    docs, in the same PR.
 6. **RFC-citable behavior.** Token and protocol behaviors reference the
    spec paragraph that justifies them, in code comments and changelog

--- a/book/src/guides/testing-an-mcp-client.md
+++ b/book/src/guides/testing-an-mcp-client.md
@@ -3,7 +3,7 @@
 nanoidp is an OAuth 2.1 / OIDC authorization server. To test a real MCP
 client's authorization code against it end to end, you need a protected MCP
 *resource* server for the client to call. The repository ships a fixture for
-exactly this: [`examples/mock_mcp_server.py`](https://github.com/cdelmonte-zg/nanoidp/blob/main/examples/mock_mcp_server.py),
+exactly this: [`e2e/mock_mcp_server.py`](https://github.com/cdelmonte-zg/nanoidp/blob/main/e2e/mock_mcp_server.py),
 a minimal MCP Streamable HTTP server that validates bearer tokens against
 nanoidp and exposes three scope-gated tools.
 
@@ -79,17 +79,17 @@ oauth:
 PORT=8003 python -m nanoidp
 
 # the mock resource server
-python examples/mock_mcp_server.py \
+python e2e/mock_mcp_server.py \
   --issuer http://localhost:8003 \
   --resource http://localhost:9100/mcp \
   --port 9100
 
 # drive the whole loop deterministically (no LLM)
-python examples/test_agent.py --url http://localhost:8003 \
+python e2e/test_agent.py --url http://localhost:8003 \
   --mcp http://localhost:9100/mcp
 ```
 
-`examples/test_agent.py --mcp` acts as the MCP client itself, through the
+`e2e/test_agent.py --mcp` acts as the MCP client itself, through the
 `mcp` SDK, so a failure means PKCE, discovery, `resource`, audience, scope or
 MCP framing is wrong - never that a model chose not to call a tool.
 

--- a/book/src/project/architecture.md
+++ b/book/src/project/architecture.md
@@ -170,7 +170,7 @@ A new client field touches all of these:
 
 Then: tests for the YAML round-trip and the persist-through-edit and
 regenerate-secret paths, MCP parity coverage, and an
-`examples/test_agent.py` scenario, in the same PR (features ship
+`e2e/test_agent.py` scenario, in the same PR (features ship
 whole). #214 settled how this flow is protected: no code-generating
 registry - the declarative surfaces (the YAML load contract, the MCP
 read surface and tool schemas, the form template) are pinned to
@@ -183,7 +183,7 @@ builders) stay covered by the per-feature tests this list requires.
 
 - `tests/` (unit and integration through the Flask test client) runs
   in CI on Python 3.10/3.11/3.12, with coverage uploaded to Codecov.
-- `examples/test_agent.py` is the end-to-end agent: it drives a real
+- `e2e/test_agent.py` is the end-to-end agent: it drives a real
   server over HTTP and MCP the way an agent would. CI runs it in the
   `http-e2e` and `mcp-e2e` jobs. When a test creates state through
   the UI it must use the shared session (`self.session`), or the

--- a/book/src/reference/saml.md
+++ b/book/src/reference/saml.md
@@ -128,9 +128,9 @@ The metadata advertises `WantAuthnRequestsSigned="true"` if and only if
 enforcement is on. A request verifies if any registered certificate
 validates it.
 
-Need a test SP keypair? `python examples/gen_sp_keypair.py --out .`
+Need a test SP keypair? `python e2e/gen_sp_keypair.py --out .`
 generates `sp-key.pem`/`sp-cert.pem`, and
-`examples/test_agent.py --saml-signed` exercises the whole behavior
+`e2e/test_agent.py --saml-signed` exercises the whole behavior
 against a running server.
 
 ## XML canonicalization algorithm

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,27 @@
+# End-to-end test harness
+
+The CI end-to-end suite. Unlike `examples/` (real usage presets), nothing here
+is meant to be copied into a project - these scripts drive a running nanoidp
+over the network to cover what the unit suite structurally cannot: real HTTP,
+the SAML redirect/POST bindings, the MCP Streamable HTTP transport, and the
+OAuth/MCP interoperability loop. They run in `.github/workflows/e2e.yml`.
+
+| File | What it does |
+| --- | --- |
+| `test_agent.py` | The main agent. Drives a real server and asserts protocol behaviour. Suites: default, `--oauth21`, `--saml-signed`, `--mcp`. |
+| `mock_mcp_server.py` | A minimal OAuth-protected MCP resource server (fixture) for the `--mcp` interoperability suite. See the guide "Testing an MCP client against nanoidp". |
+| `mcp_smoke_test.py` | Exercises the real MCP stdio server startup + a `tools/call`, the transport a unit test cannot reach. |
+| `gen_sp_keypair.py` | Generates a test SP keypair for the signed-SAML suite. |
+
+## Running
+
+```bash
+# start a server first (see CONTRIBUTING.md), then:
+python e2e/test_agent.py                              # default suite
+python e2e/test_agent.py --oauth21 --url http://localhost:8001
+python e2e/test_agent.py --mcp http://localhost:9100/mcp
+python e2e/mcp_smoke_test.py --config ./config
+```
+
+Adding a feature? Extend the matching suite here in the same PR - an
+end-to-end scenario is part of the deliverable, not a follow-up.

--- a/e2e/gen_sp_keypair.py
+++ b/e2e/gen_sp_keypair.py
@@ -10,7 +10,7 @@ certificate in settings.yaml:
         - /path/to/sp-cert.pem
 
 Usage:
-    python examples/gen_sp_keypair.py [--out DIR] [--cn COMMON_NAME]
+    python e2e/gen_sp_keypair.py [--out DIR] [--cn COMMON_NAME]
 """
 
 import argparse

--- a/e2e/mcp_smoke_test.py
+++ b/e2e/mcp_smoke_test.py
@@ -8,7 +8,7 @@ subprocess, performs the MCP handshake, lists the tools and calls a couple of
 read-only ones, asserting on the results.
 
 Usage:
-    python examples/mcp_smoke_test.py [--config ./config]
+    python e2e/mcp_smoke_test.py [--config ./config]
 
 Exit code 0 on success, 1 on any failure.
 """

--- a/e2e/mock_mcp_server.py
+++ b/e2e/mock_mcp_server.py
@@ -41,7 +41,7 @@ server - that is the difference between self-contained and introspected
 tokens, and this fixture only shows the self-contained side.
 
 Run:
-    python examples/mock_mcp_server.py \
+    python e2e/mock_mcp_server.py \
         --issuer http://localhost:8000 \
         --resource http://localhost:9100/mcp \
         --host 127.0.0.1 --port 9100

--- a/e2e/test_agent.py
+++ b/e2e/test_agent.py
@@ -4817,7 +4817,7 @@ class NanoIDPTestAgent:
 
         Requires a running nanoidp (whose oauth.scopes_supported includes
         documents:read, documents:write, admin) AND the mock MCP server
-        (examples/mock_mcp_server.py) reachable at `mcp_url`."""
+        (e2e/mock_mcp_server.py) reachable at `mcp_url`."""
         print("\n" + "=" * 70)
         print("  NanoIDP OAuth/MCP Interoperability Suite (#191)")
         print("=" * 70)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "mypy>=1.8.0",
     "types-PyYAML",
     "types-jsonschema",
-    "requests>=2.31.0",  # examples/test_agent.py (e2e)
+    "requests>=2.31.0",  # e2e/test_agent.py (e2e)
     "import-linter>=2.1",  # wildcard forbidden_modules; architectural import contracts (#149), see [tool.importlinter]
 ]
 

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -147,7 +147,7 @@ def get_configuration() -> ResponseReturnValue:
             "issuer": settings.issuer,
             "issuer_from_request": settings.issuer_from_request,
             # Companions of issuer_from_request: exposed so a config-agnostic
-            # client (examples/test_agent.py) can predict the effective issuer
+            # client (e2e/test_agent.py) can predict the effective issuer
             # instead of assuming an empty allowlist.
             "issuer_allowlist": settings.issuer_allowlist,
             "device_verification_base_url": settings.device_verification_base_url,

--- a/tests/test_ui_expected_revision.py
+++ b/tests/test_ui_expected_revision.py
@@ -305,7 +305,7 @@ class TestFreshFormSubmissionStillSucceeds:
         self, app, client, isolated_repo_config
     ):
         """A POST with no expected_revision at all (an old cached page, a
-        script, examples/test_agent.py) keeps today's last-write-wins -
+        script, e2e/test_agent.py) keeps today's last-write-wins -
         nothing about this phase should require every caller to opt in."""
         resp = client.post("/users/admin/edit", data={"email": "noopt@example.org"})
 

--- a/tests/test_ui_forms.py
+++ b/tests/test_ui_forms.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the routes/ui.py form flows (#213).
 
-These flows were covered almost only by examples/test_agent.py, which CI
+These flows were covered almost only by e2e/test_agent.py, which CI
 runs without a management secret; that is exactly the blind spot where a
 mutation that 302s to /login can pass a status-code-only assertion (the
 PR #176 round-3 finding). Every mutating test here therefore asserts on


### PR DESCRIPTION
First refactor from the integrated 2.9.0 architecture review (on `review/2.9.0-oauth-integration`). Behaviour-preserving, per the review rule "no new behaviour except an obvious bug". **Stacked on #260 (#191);** base is `stack/191-mock-mcp-server` so CI runs and the diff is this PR's own.

**Why.** The end-to-end suite lived under `examples/` next to the real usage presets, but it was never a usage example - it is the CI e2e suite that drives a running server over the network. Mixing the harness with the presets made the tree harder to read, which is exactly the human-readable-architecture goal the review is about.

**What moves.** Only the harness -> `e2e/`:

| File | Role |
| --- | --- |
| `test_agent.py` | the main agent (default / `--oauth21` / `--saml-signed` / `--mcp`) |
| `mock_mcp_server.py` | the OAuth-protected MCP resource-server fixture (#191) |
| `mcp_smoke_test.py` | the MCP stdio transport smoke test |
| `gen_sp_keypair.py` | the signed-SAML test SP keypair generator |

`examples/` keeps only the real integration presets (spring-boot-saml, react-spa-pkce, microservices-client-credentials, cli-device-flow, persona-login) and the plugins - so `examples/README.md` (a preset index) is now accurate as-is.

**Reference updates** (every invocation path): `.github/workflows/e2e.yml`, `CONTRIBUTING.md`, `VISION.md`, the mdBook guides (`testing-an-mcp-client`, `architecture`, `saml`), `pyproject.toml`, and two source/test comments (`routes/api.py`, `tests/`), from `python examples/...` to `python e2e/...`. New `e2e/README.md`. Historical CHANGELOG entries keep their original paths (accurate for their release); the 2.9 entries and a new **Changed** note point at `e2e/`.

**No behaviour, no packaged code change.** `git` tracks all four as renames. mypy `files=["src"]` and the hatch sdist never included `examples/`, so neither scope changes; `ruff check .` still covers the harness under its new path.

**Verification** (from the new `e2e/` location): MCP interop suite **9/9**, MCP stdio smoke test passing, unit suite **1812**, `ruff` and `mypy` clean.

Not merging yet: like the rest of the 2.9 stack, this stays off `main` during the 2.8.0-rc2 freeze and lands with the stack after 2.8.0 final.
