### PR TITLE
feat: per-client horizontal /authorize login layout (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ previous leniency allowed - needs a one-time adjustment.
   hand back one that could not be spent.
 
 ### Added
+- **Horizontal `/authorize` login card composition** (#249). New per-client
+  `layout` field, `"vertical"` (default, unchanged) or `"horizontal"`: the
+  latter places the client info block and the login form side by side in a
+  Bootstrap two-column split, with the header and footer still full width,
+  collapsing back to the single-column stack on narrow viewports. One of
+  exactly two nanoidp-owned layouts - no per-client CSS or column widths.
+  Full support across settings.yaml, the UI client form, and the MCP
+  `create_client`/`update_client` tools; omitted (or `"vertical"`) writes
+  nothing to YAML, matching every other default-valued client field.
 - **Mock protected MCP server as an e2e fixture** (#191). `e2e/mock_mcp_server.py`
   is a minimal MCP Streamable HTTP resource server (the `mcp` SDK's
   resource-server mode) with three scope-gated tools (`read_document` /

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -281,6 +281,9 @@ oauth:
       footer_color: "#e8f4f8"      # optional; hex only, the card's footer band
       show_client_id: true         # optional; default true
       show_description: true       # optional; default false
+      layout: "horizontal"         # optional; "vertical" (default) or "horizontal" (#249):
+                                    # horizontal places the client info and login form side by
+                                    # side, collapsing back to a single column on narrow viewports
     - client_id: "scoped-client"
       client_secret: "secret"
       description: "Client restricted to a scope subset"
@@ -476,6 +479,13 @@ or markup, and a logo is a local file, never a remote URL. To add a logo,
 drop an image at `<logos_dir>/<client_id>.{svg,png,jpg,jpeg,webp}` (default
 `logos_dir`: `src/nanoidp/static/logos`, overridable via `oauth.logos_dir`);
 it's picked up by filename, no config entry needed.
+
+`layout` (#249) controls the card's composition: `"vertical"` (default) is
+the single-column card - header, client info, then the login form, footer;
+`"horizontal"` places the client info and the login form side by side, with
+the header and footer still full width, collapsing back to the vertical
+stack on narrow viewports. It's one of exactly two nanoidp-owned layouts,
+not a general styling knob - there's no per-client CSS or column widths.
 
 To preview a client's branded login page, open `/authorize` with its
 `client_id` and a `redirect_uri` (any syntactically valid URL works unless

--- a/docs/schema/config.v1.json
+++ b/docs/schema/config.v1.json
@@ -148,6 +148,15 @@
             "default": null,
             "title": "Header Color"
           },
+          "layout": {
+            "default": "vertical",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ],
+            "title": "Layout",
+            "type": "string"
+          },
           "redirect_uris": {
             "default": null,
             "title": "Redirect Uris"

--- a/e2e/test_agent.py
+++ b/e2e/test_agent.py
@@ -1468,7 +1468,60 @@ class NanoIDPTestAgent:
                 "footer_color": "#654321" in html,
                 "client_id_shown": test_client_id in html,
                 "description_shown": test_description in html,
+                # #249: the default ("vertical") layout must not render the
+                # horizontal two-column markup. The CSS selector for that
+                # class lives in every page's <style> block regardless of
+                # layout, so this checks the rendered class attribute, not
+                # a bare substring match.
+                "vertical_has_no_horizontal_markup": (
+                    'class="authorize-card authorize-card-horizontal"' not in html
+                ),
             }
+
+            # #249: a client with layout=horizontal renders the two-column
+            # composition. Same create/authorize/delete shape as above, kept
+            # as a second client so the default-layout assertion above stays
+            # a clean negative check.
+            horizontal_client_id = f"branding-horizontal-{secrets.token_hex(4)}"
+            try:
+                create_h = self.session.post(
+                    f"{self.base_url}/clients/create",
+                    data={
+                        "client_id": horizontal_client_id,
+                        "client_secret": "branding-test-secret",
+                        "layout": "horizontal",
+                    },
+                    allow_redirects=False,
+                    timeout=5,
+                )
+                created_h = (
+                    create_h.status_code in (302, 303)
+                    and create_h.headers.get("Location", "").rstrip("/").endswith("/clients")
+                )
+                checks["horizontal_client_created"] = created_h
+                if created_h:
+                    authorize_h = requests.get(
+                        f"{self.base_url}/authorize",
+                        params={
+                            "response_type": "code",
+                            "client_id": horizontal_client_id,
+                            "redirect_uri": "http://localhost:3000/callback",
+                        },
+                        timeout=5,
+                    )
+                    html_h = authorize_h.text
+                    checks["horizontal_has_two_column_markup"] = (
+                        authorize_h.status_code == 200
+                        and 'class="authorize-card authorize-card-horizontal"' in html_h
+                        and "col-md-6" in html_h
+                    )
+                else:
+                    checks["horizontal_has_two_column_markup"] = False
+            finally:
+                self.session.post(
+                    f"{self.base_url}/clients/{horizontal_client_id}/delete", timeout=5
+                )
+
             success = authorize.status_code == 200 and all(checks.values())
             return self._add_result(
                 "Client Branding", TestCategory.OAUTH, success,

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -81,6 +81,8 @@ class ClientEntry(BaseModel):
     token_endpoint_auth_method: Literal[
         "client_secret_basic", "client_secret_post", "none"
     ] = "client_secret_basic"
+    # Same closed-enum reasoning as token_endpoint_auth_method above (#249).
+    layout: Literal["vertical", "horizontal"] = "vertical"
     description: str = ""
     background_color: Optional[str] = None
     header_color: Optional[str] = None
@@ -99,6 +101,7 @@ class ClientEntry(BaseModel):
             # ('none'), rejected by the model for a confidential one (#188).
             client_secret=self.client_secret or None,
             token_endpoint_auth_method=self.token_endpoint_auth_method,
+            layout=self.layout,
             description=self.description,
             background_color=self.background_color,
             header_color=self.header_color,

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -247,6 +247,17 @@ def _normalize_auth_method(value: Any) -> str:
     return str(value)
 
 
+_LAYOUTS = ("vertical", "horizontal")
+
+
+def _normalize_layout(value: Any) -> str:
+    """Pre-validate layout before any assignment (#249), same
+    pre-validation principle as token_endpoint_auth_method above."""
+    if value not in _LAYOUTS:
+        raise ValueError("layout must be one of " + ", ".join(_LAYOUTS))
+    return str(value)
+
+
 def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
     """Convert OAuthClient to dictionary (without secret)."""
     return {
@@ -258,6 +269,7 @@ def _client_to_dict(client: OAuthClient) -> dict[str, Any]:
         "footer_color": client.footer_color,
         "show_client_id": client.show_client_id,
         "show_description": client.show_description,
+        "layout": client.layout,
         "additional_audiences": client.additional_audiences,
         "redirect_uris": client.redirect_uris,
         "allowed_scopes": client.allowed_scopes,
@@ -692,6 +704,11 @@ _TOOLS: list[Tool] = [
                     "type": "boolean",
                     "description": "Show description on the /authorize login page (optional, default false)",
                 },
+                "layout": {
+                    "type": "string",
+                    "enum": ["vertical", "horizontal"],
+                    "description": "/authorize login card composition (#249): 'vertical' (default) is the single-column card; 'horizontal' places the client info and the login form side by side, collapsing back to a single column on narrow viewports (optional, default vertical)",
+                },
                 "additional_audiences": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -764,6 +781,11 @@ _TOOLS: list[Tool] = [
                 "show_description": {
                     "type": "boolean",
                     "description": "Show description on the /authorize login page (optional)",
+                },
+                "layout": {
+                    "type": "string",
+                    "enum": ["vertical", "horizontal"],
+                    "description": "/authorize login card composition (#249): 'horizontal' places the client info and the login form side by side, collapsing back to a single column on narrow viewports (optional)",
                 },
                 "additional_audiences": {
                     "type": "array",
@@ -1475,6 +1497,7 @@ def _tool_create_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         footer_color=_normalize_hex_color(arguments.get("footer_color"), "footer_color"),
         show_client_id=arguments.get("show_client_id", True),
         show_description=arguments.get("show_description", False),
+        layout=_normalize_layout(arguments.get("layout", "vertical")),  # type: ignore[arg-type]
         additional_audiences=_normalize_audiences(arguments.get("additional_audiences")),
         redirect_uris=_normalize_str_list(arguments.get("redirect_uris"), "redirect_uris"),
         allowed_scopes=_normalize_str_list(arguments.get("allowed_scopes"), "allowed_scopes"),
@@ -1512,6 +1535,9 @@ def _tool_update_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         _normalize_str_list(arguments["allowed_resources"], "allowed_resources")
         if "allowed_resources" in arguments
         else None
+    )
+    new_layout = (
+        _normalize_layout(arguments["layout"]) if "layout" in arguments else None
     )
     new_background_color = (
         _normalize_hex_color(arguments["background_color"], "background_color")
@@ -1577,6 +1603,8 @@ def _tool_update_client(arguments: dict[str, Any], config: ConfigManager) -> dic
         client.show_client_id = arguments["show_client_id"]
     if "show_description" in arguments:
         client.show_description = arguments["show_description"]
+    if new_layout is not None:
+        client.layout = new_layout  # type: ignore[assignment]
     if new_audiences is not None:
         client.additional_audiences = new_audiences
     if new_redirect_uris is not None:

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -232,6 +232,19 @@ class OAuthClient(BaseModel):
             "aud at oauth.audience."
         ),
     )
+    layout: Literal["vertical", "horizontal"] = Field(
+        default="vertical",
+        description=(
+            "/authorize login card composition (issue #249). 'vertical' "
+            "(default) is the single-column card: header, client block "
+            "(logo, client id, description, scope badges), the form, "
+            "footer. 'horizontal' places the client block and the form "
+            "side by side, header and footer still full width; it "
+            "collapses back to the vertical stack on narrow viewports. "
+            "One of two nanoidp-owned layouts - not a general styling "
+            "knob, so there is no per-client CSS or markup here."
+        ),
+    )
 
     @model_validator(mode="after")
     def _confidential_clients_need_a_secret(self) -> "OAuthClient":

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -463,6 +463,7 @@ def client_create() -> ResponseReturnValue:
             client_id=client_id,
             client_secret=client_secret,
             token_endpoint_auth_method=auth_method,  # type: ignore[arg-type]
+            layout=request.form.get("layout", "vertical"),  # type: ignore[arg-type]
             description=request.form.get("description", ""),
             background_color=request.form.get("background_color") or None,
             header_color=request.form.get("header_color") or None,
@@ -546,6 +547,7 @@ def client_edit(client_id: str) -> ResponseReturnValue:
             client_id=client_id,
             client_secret=client_secret,
             token_endpoint_auth_method=auth_method,  # type: ignore[arg-type]
+            layout=request.form.get("layout", client.layout),  # type: ignore[arg-type]
             description=request.form.get("description", ""),
             background_color=request.form.get("background_color") or None,
             header_color=request.form.get("header_color") or None,

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -275,6 +275,8 @@ def client_to_yaml(client: OAuthClient) -> Dict[str, Any]:
         entry["client_secret"] = _quoted(client.client_secret)
     if client.token_endpoint_auth_method != "client_secret_basic":
         entry["token_endpoint_auth_method"] = client.token_endpoint_auth_method
+    if client.layout != "vertical":
+        entry["layout"] = client.layout
     entry["description"] = _quoted(client.description)
     if client.background_color:
         entry["background_color"] = client.background_color
@@ -336,6 +338,13 @@ def merge_client_entry(raw_entry: Dict[str, Any], client: OAuthClient) -> Dict[s
             updated["token_endpoint_auth_method"] = client.token_endpoint_auth_method
         else:
             updated.pop("token_endpoint_auth_method", None)
+
+    # Same "default-valued scalar" shape (#249).
+    if not is_unchanged(raw_entry.get("layout"), client.layout):
+        if client.layout != "vertical":
+            updated["layout"] = client.layout
+        else:
+            updated.pop("layout", None)
 
     for field_name, new_bool_value, default_value in (
         ("show_client_id", client.show_client_id, True),

--- a/src/nanoidp/templates/authorize.html
+++ b/src/nanoidp/templates/authorize.html
@@ -22,6 +22,12 @@
             border-radius: 1rem;
             box-shadow: 0 10px 40px rgba(0,0,0,0.3);
         }
+        /* Horizontal composition (issue #249): wider card so the two
+           Bootstrap columns below have room; col-md-6 already collapses
+           back to a single stacked column under the md breakpoint. */
+        .authorize-card.authorize-card-horizontal {
+            max-width: 760px;
+        }
         .authorize-header {
             background: {% if client and client.header_color %}{{ client.header_color }}{% else %}linear-gradient(135deg, #0d6efd 0%, #6610f2 100%){% endif %};
             color: #fff;
@@ -32,6 +38,20 @@
         .authorize-header i {
             font-size: 3rem;
             margin-bottom: 0.5rem;
+        }
+        /* Horizontal composition (#249): the stacked 3-line header (icon,
+           title, subtitle) is too tall next to the wider two-column body,
+           so it collapses to one row here instead. */
+        .authorize-card-horizontal .authorize-header {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            padding: 1rem 2rem;
+        }
+        .authorize-card-horizontal .authorize-header i {
+            font-size: 1.75rem;
+            margin-bottom: 0;
         }
         .authorize-body {
             padding: 2rem;
@@ -57,21 +77,7 @@
         }
     </style>
 </head>
-<body>
-    <div class="authorize-card">
-        <div class="authorize-header">
-            <i class="bi bi-shield-check"></i>
-            <h3 class="mb-0">NanoIDP</h3>
-            <small class="opacity-75">Authorization Request</small>
-        </div>
-        <div class="authorize-body">
-            {% if error %}
-            <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                <i class="bi bi-exclamation-triangle me-2"></i>{{ error }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-            {% endif %}
-
+{% macro client_info_block() %}
             <div class="client-info">
                 <div class="d-flex align-items-center mb-2">
                     {% if logo_url %}
@@ -107,7 +113,9 @@
                     </div>
                 </div>
             </div>
+{% endmacro %}
 
+{% macro login_form_block() %}
             {% if persona_mode %}
             <form method="POST">
                 {{ macros.persona_picker(users, "Persona login - select a user to authorize.") }}
@@ -128,6 +136,37 @@
                     <i class="bi bi-check-circle me-2"></i>Authorize
                 </button>
             </form>
+            {% endif %}
+{% endmacro %}
+
+{% set horizontal = client and client.layout == 'horizontal' %}
+<body>
+    <div class="authorize-card{% if horizontal %} authorize-card-horizontal{% endif %}">
+        <div class="authorize-header">
+            <i class="bi bi-shield-check"></i>
+            <h3 class="mb-0">NanoIDP</h3>
+            <small class="opacity-75">Authorization Request</small>
+        </div>
+        <div class="authorize-body">
+            {% if error %}
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <i class="bi bi-exclamation-triangle me-2"></i>{{ error }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+            {% endif %}
+
+            {% if horizontal %}
+            <div class="row g-4 align-items-center">
+                <div class="col-md-6">
+                    {{ client_info_block() }}
+                </div>
+                <div class="col-md-6">
+                    {{ login_form_block() }}
+                </div>
+            </div>
+            {% else %}
+            {{ client_info_block() }}
+            {{ login_form_block() }}
             {% endif %}
 
             <div class="authorize-footer text-center mt-3">

--- a/src/nanoidp/templates/clients_form.html
+++ b/src/nanoidp/templates/clients_form.html
@@ -184,6 +184,19 @@
                         <label class="form-check-label" for="show_description">Show description on login page</label>
                     </div>
 
+                    <div class="mb-3">
+                        <label for="layout" class="form-label">Login Page Layout</label>
+                        <select class="form-select" id="layout" name="layout">
+                            {% set current_layout = client.layout if client else 'vertical' %}
+                            <option value="vertical" {% if current_layout == 'vertical' %}selected{% endif %}>Vertical (single column)</option>
+                            <option value="horizontal" {% if current_layout == 'horizontal' %}selected{% endif %}>Horizontal (client info beside the form)</option>
+                        </select>
+                        <div class="form-text">
+                            Horizontal places the client info and the login form side by side; it collapses
+                            back to a single column on narrow screens.
+                        </div>
+                    </div>
+
                     <div class="alert alert-info" role="alert">
                         <i class="bi bi-info-circle me-2"></i>
                         <strong>Logo:</strong> To add a client logo to the login page, place an image file at

--- a/tests/test_client_contract.py
+++ b/tests/test_client_contract.py
@@ -51,6 +51,7 @@ FULL_A = OAuthClient(
     redirect_uris=["https://a.example/cb", "http://127.0.0.1:7001/cb"],
     allowed_scopes=["openid", "profile"],
     allowed_resources=["https://a.example/mcp", "https://a.example/api"],
+    layout="horizontal",
 )
 
 # A public client (#188): no secret at all. client_secret and
@@ -70,6 +71,7 @@ FULL_B = OAuthClient(
     redirect_uris=["https://b.example/cb"],
     allowed_scopes=["openid", "email", "groups"],
     allowed_resources=["https://b.example/mcp"],
+    layout="horizontal",
 )
 
 # Every field at its default except the two required ones.
@@ -138,9 +140,11 @@ class TestFixturesCoverTheModel:
 
     @pytest.mark.parametrize("name", sorted(set(OAuthClient.model_fields) - {"client_id"}))
     def test_full_a_and_full_b_differ_in_every_field(self, name):
-        if isinstance(getattr(FULL_A, name), bool):
-            # Both flip the default; a boolean cannot differ from the default
-            # in two ways. The way back to DEFAULTS covers the other value.
+        if isinstance(getattr(FULL_A, name), bool) or name == "layout":
+            # Both flip the default; a bool (or, for layout, the only other
+            # value of a two-valued literal, #249) cannot differ from the
+            # default in two ways. The way back to DEFAULTS covers the other
+            # value.
             return
         assert getattr(FULL_A, name) != getattr(FULL_B, name), name
 

--- a/tests/test_mcp_tool_branches.py
+++ b/tests/test_mcp_tool_branches.py
@@ -753,6 +753,55 @@ class TestPublicClientTools:
         assert mcp_config.get_client("branch-client").is_public is False
 
 
+class TestClientLayout:
+    """#249: layout is pre-validated before any assignment, same principle
+    as token_endpoint_auth_method in TestPublicClientTools above."""
+
+    @pytest.mark.asyncio
+    async def test_create_with_horizontal_layout(self, mcp_config, mcp_call_tool):
+        payload = _payload(
+            await mcp_call_tool(
+                "create_client",
+                {
+                    "client_id": "layout-mcp",
+                    "client_secret": "layout-secret",
+                    "layout": "horizontal",
+                },
+            )
+        )
+        assert payload["success"] is True
+        assert payload["client"]["layout"] == "horizontal"
+        assert mcp_config.get_client("layout-mcp").layout == "horizontal"
+
+    @pytest.mark.asyncio
+    async def test_update_sets_layout(self, mcp_config, mcp_call_tool):
+        payload = _payload(
+            await mcp_call_tool(
+                "update_client",
+                {"client_id": "branch-client", "layout": "horizontal"},
+            )
+        )
+        assert payload["success"] is True
+        assert mcp_config.get_client("branch-client").layout == "horizontal"
+
+    @pytest.mark.asyncio
+    async def test_invalid_layout_rejects_before_any_mutation(
+        self, mcp_config, mcp_call_tool
+    ):
+        result = await mcp_call_tool(
+            "update_client",
+            {
+                "client_id": "branch-client",
+                "description": "must-not-land",
+                "layout": "diagonal",
+            },
+        )
+        assert result.is_error is True
+        client = mcp_config.get_client("branch-client")
+        assert client.description != "must-not-land"
+        assert client.layout == "vertical"
+
+
 class TestDispatchGuards:
     @pytest.mark.asyncio
     async def test_readonly_mode_rejects_mutating_tool(


### PR DESCRIPTION

Adds OAuthClient.layout ("vertical" default, "horizontal"), following
the codebase's field-flow: model, config_documents, client_to_yaml/
merge_client_entry (omit-at-default, #127), the clients form, UI
create/edit routes, and the MCP create_client/update_client tools
(pre-validated before assignment, same rule as token_endpoint_auth_method).
authorize.html splits the client-info and login-form blocks into local
macros so horizontal can lay them out side by side in a Bootstrap
row/col-md-6 (collapses to vertical below md) while the header/footer
stay full width, with no new static asset.

Covers the imperative legs test_client_field_parity.py doesn't reach:
extends the parametric test_client_contract.py fixtures, adds
TestClientLayout to test_mcp_tool_branches.py, and extends
e2e/test_agent.py's Client Branding check to assert the two-column
markup for horizontal and its absence for vertical. Regenerates
docs/schema/config.v1.json and documents the field in
configuration.md and the CHANGELOG.
