### PR TITLE
chore: bump to 3.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "2.8.0"
+version = "3.0.0rc1"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
First release candidate of the 3.0 cycle - the OAuth/MCP interoperability foundation, now with breaking client-authentication changes.

- `pyproject` version `2.8.0` -> `3.0.0rc1` (PEP 440).
- CHANGELOG stays under `[Unreleased]` (consolidated into `[3.0.0]` at the final, per the project's rc policy); the breaking changes and migration notes are already there.

The tag `v3.0.0-rc1` is cut on the merge commit: a hyphenated pre-release tag, so GHCR `:latest` stays on `v2.8.0` and plain `pip install nanoidp` keeps resolving `2.8.0`; `--pre`/an exact pin gets the rc. Built `nanoidp-3.0.0rc1` wheel smoke-tests clean (version banner 3.0.0rc1, `--help`, `nanoidp-mcp`, init, startup, `/api/health`, discovery).