### PR TITLE
fix: /api/users/<u>/token honours #73 client binding (access-point parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,11 @@ previous leniency allowed - needs a one-time adjustment.
   tool gains an optional `client_id` (which must name a real client) that binds
   the minted token and issues a refresh token spendable by it; without it the
   tool mints an unbound access token with no refresh token at all, rather than
-  hand back one that could not be spent.
+  hand back one that could not be spent. The HTTP testing endpoint
+  `POST /api/users/<username>/token` gets the same treatment - a new optional
+  `client_id` binds the token, and it no longer returns a `refresh_token` when
+  unbound - so all three token minters (a grant, the MCP tool, this endpoint)
+  agree.
 
 ### Added
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`

--- a/book/src/reference/endpoints.md
+++ b/book/src/reference/endpoints.md
@@ -42,7 +42,7 @@ covered in [SAML options](saml.md).
 | `GET /api/health` | Health check |
 | `GET /api/users` | List users |
 | `GET /api/users/{username}` | Get user details |
-| `POST /api/users/{username}/token` | Generate token |
+| `POST /api/users/{username}/token` | Generate a token for a user (testing). Optional JSON body: `exp_minutes`, and `client_id` (must name a real client) which binds the token and issues a spendable `refresh_token`; without `client_id` the response is an access token only (no `refresh_token`, since one with no client binding is refused since 3.0, #73). |
 | `GET /api/audit` | Get audit log |
 | `GET /api/audit/stats` | Audit log statistics |
 | `POST /api/audit/clear` | Clear the audit log |

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -79,7 +79,18 @@ def generate_token(username: str) -> ResponseReturnValue:
     if not user:
         return jsonify({"error": "User not found"}), 404
 
-    exp_minutes = request.json.get("exp_minutes", config.settings.token_expiry_minutes) if request.is_json else config.settings.token_expiry_minutes
+    body = request.get_json(silent=True) or {}
+    exp_minutes = body.get("exp_minutes", config.settings.token_expiry_minutes)
+
+    # Optional client binding (#73), mirroring the MCP generate_token tool: a
+    # given client_id (which must name a real client) binds the token and issues
+    # a spendable refresh token; without it the token is unbound and NO refresh
+    # token is issued - since 3.0 a refresh token with no client_id binding is
+    # refused, so returning one from this testing endpoint would be a dead
+    # credential.
+    client_id = body.get("client_id")
+    if client_id is not None and config.get_client(client_id) is None:
+        return jsonify({"error": f"Client '{client_id}' not found"}), 400
 
     token_service = get_token_service()
     # Same effective-issuer resolution as /token and discovery (#133): a
@@ -89,6 +100,8 @@ def generate_token(username: str) -> ResponseReturnValue:
         user=user,
         exp_minutes=exp_minutes,
         issuer=effective_issuer(config.settings),
+        client_id=client_id,
+        issue_refresh_token=client_id is not None,
     )
 
     return jsonify(token_response)

--- a/tests/test_issuer_from_request.py
+++ b/tests/test_issuer_from_request.py
@@ -348,3 +348,38 @@ class TestApiGenerateTokenIssuer:
             self._minted_iss(client, "evil.example.com")
             == get_config().settings.issuer
         )
+
+
+class TestApiGenerateTokenBinding:
+    """/api/users/<u>/token mirrors the MCP generate_token tool for #73: an
+    unbound token (no client_id) gets no refresh token, since a refresh token
+    with no client_id binding is refused; a client_id (which must be a real
+    client) binds it so the refresh token is actually spendable."""
+
+    def test_unbound_token_has_no_refresh_token(self, client):
+        resp = client.post("/api/users/admin/token")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert "access_token" in data
+        assert "refresh_token" not in data
+
+    def test_bound_token_refresh_is_spendable(self, client):
+        import base64
+
+        resp = client.post("/api/users/admin/token", json={"client_id": "demo-client"})
+        assert resp.status_code == 200
+        rt = json.loads(resp.data)["refresh_token"]
+        header = {
+            "Authorization": "Basic " + base64.b64encode(b"demo-client:demo-secret").decode()
+        }
+        refreshed = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": rt},
+            headers=header,
+        )
+        assert refreshed.status_code == 200, refreshed.data
+
+    def test_unknown_client_id_is_rejected(self, client):
+        resp = client.post("/api/users/admin/token", json={"client_id": "does-not-exist"})
+        assert resp.status_code == 400
+        assert "does-not-exist" in json.loads(resp.data)["error"]


### PR DESCRIPTION
Access-point parity gap found while auditing whether #73 (`refresh token needs a client_id binding`) reached every token minter.

**The gap.** `#73` / PR #269 fixed the MCP `generate_token` tool (optional `client_id`, no refresh token when unbound) but its **HTTP twin** - `POST /api/users/<username>/token`, which the dashboard Token Tester (`test.html`) and the per-user "generate token" button (`users.html`) call - still minted via `create_token` with no `client_id`. So it kept returning a `refresh_token` that #73 now refuses on use: a dead credential.

**Fix.** Mirror the MCP tool exactly:
- optional `client_id` in the JSON body, which **must name a real client** (else `400`);
- `issue_refresh_token = client_id is not None`, so an unbound token gets an access token with **no** refresh token, and a bound one gets a spendable refresh token.

**No caller breaks.** The e2e agent (`test_api_direct_token`) and both UI callers only read `access_token`; none reference `refresh_token`.

**Tests.** `TestApiGenerateTokenBinding`: unbound -> no `refresh_token`; bound (`client_id`) -> the refresh token actually works on `/token` (200); unknown `client_id` -> `400`. Existing `/api/users/<u>/token` issuer tests unaffected. `ruff`/`mypy` clean.

Small, independent of the 3.0.0 device-flow PR; goes into 3.0.0 with the rest.