### PR TITLE
feat: public clients on the device flow (#255, RFC 8628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,8 @@ previous leniency allowed - needs a one-time adjustment.
   authorization_code + PKCE, and this completes the pair for CLI/TV/IoT-style
   clients. Because an unauthenticated device authorization request is cheaper to
   spam, the in-memory device-code store is now capacity-bounded: at the cap it
-  returns `503` `slow_down` rather than growing without bound or evicting a live
-  authorization.
+  returns `503` `server_error` rather than growing without bound or evicting a
+  live authorization.
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`
   is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
   resource-server mode) with three scope-gated tools (`read_document` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,9 @@ previous leniency allowed - needs a one-time adjustment.
   authorization_code + PKCE, and this completes the pair for CLI/TV/IoT-style
   clients. Because an unauthenticated device authorization request is cheaper to
   spam, the in-memory device-code store is now capacity-bounded: at the cap it
-  returns `503` `server_error` rather than growing without bound or evicting a
-  live authorization.
+  returns a plain `503` (with `Retry-After`) rather than growing without bound or
+  evicting a live authorization - not an OAuth error code, since RFC 6749 §5.2
+  has no registered code for server saturation.
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`
   is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
   resource-server mode) with three scope-gated tools (`read_document` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,10 @@ previous leniency allowed - needs a one-time adjustment.
   - **Two authentication methods in one request are rejected** (HTTP Basic and a
     body `client_secret` together, RFC 6749 §2.3) - Basic no longer silently
     wins. *Migration:* send credentials one way only.
-  - Public-client policy is unchanged: `/introspect` and `/device_authorization`
-    still refuse public clients; `/revoke` keeps its RFC 7009 §2.1 ownership
-    relaxation.
+  - Public-client policy: `/introspect` refuses public clients (RFC 7662),
+    `/revoke` keeps its RFC 7009 §2.1 ownership relaxation, and
+    `/device_authorization` now accepts a public client by client_id alone
+    (RFC 8628, see the device-flow entry below).
 - **`/authorize` reports errors after `redirect_uri` validation by redirecting
   to the client** (#189, RFC 6749 §4.1.2.1 / RFC 9207): `unsupported_response_type`,
   `invalid_scope`, PKCE errors and `invalid_target` are now `302` redirects
@@ -62,6 +63,14 @@ previous leniency allowed - needs a one-time adjustment.
   hand back one that could not be spent.
 
 ### Added
+- **Public clients on the device flow** (#255, RFC 8628). A public client
+  (`token_endpoint_auth_method: "none"`) can now use the device authorization
+  grant: it presents its `client_id` alone at `/device_authorization` (§3.1)
+  and again when polling `/token` (§3.4), with no secret. The issued
+  `device_code` is bound to that `client_id` and only it can redeem it, which
+  stands in for client authentication. Confidential clients still authenticate
+  as before; #188 shipped public clients for authorization_code + PKCE, and
+  this completes the pair for CLI/TV/IoT-style clients.
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`
   is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
   resource-server mode) with three scope-gated tools (`read_document` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,14 @@ previous leniency allowed - needs a one-time adjustment.
   grant: it presents its `client_id` alone at `/device_authorization` (§3.1)
   and again when polling `/token` (§3.4), with no secret. The issued
   `device_code` is bound to that `client_id` and only it can redeem it, which
-  stands in for client authentication. Confidential clients still authenticate
-  as before; #188 shipped public clients for authorization_code + PKCE, and
-  this completes the pair for CLI/TV/IoT-style clients.
+  stands in for client authentication (it presents client_id as a parameter,
+  not via HTTP Basic or a secret, RFC 8628 §3.1; both are rejected). Confidential
+  clients still authenticate as before; #188 shipped public clients for
+  authorization_code + PKCE, and this completes the pair for CLI/TV/IoT-style
+  clients. Because an unauthenticated device authorization request is cheaper to
+  spam, the in-memory device-code store is now capacity-bounded: at the cap it
+  returns `503` `slow_down` rather than growing without bound or evicting a live
+  authorization.
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`
   is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
   resource-server mode) with three scope-gated tools (`read_document` /

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -391,6 +391,9 @@ reuse detection (OAuth 2.1 §4.3.1/§6.1), whatever
 must match, otherwise the response is still `200` and nothing is revoked
 (RFC 7009 §2.1 and its privacy guidance). `/introspect` stays
 authenticated (RFC 7662): a public `client_id` is not authentication.
+`/device_authorization` accepts a public client by `client_id` alone
+(RFC 8628 §3.1, #255) - it presents the `client_id` as a parameter, not
+via HTTP Basic or a secret, and the issued `device_code` is bound to it.
 A confidential client authenticates on every grant, `authorization_code`
 included (RFC 6749 §3.2.1); a missing or wrong secret is `invalid_client`.
 The registered `token_endpoint_auth_method` is enforced (RFC 7591) at
@@ -409,6 +412,18 @@ than introduce a second field. A client that authenticated to these
 endpoints over the other channel before must now use the channel its
 `token_endpoint_auth_method` names (or be re-registered for the method it
 actually uses).
+
+Public-client handling differs by endpoint (each follows its own RFC), so
+here it is in one place:
+
+| Endpoint | A public client (`token_endpoint_auth_method: "none"`) |
+|----------|--------------------------------------------------------|
+| `/authorize` | Accepted; PKCE with `S256` is mandatory regardless of profile (OAuth 2.1 §7.5.1). |
+| `/token` - `authorization_code`, `refresh_token`, `device_code` | Identified by `client_id` alone; refresh tokens always rotate with reuse detection. |
+| `/token` - `client_credentials` | Refused with `unauthorized_client` (the grant IS client authentication). |
+| `/device_authorization` | Accepted by `client_id` alone (RFC 8628 §3.1); HTTP Basic or a `client_secret` is rejected; the `device_code` is bound to the client. |
+| `/revoke` | Accepted by `client_id` alone; an ownership check on the token's `client_id` claim stands in for authentication (RFC 7009 §2.1). |
+| `/introspect` | Refused - a public `client_id` is not authentication (RFC 7662); `none` is not in `introspection_endpoint_auth_methods_supported`. |
 
 **Authorization response `iss`** (issue #189, RFC 9207): `/authorize`
 returns `iss=<effective issuer>` on every response delivered through a

--- a/e2e/test_agent.py
+++ b/e2e/test_agent.py
@@ -1763,6 +1763,48 @@ class NanoIDPTestAgent:
         except Exception as e:
             return self._add_result("Device Flow", TestCategory.OAUTH, False, str(e))
 
+    def test_public_client_device_flow(self) -> TestResult:
+        """A PUBLIC client completes the device flow with client_id alone (#255,
+        RFC 8628 §3.1/§3.4): no secret at the device authorization endpoint or
+        when polling the token endpoint. Uses the bundled mcp-public-client."""
+        pub = "mcp-public-client"
+        try:
+            # 1. device authorization: client_id alone, no auth header
+            resp = requests.post(
+                f"{self.base_url}/device_authorization",
+                data={"client_id": pub, "scope": "openid"}, timeout=5,
+            )
+            if resp.status_code != 200:
+                return self._add_result(
+                    "Public Client Device Flow", TestCategory.OAUTH, False,
+                    f"device_authorization for a public client -> {resp.status_code}",
+                    {"status": resp.status_code},
+                )
+            data = resp.json()
+            user_code, device_code = data.get("user_code"), data.get("device_code")
+            # 2. user approves
+            requests.post(
+                f"{self.base_url}/device",
+                data={"user_code": user_code, "username": self.username,
+                      "password": self.password}, timeout=5,
+            )
+            time.sleep(1)
+            # 3. poll the token endpoint with client_id alone, no secret
+            token_resp = requests.post(
+                f"{self.base_url}/token",
+                data={"grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                      "device_code": device_code, "client_id": pub}, timeout=5,
+            )
+            ok = token_resp.status_code == 200 and "access_token" in token_resp.json()
+            return self._add_result(
+                "Public Client Device Flow", TestCategory.OAUTH, ok,
+                "a public client (no secret) completes device_auth -> verify -> "
+                "token with client_id alone (RFC 8628, #255)",
+                {"device_status": resp.status_code, "token_status": token_resp.status_code},
+            )
+        except Exception as e:
+            return self._add_result("Public Client Device Flow", TestCategory.OAUTH, False, str(e))
+
     def test_token_decode(self) -> TestResult:
         """Decode and validate JWT structure."""
         if not self.access_token:
@@ -4876,6 +4918,7 @@ class NanoIDPTestAgent:
                 self.test_id_token_audience_array,
                 self.test_id_token_not_accepted_as_access_token,
                 self.test_device_flow,
+                self.test_public_client_device_flow,
                 self.test_device_verification_base_url,
                 self.test_token_decode,
                 self.test_introspection,

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1466,11 +1466,13 @@ def device_authorization() -> ResponseReturnValue:
     # A hard cap bounds the in-memory store, which matters now that a public
     # client can create entries with its client_id alone (#255): at capacity,
     # refuse new authorizations rather than grow without bound or evict a live
-    # one. This is a temporary server-side condition (the store drains as codes
-    # expire), reported as server_error with 503 - NOT slow_down, which RFC 8628
-    # §3.5 defines specifically for the token endpoint's POLLING response
-    # (increase the interval), a semantics that has no place on the device
-    # authorization response (whose errors follow RFC 6749 §5.2).
+    # one. Deliberately NOT an OAuth error code: RFC 8628 §3.2 says the device
+    # authorization response's errors take the RFC 6749 §5.2 (token endpoint)
+    # form, and §5.2 has no registered code for server saturation (server_error
+    # is registered for the authorization endpoint only, and slow_down is the
+    # token endpoint's POLLING signal, §3.5). So this is a plain HTTP 503 - the
+    # correct semantics for a temporary capacity exhaustion - with a message and
+    # a Retry-After hint, not a fabricated OAuth token error.
     try:
         device_code, user_code = get_device_code_store().create(
             client_id, scope, resource=validated_resources
@@ -1483,15 +1485,10 @@ def device_authorization() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": "device code store at capacity"},
         )
-        return (
-            jsonify(
-                {
-                    "error": "server_error",
-                    "error_description": "Too many pending device authorizations; retry later",
-                }
-            ),
-            503,
-        )
+        response = jsonify({"message": "Too many pending device authorizations; retry later"})
+        response.status_code = 503
+        response.headers["Retry-After"] = str(DEVICE_POLL_INTERVAL)
+        return response
 
     audit_event(
         "device_authorization_request",

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1466,8 +1466,11 @@ def device_authorization() -> ResponseReturnValue:
     # A hard cap bounds the in-memory store, which matters now that a public
     # client can create entries with its client_id alone (#255): at capacity,
     # refuse new authorizations rather than grow without bound or evict a live
-    # one. RFC 8628 has no dedicated error here, so use slow_down (§3.5) - the
-    # honest signal to a caller flooding the endpoint.
+    # one. This is a temporary server-side condition (the store drains as codes
+    # expire), reported as server_error with 503 - NOT slow_down, which RFC 8628
+    # §3.5 defines specifically for the token endpoint's POLLING response
+    # (increase the interval), a semantics that has no place on the device
+    # authorization response (whose errors follow RFC 6749 §5.2).
     try:
         device_code, user_code = get_device_code_store().create(
             client_id, scope, resource=validated_resources
@@ -1483,7 +1486,7 @@ def device_authorization() -> ResponseReturnValue:
         return (
             jsonify(
                 {
-                    "error": "slow_down",
+                    "error": "server_error",
                     "error_description": "Too many pending device authorizations; retry later",
                 }
             ),

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1348,28 +1348,30 @@ def device_authorization() -> ResponseReturnValue:
     Device Authorization endpoint (RFC 8628).
     Initiates the device flow by returning device_code and user_code.
 
-    Required:
-    - Client authentication (Basic auth)
+    Client identification:
+    - A confidential client authenticates with its registered method.
+    - A public client (token_endpoint_auth_method 'none') presents its
+      client_id alone, no secret (RFC 8628 §3.1, #255).
 
     Optional:
     - scope: Requested scopes
     """
     config = get_config()
 
-    # Client authentication, enforced as at the token endpoint (#262):
-    # registered method enforced, two auth methods in one request rejected.
-    # Public clients are NOT supported on the device flow yet (#255 tracks
-    # that decision; today a public client uses authorization_code + PKCE).
+    # Client authentication. A confidential client authenticates as at the
+    # token endpoint (#262): registered method enforced, two auth methods in
+    # one request rejected. A PUBLIC client (token_endpoint_auth_method 'none')
+    # presents its client_id alone with no secret (RFC 8628 §3.1, #255): the
+    # issued device_code is bound to that client_id and only it can poll for
+    # the token, which is what stands in for client authentication here (the
+    # same shape as /revoke's public relaxation).
     auth = request.authorization
     body_client_id = request.form.get("client_id")
     body_client_secret = request.form.get("client_secret") or None
     resolved_client_id = (auth.username if auth else None) or body_client_id
     device_client = config.get_client(resolved_client_id) if resolved_client_id else None
     if device_client is not None and device_client.is_public:
-        auth_error: Optional[str] = (
-            "public clients are not supported on the device flow yet (#255); "
-            "this client's token_endpoint_auth_method is 'none'"
-        )
+        auth_error: Optional[str] = None
     else:
         auth_error = _enforce_registered_client_auth(
             config, resolved_client_id, auth, body_client_secret

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -34,7 +34,11 @@ from ..services import (
     get_revocation_store,
     get_token_service,
 )
-from ..services.device_code import DEVICE_CODE_EXPIRES_IN, DEVICE_POLL_INTERVAL
+from ..services.device_code import (
+    DEVICE_CODE_EXPIRES_IN,
+    DEVICE_POLL_INTERVAL,
+    DeviceCodeStoreFull,
+)
 from ..services.discovery import issuer_qualifies_for_iss_parameter
 from ..services.redirect_uri import (
     append_authorization_params,
@@ -1371,7 +1375,17 @@ def device_authorization() -> ResponseReturnValue:
     resolved_client_id = (auth.username if auth else None) or body_client_id
     device_client = config.get_client(resolved_client_id) if resolved_client_id else None
     if device_client is not None and device_client.is_public:
-        auth_error: Optional[str] = None
+        # RFC 8628 §3.1: a public client provides its client_id as a parameter,
+        # not via HTTP Basic or a client_secret. The client_id is public, so
+        # this is about using the right channel (as /token enforces the
+        # registered method), not secrecy - presenting either is rejected.
+        if auth is not None or body_client_secret is not None:
+            auth_error: Optional[str] = (
+                "a public client presents its client_id as a parameter, without "
+                "HTTP Basic or a client_secret (RFC 8628 §3.1)"
+            )
+        else:
+            auth_error = None
     else:
         auth_error = _enforce_registered_client_auth(
             config, resolved_client_id, auth, body_client_secret
@@ -1449,9 +1463,32 @@ def device_authorization() -> ResponseReturnValue:
 
     # Create the device authorization; the store prunes stale entries and
     # keeps the user-code index internally (#84, previously module globals).
-    device_code, user_code = get_device_code_store().create(
-        client_id, scope, resource=validated_resources
-    )
+    # A hard cap bounds the in-memory store, which matters now that a public
+    # client can create entries with its client_id alone (#255): at capacity,
+    # refuse new authorizations rather than grow without bound or evict a live
+    # one. RFC 8628 has no dedicated error here, so use slow_down (§3.5) - the
+    # honest signal to a caller flooding the endpoint.
+    try:
+        device_code, user_code = get_device_code_store().create(
+            client_id, scope, resource=validated_resources
+        )
+    except DeviceCodeStoreFull:
+        audit_event(
+            "device_authorization_request",
+            "failed",
+            endpoint="/device_authorization",
+            client_id=client_id,
+            details={"reason": "device code store at capacity"},
+        )
+        return (
+            jsonify(
+                {
+                    "error": "slow_down",
+                    "error_description": "Too many pending device authorizations; retry later",
+                }
+            ),
+            503,
+        )
 
     audit_event(
         "device_authorization_request",

--- a/src/nanoidp/services/device_code.py
+++ b/src/nanoidp/services/device_code.py
@@ -34,6 +34,20 @@ _USER_CODE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
 DEVICE_CODE_EXPIRES_IN = 600  # seconds (RFC 8628 leaves this to the AS)
 DEVICE_POLL_INTERVAL = 5  # seconds
 
+# A hard cap on concurrently pending device authorizations, so the in-memory
+# store cannot grow without bound. It matters now that a public client can
+# create entries with its client_id alone (#255): an unauthenticated device
+# authorization request is cheaper to spam than a credentialed one. The cap is
+# generous for real dev/test use (each entry lives at most
+# DEVICE_CODE_EXPIRES_IN and is pruned on the next create); reaching it refuses
+# NEW authorizations rather than evicting live ones, so an in-flight legitimate
+# code is never dropped.
+MAX_PENDING_DEVICE_CODES = 10_000
+
+
+class DeviceCodeStoreFull(Exception):
+    """Raised by create() when MAX_PENDING_DEVICE_CODES pending entries exist."""
+
 
 @dataclass
 class DeviceCodeGrant:
@@ -103,6 +117,10 @@ class DeviceCodeStore:
 
         with self._lock:
             self.prune_expired()
+            if len(self._codes) >= MAX_PENDING_DEVICE_CODES:
+                raise DeviceCodeStoreFull(
+                    f"{MAX_PENDING_DEVICE_CODES} device authorizations already pending"
+                )
             self._codes[device_code] = DeviceCodeGrant(
                 user_code=user_code,
                 client_id=client_id,

--- a/tests/test_device_flow_complete.py
+++ b/tests/test_device_flow_complete.py
@@ -391,14 +391,18 @@ class TestDeviceCodeStoreCapacity:
         with pytest.raises(dc.DeviceCodeStoreFull):
             store.create("demo-client", "openid")
 
-    def test_endpoint_returns_503_server_error_at_capacity(self, client, auth_header, monkeypatch):
-        # server_error (RFC 6749 §5.2), NOT slow_down: slow_down is the token
-        # endpoint's polling response (RFC 8628 §3.5), not a device-authorization
-        # capacity error.
+    def test_endpoint_returns_plain_503_at_capacity(self, client, auth_header, monkeypatch):
+        # A plain HTTP 503 (with a message + Retry-After), NOT a fabricated OAuth
+        # error: RFC 8628 §3.2 takes the RFC 6749 §5.2 error form, which has no
+        # registered code for saturation (server_error is authorization-endpoint
+        # only; slow_down is the token endpoint's polling signal, §3.5).
         from nanoidp.services import device_code as dc
 
         monkeypatch.setattr(dc, "MAX_PENDING_DEVICE_CODES", 1)
         assert client.post("/device_authorization", headers=auth_header).status_code == 200
         resp = client.post("/device_authorization", headers=auth_header)
         assert resp.status_code == 503
-        assert json.loads(resp.data)["error"] == "server_error"
+        body = json.loads(resp.data)
+        assert "error" not in body  # not a fake OAuth token error
+        assert "message" in body
+        assert resp.headers.get("Retry-After")

--- a/tests/test_device_flow_complete.py
+++ b/tests/test_device_flow_complete.py
@@ -391,11 +391,14 @@ class TestDeviceCodeStoreCapacity:
         with pytest.raises(dc.DeviceCodeStoreFull):
             store.create("demo-client", "openid")
 
-    def test_endpoint_returns_slow_down_at_capacity(self, client, auth_header, monkeypatch):
+    def test_endpoint_returns_503_server_error_at_capacity(self, client, auth_header, monkeypatch):
+        # server_error (RFC 6749 §5.2), NOT slow_down: slow_down is the token
+        # endpoint's polling response (RFC 8628 §3.5), not a device-authorization
+        # capacity error.
         from nanoidp.services import device_code as dc
 
         monkeypatch.setattr(dc, "MAX_PENDING_DEVICE_CODES", 1)
         assert client.post("/device_authorization", headers=auth_header).status_code == 200
         resp = client.post("/device_authorization", headers=auth_header)
         assert resp.status_code == 503
-        assert json.loads(resp.data)["error"] == "slow_down"
+        assert json.loads(resp.data)["error"] == "server_error"

--- a/tests/test_device_flow_complete.py
+++ b/tests/test_device_flow_complete.py
@@ -375,3 +375,27 @@ class TestDeviceAuthorizationResponse:
 
         # Should be at least 1 second and at most 60 seconds
         assert 1 <= interval <= 60
+
+
+class TestDeviceCodeStoreCapacity:
+    """#255: the in-memory device code store is capacity-bounded, so a public
+    client (client_id alone, no credential) cannot grow it without bound."""
+
+    def test_store_raises_when_full(self, monkeypatch):
+        from nanoidp.services import device_code as dc
+
+        monkeypatch.setattr(dc, "MAX_PENDING_DEVICE_CODES", 2)
+        store = dc.DeviceCodeStore()
+        store.create("demo-client", "openid")
+        store.create("demo-client", "openid")
+        with pytest.raises(dc.DeviceCodeStoreFull):
+            store.create("demo-client", "openid")
+
+    def test_endpoint_returns_slow_down_at_capacity(self, client, auth_header, monkeypatch):
+        from nanoidp.services import device_code as dc
+
+        monkeypatch.setattr(dc, "MAX_PENDING_DEVICE_CODES", 1)
+        assert client.post("/device_authorization", headers=auth_header).status_code == 200
+        resp = client.post("/device_authorization", headers=auth_header)
+        assert resp.status_code == 503
+        assert json.loads(resp.data)["error"] == "slow_down"

--- a/tests/test_public_clients.py
+++ b/tests/test_public_clients.py
@@ -769,3 +769,14 @@ class TestPublicClientDeviceFlow:
         )
         assert resp.status_code == 400
         assert json.loads(resp.data)["error"] == "invalid_grant"
+
+    def test_public_client_basic_header_is_rejected(self, client, public_client):
+        # RFC 8628 §3.1: a public client uses the client_id parameter, not Basic.
+        resp = client.post("/device_authorization", headers=_basic(PUBLIC_ID, "anything"))
+        assert resp.status_code == 401
+
+    def test_public_client_body_secret_is_rejected(self, client, public_client):
+        resp = client.post(
+            "/device_authorization", data={"client_id": PUBLIC_ID, "client_secret": "x"}
+        )
+        assert resp.status_code == 401

--- a/tests/test_public_clients.py
+++ b/tests/test_public_clients.py
@@ -670,9 +670,12 @@ class TestNonTokenEndpointAuthEnforcement:
         )
         assert resp.status_code == 401
 
-    def test_device_public_client_rejected(self, client, public_client):
+    def test_device_public_client_accepted(self, client, public_client):
+        # #255: a public client presents client_id alone at the device
+        # authorization endpoint (RFC 8628 §3.1), no secret.
         resp = client.post("/device_authorization", data={"client_id": PUBLIC_ID})
-        assert resp.status_code == 401
+        assert resp.status_code == 200
+        assert "device_code" in json.loads(resp.data)
 
     # positive: a client_secret_post client authenticates over the BODY (the
     # channel its registered method names) at each endpoint.
@@ -718,3 +721,51 @@ class TestNonTokenEndpointAuthEnforcement:
         )
         assert resp.status_code == 200
         assert "device_code" in json.loads(resp.data)
+
+
+class TestPublicClientDeviceFlow:
+    """#255: a public client completes the device flow end to end (RFC 8628),
+    presenting client_id alone at the device authorization endpoint (§3.1) and
+    at the token endpoint (§3.4) - no secret anywhere. The device_code is bound
+    to that client_id, which is what stands in for client authentication."""
+
+    _GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+
+    def _authorize(self, client, user_code):
+        return client.post(
+            "/device",
+            data={
+                "user_code": user_code,
+                "username": "admin",
+                "password": "admin",
+                "action": "authorize",
+            },
+        )
+
+    def test_public_client_completes_the_device_flow(self, client, public_client):
+        # 1. device authorization with client_id alone
+        resp = client.post("/device_authorization", data={"client_id": PUBLIC_ID})
+        assert resp.status_code == 200, resp.data
+        data = json.loads(resp.data)
+        # 2. user approves
+        assert self._authorize(client, data["user_code"]).status_code == 200
+        # 3. poll the token endpoint with client_id alone, no secret
+        resp = client.post(
+            "/token",
+            data={"grant_type": self._GRANT, "device_code": data["device_code"], "client_id": PUBLIC_ID},
+        )
+        assert resp.status_code == 200, resp.data
+        assert "access_token" in json.loads(resp.data)
+
+    def test_device_code_is_bound_to_the_issuing_public_client(self, client, public_client):
+        # a device_code issued to the public client cannot be polled by another
+        resp = client.post("/device_authorization", data={"client_id": PUBLIC_ID})
+        data = json.loads(resp.data)
+        self._authorize(client, data["user_code"])
+        resp = client.post(
+            "/token",
+            data={"grant_type": self._GRANT, "device_code": data["device_code"]},
+            headers=_basic("demo-client", "demo-secret"),
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_grant"


### PR DESCRIPTION
Third and last follow-up for 3.0.0. **Additive** (enables a capability). Closes #255.

**What.** A public client (`token_endpoint_auth_method: "none"`) can now use the device authorization grant. RFC 8628 §3.1/§3.4 contemplate exactly this: a public CLI/TV/IoT-style client presents its `client_id` alone at `/device_authorization` and again when polling `/token`, with no secret. #188 shipped public clients for authorization_code + PKCE; this completes the pair. (#262 had made the confidential-only refusal explicit, with a pointer here.)

**How it works.** The core change is the `/device_authorization` auth gate: a public client is accepted by `client_id` alone (and RFC 8628 §3.1-precisely: presenting HTTP Basic or a `client_secret` is rejected), the same shape as `/revoke`'s relaxation. Everything else on the flow already worked:
- the issued `device_code` is bound to the `client_id`, and the store's `poll()` enforces it (`WRONG_CLIENT`);
- the `/token` client-auth boundary (#188) already lets a public client through the non-`client_credentials` device grant.

Confidential clients still authenticate with their registered method (via `_enforce_registered_client_auth`). No PKCE (not part of the device grant).

**Bounded state (the abuse item #255 scoped).** Because a public client can now create device authorizations with its `client_id` alone, `DeviceCodeStore` is capacity-bounded (`MAX_PENDING_DEVICE_CODES = 10000`): at the cap `create()` raises `DeviceCodeStoreFull` and the endpoint returns a plain `503` with `Retry-After` (not an OAuth error code - RFC 6749 §5.2 has no registered code for saturation, and `slow_down` is the token endpoint's polling signal), refusing new authorizations rather than growing without bound or evicting a live one.

**Tests.**
- The #262 public-device rejection test is flipped to accept (`200` + `device_code`).
- A full public device flow: `device_authorization` -> approve at `/device` -> poll `/token`, `client_id` only, no secret -> `access_token`.
- A binding test: a `device_code` issued to the public client cannot be redeemed by another client (`invalid_grant`); Basic and a body secret on a public client are each rejected (`401`); the store raises at capacity and the endpoint returns a plain `503` (no fabricated OAuth error).
- **e2e**: `e2e/test_agent.py` gains `test_public_client_device_flow` against the bundled `mcp-public-client` - verified live, **OAuth2/OIDC 27/27, TOTAL 61/61**.
- Unit suite **1850**, `ruff` and `mypy` clean. The #262 CHANGELOG note is corrected (`/device_authorization` now accepts public clients).
