### PR TITLE
docs: document the MCP generate_token resource boundary (2.9 arch review)

### DIFF
--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -551,7 +551,11 @@ _TOOLS: list[Tool] = [
                         "array for several) instead of oauth.audience, so a "
                         "token minted for one MCP server is rejected by "
                         "another. Each must be an absolute URI without a "
-                        "fragment (optional)"
+                        "fragment. This tool mints for a user directly, with no "
+                        "client in the request, so the per-client "
+                        "allowed_resources ceiling that /token enforces does "
+                        "not apply here - the aud is whatever you pass "
+                        "(optional)"
                     ),
                 },
             },
@@ -1327,8 +1331,16 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
         or None,
         userinfo_claims=_normalize_str_list(arguments.get("userinfo_claims"), "userinfo_claims")
         or None,
-        # RFC 8707 resource indicators (#187): bind the access token aud to
-        # the given resource(s), the same as sending resource on /token.
+        # RFC 8707 resource indicators (#187): set the access token aud to the
+        # given resource(s). BOUNDARY: unlike /token, /authorize and
+        # /device_authorization - which run every requested resource through
+        # resolve_resources and reject one outside the client's
+        # allowed_resources with invalid_target - this tool has no client in
+        # the request. It mints a token directly for a user (a testing /
+        # simulation affordance, not an OAuth grant), so there is no per-client
+        # allowed_resources ceiling to apply and the aud is whatever is passed.
+        # That is deliberate; a reader expecting parity with /token should know
+        # the ceiling lives on the grant endpoints, not on this admin tool.
         resource=_normalize_str_list(arguments.get("resource"), "resource") or None,
     )
     result = {

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -546,16 +546,15 @@ _TOOLS: list[Tool] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        "RFC 8707 resource indicator(s) (#187): bind the access "
-                        "token 'aud' to these resources (a string for one, an "
-                        "array for several) instead of oauth.audience, so a "
-                        "token minted for one MCP server is rejected by "
-                        "another. Each must be an absolute URI without a "
-                        "fragment. This tool mints for a user directly, with no "
-                        "client in the request, so the per-client "
-                        "allowed_resources ceiling that /token enforces does "
-                        "not apply here - the aud is whatever you pass "
-                        "(optional)"
+                        "Audience value(s) to place in the access token's 'aud' "
+                        "claim (a string for one, an array for several) instead "
+                        "of oauth.audience, so a token minted for one MCP server "
+                        "is rejected by another (#187). Unlike the 'resource' "
+                        "parameter on the OAuth grant endpoints, this "
+                        "administrative/testing tool has no client context: it "
+                        "applies no RFC 8707 syntax validation and no per-client "
+                        "allowed_resources ceiling. The supplied values are used "
+                        "directly as the audience (optional)"
                     ),
                 },
             },


### PR DESCRIPTION
Third refactor from the integrated 2.9.0 architecture review. **Doc-only, no behaviour change.** **Stacked on #263 (client-auth) -> #261 (e2e move) -> #260 (#191);** base is `stack/centralize-client-auth`.

**Finding (from the review).** The MCP `generate_token` tool sets the access token `aud` from its `resource` argument but never calls `resolve_resources`, so the per-client RFC 8707 `allowed_resources` ceiling that `/token`, `/authorize` and `/device_authorization` enforce (`invalid_target`) is not applied via MCP. A reader could assume parity with `/token` and treat this as a gap.

**It is not a gap - it is inherent.** `generate_token` has **no client in the request**: it mints a token directly for a *user*, a testing/simulation affordance, not an OAuth grant. There is no per-client `allowed_resources` to apply, so the `aud` is whatever the caller passes - by design. The confusion was purely that the boundary was undocumented.

**What this PR does.** Documents the boundary in two places so issue and code tell the same story:
- the inline comment at the `resource=` call in `_tool_generate_token`, contrasting it explicitly with the grant endpoints;
- the tool's `resource` schema `description` (what an MCP client sees), noting that the per-client ceiling does not apply here.

No code path changes. Verified: `ruff` and `mypy` clean; the MCP tool tests (210) pass.

Not merging yet: stays off `main` during the 2.8.0-rc2 freeze, lands with the 2.9 stack after 2.8.0 final. With this, the three actionable findings from the architecture review are addressed; the optional `oauth.py` package split (finding 3) is left as a separate decision.
