### PR TITLE
chore: release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-08-29
+
 ### Fixed
 - **`client_credentials` no longer returns a refresh token** (#239). RFC
   6749 §4.4.3: "A refresh token SHOULD NOT be included" - the client
@@ -1115,6 +1117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Key rotation with JWKS support for multiple keys
 - External key import support
 
+[2.8.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/cdelmonte-zg/nanoidp/compare/v2.4.0...v2.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.8.0rc2"
+version = "2.8.0"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Finalizes the 2.8.0 release from `main` (= the v2.8.0-rc2 commit, soaked clean).

- `pyproject` version `2.8.0rc2` -> `2.8.0`.
- CHANGELOG: `[Unreleased]` consolidated into `[2.8.0] - 2026-08-29` with the `v2.7.0...v2.8.0` compare link; a fresh empty `[Unreleased]` on top.

No code changes. Verified: built wheel `nanoidp-2.8.0` smoke-tests clean in a fresh venv (version banner 2.8.0, `--help`, `nanoidp-mcp` entrypoint, `init`, startup, `/api/health`, discovery, JWKS). The tag `v2.8.0` is cut on the merge commit after this lands, triggering the PyPI + GHCR publish (a non-hyphenated tag, so `:latest` correctly moves to the final).