### PR TITLE
feat: reject refresh tokens without a client_id binding (#73, BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,10 @@ previous leniency allowed - needs a one-time adjustment.
   until they expired - a transitional compat deferred to the next major, now
   closed. *Migration:* discard refresh tokens minted before 2.2.0 and obtain
   new ones (every grant since 2.2.0 already binds them). The MCP `generate_token`
-  tool gains an optional `client_id` that binds the minted token so its refresh
-  token is spendable; without it the tool mints an unbound token, fine for a
-  one-shot access-token test but not refreshable.
+  tool gains an optional `client_id` (which must name a real client) that binds
+  the minted token and issues a refresh token spendable by it; without it the
+  tool mints an unbound access token with no refresh token at all, rather than
+  hand back one that could not be spent.
 
 ### Added
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ previous leniency allowed - needs a one-time adjustment.
   missing/malformed/unregistered `redirect_uri`) still return JSON locally.
   *Migration:* a client that parsed the `400` body should read the error from
   the redirect query instead - which is what a spec-compliant client already does.
+- **A refresh token without a `client_id` binding claim is rejected** (#73,
+  `invalid_grant`, RFC 6749 §5.2). The binding was added in 2.2.0 (#56);
+  tokens minted before it were still spendable by any authenticated client
+  until they expired - a transitional compat deferred to the next major, now
+  closed. *Migration:* discard refresh tokens minted before 2.2.0 and obtain
+  new ones (every grant since 2.2.0 already binds them). The MCP `generate_token`
+  tool gains an optional `client_id` that binds the minted token so its refresh
+  token is spendable; without it the tool mints an unbound token, fine for a
+  one-shot access-token test but not refreshable.
 
 ### Added
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -17,7 +17,7 @@ readonly mode, and the exposure warnings, see the
 | `create_persona_user` | Create a password-less user for persona login mode (local dev/testing convenience) |
 | `update_user` | Update an existing user (password, email, roles, …) |
 | `delete_user` | Delete a user |
-| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter; `resource` binds the access token `aud` to an RFC 8707 resource, #187; `client_id` binds the token to a client so its refresh token is spendable - omit for an unbound, non-refreshable token, #73) |
+| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter; `resource` binds the access token `aud` to an RFC 8707 resource, #187; `client_id` (must name a real client) binds the token and issues a refresh token spendable by it - omit for an unbound access token with no refresh token, #73) |
 | `decode_token` | Decode JWT token (without verification) |
 | `verify_token` | Verify JWT token signature and expiration (pass `audience` to also require the token's `aud` to match, simulating a resource server; omit it to accept a resource-bound token and read its claims, #187) |
 | `list_clients` | List OAuth clients |

--- a/book/src/reference/mcp.md
+++ b/book/src/reference/mcp.md
@@ -17,7 +17,7 @@ readonly mode, and the exposure warnings, see the
 | `create_persona_user` | Create a password-less user for persona login mode (local dev/testing convenience) |
 | `update_user` | Update an existing user (password, email, roles, …) |
 | `delete_user` | Delete a user |
-| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter; `resource` binds the access token `aud` to an RFC 8707 resource, #187) |
+| `generate_token` | Generate OAuth2 tokens for a user (pass `scope` with `openid` to also get an ID Token; `id_token_claims`/`userinfo_claims` mirror the OIDC `claims` request parameter; `resource` binds the access token `aud` to an RFC 8707 resource, #187; `client_id` binds the token to a client so its refresh token is spendable - omit for an unbound, non-refreshable token, #73) |
 | `decode_token` | Decode JWT token (without verification) |
 | `verify_token` | Verify JWT token signature and expiration (pass `audience` to also require the token's `aud` to match, simulating a resource server; omit it to accept a resource-bound token and read its claims, #187) |
 | `list_clients` | List OAuth clients |

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -506,6 +506,16 @@ _TOOLS: list[Tool] = [
                     "type": "integer",
                     "description": "Token expiration in minutes (optional, default: 60)",
                 },
+                "client_id": {
+                    "type": "string",
+                    "description": (
+                        "Bind the token to this client (optional). Stamps the "
+                        "client_id claim so the refresh token is spendable - "
+                        "since 3.0 a refresh token with no client_id binding is "
+                        "refused (#73). Omit for an unbound token, fine for a "
+                        "one-shot access-token test but not refreshable"
+                    ),
+                },
                 "extra_claims": {
                     "type": "object",
                     "description": "Additional claims to include in the token",
@@ -1326,6 +1336,12 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
         exp_minutes=arguments.get("expires_in_minutes", config.settings.token_expiry_minutes),
         extra_claims=arguments.get("extra_claims"),
         scope=arguments.get("scope"),
+        # Optional client binding (#73): stamps the client_id claim so the
+        # refresh token can actually be spent - since 3.0 a refresh token with
+        # no client_id binding is refused. Omit for an unbound token (aud =
+        # oauth.audience or the resource below); such a token is fine for a
+        # one-shot access-token test but is NOT refreshable.
+        client_id=arguments.get("client_id"),
         # _execute_tool is also reachable directly (see tests), bypassing
         # call_tool's input_schema validation; reject a non-list with a
         # clean error here too instead of minting a token whose malformed
@@ -1339,10 +1355,10 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
         # given resource(s). BOUNDARY: unlike /token, /authorize and
         # /device_authorization - which run every requested resource through
         # resolve_resources and reject one outside the client's
-        # allowed_resources with invalid_target - this tool has no client in
-        # the request. It mints a token directly for a user (a testing /
-        # simulation affordance, not an OAuth grant), so there is no per-client
-        # allowed_resources ceiling to apply and the aud is whatever is passed.
+        # allowed_resources with invalid_target - this tool never applies that
+        # per-client ceiling, even when client_id is given for the refresh
+        # binding above: it mints a token directly (a testing / simulation
+        # affordance, not an OAuth grant), so the aud is whatever is passed.
         # That is deliberate; a reader expecting parity with /token should know
         # the ceiling lives on the grant endpoints, not on this admin tool.
         resource=_normalize_str_list(arguments.get("resource"), "resource") or None,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -509,11 +509,12 @@ _TOOLS: list[Tool] = [
                 "client_id": {
                     "type": "string",
                     "description": (
-                        "Bind the token to this client (optional). Stamps the "
-                        "client_id claim so the refresh token is spendable - "
-                        "since 3.0 a refresh token with no client_id binding is "
-                        "refused (#73). Omit for an unbound token, fine for a "
-                        "one-shot access-token test but not refreshable"
+                        "Bind the token to this client (optional; must name a "
+                        "real client). Stamps the client_id claim and issues a "
+                        "refresh token spendable by that client. Omit for an "
+                        "unbound token: NO refresh token is issued (an unbound "
+                        "one could not be spent since 3.0, #73), just an access "
+                        "token, fine for a one-shot test"
                     ),
                 },
                 "extra_claims": {
@@ -1330,18 +1331,28 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
     if not user:
         return {"success": False, "error": f"User '{username}' not found"}
 
+    # Optional client binding (#73). A given client_id must name a real client:
+    # binding to an unknown one would stamp a client_id claim no authenticable
+    # client could ever match, i.e. a refresh token that looks bound but is
+    # dead - reject it up front instead.
+    client_id = arguments.get("client_id")
+    if client_id is not None and config.get_client(client_id) is None:
+        return {"success": False, "error": f"Client '{client_id}' not found"}
+
     token_service = get_token_service()
     token_response = token_service.create_token(
         user=user,
         exp_minutes=arguments.get("expires_in_minutes", config.settings.token_expiry_minutes),
         extra_claims=arguments.get("extra_claims"),
         scope=arguments.get("scope"),
-        # Optional client binding (#73): stamps the client_id claim so the
-        # refresh token can actually be spent - since 3.0 a refresh token with
-        # no client_id binding is refused. Omit for an unbound token (aud =
-        # oauth.audience or the resource below); such a token is fine for a
-        # one-shot access-token test but is NOT refreshable.
-        client_id=arguments.get("client_id"),
+        # Client binding (#73): with client_id, the token is bound and a
+        # refresh token is issued (spendable by that client). Without it the
+        # token is unbound and NO refresh token is issued at all - a refresh
+        # token with no client_id binding is refused since 3.0, so handing one
+        # back would be a dead credential. The unbound access token is still
+        # fine for a one-shot test.
+        client_id=client_id,
+        issue_refresh_token=client_id is not None,
         # _execute_tool is also reachable directly (see tests), bypassing
         # call_tool's input_schema validation; reject a non-list with a
         # clean error here too instead of minting a token whose malformed
@@ -1366,10 +1377,13 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
     result = {
         "success": True,
         "access_token": token_response["access_token"],
-        "refresh_token": token_response["refresh_token"],
         "token_type": token_response["token_type"],
         "expires_in": token_response["expires_in"],
     }
+    # Present only for a bound (client_id) token; create_token omits the key
+    # entirely when no refresh token is issued.
+    if "refresh_token" in token_response:
+        result["refresh_token"] = token_response["refresh_token"]
     if "id_token" in token_response:
         result["id_token"] = token_response["id_token"]
     return result

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -183,10 +183,35 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         return abort(400, description="Invalid token type")
 
     # A refresh token may only be spent by the client it was issued to
-    # (RFC 9700 §4.14, #56). The binding claim was added in #56; tokens
-    # minted before it carry no client_id and stay usable (legacy compat).
+    # (RFC 9700 §4.14, #56). Since 3.0 the binding claim is MANDATORY (#73):
+    # a refresh token with no client_id claim - minted before the binding
+    # existed (pre-2.2.0/#56) - is refused, ending the transitional compat
+    # that let any authenticated client spend such a token until it expired.
     bound_client = payload.get("client_id")
-    if bound_client and bound_client != ctx.client_id:
+    if not bound_client:
+        audit_event(
+            "token_request",
+            "failed",
+            endpoint="/token",
+            client_id=ctx.client_id,
+            details={
+                "reason": "Refresh token has no client_id binding claim",
+                "grant_type": ctx.grant_type,
+            },
+        )
+        return (
+            jsonify(
+                {
+                    "error": "invalid_grant",
+                    "error_description": (
+                        "This refresh token predates client binding and is no "
+                        "longer accepted; obtain a new one"
+                    ),
+                }
+            ),
+            400,
+        )
+    if bound_client != ctx.client_id:
         audit_event(
             "token_request",
             "failed",

--- a/tests/test_claims_request_parameter.py
+++ b/tests/test_claims_request_parameter.py
@@ -433,6 +433,7 @@ class TestClaimsPersistAcrossRefresh:
                 "token_type": "refresh",
                 "token_use": "refresh",
                 "scope": "openid",
+                "client_id": "demo-client",
                 "rt_family": "forged-family",
                 "req_id_token_claims": 42,  # non-iterable
                 "req_userinfo_claims": "email",  # bare string, not a list
@@ -456,6 +457,7 @@ class TestClaimsPersistAcrossRefresh:
                 "token_type": "refresh",
                 "token_use": "refresh",
                 "scope": "openid",
+                "client_id": "demo-client",
                 "rt_family": "forged-family-2",
                 "req_id_token_claims": ["email", {"essential": True}],
             },

--- a/tests/test_issue_56_review.py
+++ b/tests/test_issue_56_review.py
@@ -69,8 +69,10 @@ class TestRefreshTokenClientBinding:
         # OIDC Core §12.2: the refreshed ID Token aud MUST equal the original
         assert refreshed_aud == original_aud == "demo-client"
 
-    def test_legacy_refresh_token_without_binding_still_works(self, app, client, auth_header):
-        """Tokens minted before the client_id claim existed keep working."""
+    def test_legacy_refresh_token_without_binding_is_rejected(self, app, client, auth_header):
+        """3.0 (#73): a refresh token with no client_id binding claim - minted
+        before the binding existed - is refused with invalid_grant, ending the
+        transitional compat that let any authenticated client spend it."""
         with app.app_context():
             from nanoidp.services import get_crypto_service
             settings = get_config().settings
@@ -81,7 +83,8 @@ class TestRefreshTokenClientBinding:
                 extra={"token_type": "refresh", "token_use": "refresh"},
             )
         resp = _refresh(client, auth_header, legacy)
-        assert resp.status_code == 200
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_grant"
 
 
 class TestAtomicRotationAndFamilies:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1092,6 +1092,7 @@ class TestGenerateTokenClaims:
         result = await self._generate(
             {
                 "username": "admin",
+                "client_id": "demo-client",
                 "scope": "openid",
                 "id_token_claims": ["email"],
                 "userinfo_claims": ["department"],
@@ -1117,3 +1118,17 @@ class TestGenerateTokenClaims:
             refreshed["access_token"], options={"verify_signature": False}
         )
         assert access_payload["req_userinfo_claims"] == ["department"]
+
+    @pytest.mark.asyncio
+    async def test_unbound_token_cannot_be_refreshed(self, app, client, auth_header):
+        """Without client_id, generate_token mints an UNBOUND token: fine for a
+        one-shot access-token test, but its refresh token has no client_id
+        binding, so since 3.0 (#73) it cannot be spent."""
+        result = await self._generate({"username": "admin", "scope": "openid"})
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": result["refresh_token"]},
+            headers=auth_header,
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_grant"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1120,15 +1120,37 @@ class TestGenerateTokenClaims:
         assert access_payload["req_userinfo_claims"] == ["department"]
 
     @pytest.mark.asyncio
-    async def test_unbound_token_cannot_be_refreshed(self, app, client, auth_header):
-        """Without client_id, generate_token mints an UNBOUND token: fine for a
-        one-shot access-token test, but its refresh token has no client_id
-        binding, so since 3.0 (#73) it cannot be spent."""
+    async def test_unbound_token_has_no_refresh_token(self, app):
+        """Without client_id, generate_token mints an UNBOUND access token and
+        issues NO refresh token: a refresh token with no client_id binding is
+        refused since 3.0 (#73), so handing one back would be a dead credential."""
         result = await self._generate({"username": "admin", "scope": "openid"})
+        assert "access_token" in result
+        assert "refresh_token" not in result
+
+    @pytest.mark.asyncio
+    async def test_bound_token_refresh_token_is_spendable(self, app, client, auth_header):
+        """With a valid client_id, the token is bound and its refresh token can
+        be spent by that client."""
+        result = await self._generate({"username": "admin", "scope": "openid", "client_id": "demo-client"})
         resp = client.post(
             "/token",
             data={"grant_type": "refresh_token", "refresh_token": result["refresh_token"]},
             headers=auth_header,
         )
-        assert resp.status_code == 400
-        assert json.loads(resp.data)["error"] == "invalid_grant"
+        assert resp.status_code == 200, resp.data
+
+    @pytest.mark.asyncio
+    async def test_unknown_client_id_is_rejected(self, app):
+        """A client_id that names no configured client is refused up front,
+        rather than stamping a binding no authenticable client could match."""
+        from nanoidp.config import get_config
+        from nanoidp.mcp_server import _execute_tool
+
+        result = await _execute_tool(
+            "generate_token",
+            {"username": "admin", "client_id": "does-not-exist"},
+            get_config(),
+        )
+        assert result["success"] is False
+        assert "does-not-exist" in result["error"]


### PR DESCRIPTION
First of the three follow-ups going into 3.0.0 alongside the landed 2.9 stack. **Breaking** (the milestone's whole purpose - accumulate the deferred breaking cleanups in the major). Closes #73.

**What.** A refresh token with **no `client_id` binding claim** is now refused with `invalid_grant` (RFC 6749 §5.2). The binding was added in 2.2.0 (#56, RFC 9700 §4.14: a refresh token may only be spent by its issuing client); tokens minted before it were still spendable by any authenticated client until they expired - the residual compat #73 tracked, "blocked on a 3.0 being planned". It is now.

- One check in `_grant_refresh_token`: `payload.get("client_id")` absent -> `invalid_grant`.
- *Migration:* discard refresh tokens minted before 2.2.0; obtain new ones (every grant since 2.2.0 already binds them).

**The generate_token interaction (surfaced by the suite, addressed here).** The MCP `generate_token` tool mints directly for a user with no client, so its refresh tokens were unbound - and now non-refreshable. Rather than leave the primary test-token minter unable to produce a refreshable token, `generate_token` gains an **optional `client_id`**:
- given -> **must name a real client**; binds the token and issues a refresh token spendable by that client (a validated, working credential);
- omitted -> unbound access token with **no refresh token at all** - handing back one with no client_id binding would be a dead credential since 3.0.

This is additive; the resource/`allowed_resources` boundary documented in #264 is unchanged (still never applied here, even with `client_id`). MCP schema + `book/src/reference/mcp.md` updated.

**Tests.** The #56 legacy-compat test (`..._still_works`) is flipped to `..._is_rejected` (400 `invalid_grant`, the real #73 requirement, built directly from a hand-crafted unbound token). For generate_token: `test_unbound_token_has_no_refresh_token` (unbound -> no refresh token issued), `test_bound_token_refresh_token_is_spendable` (a valid client_id -> the refresh token actually works on `/token`, 200), and `test_unknown_client_id_is_rejected`. The two claims-across-refresh tests now mint **bound** tokens so they still exercise claims persistence with a valid 3.0 token.

**Verified**: unit suite **1832**, `ruff` and `mypy` clean.
