### PR TITLE
fix: cross-entry-point consistency for the 3.0 clean base (#275-#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,43 @@ previous leniency allowed - needs a one-time adjustment.
   `client_id` binds the token, and it no longer returns a `refresh_token` when
   unbound - so all three token minters (a grant, the MCP tool, this endpoint)
   agree.
+- **One request, one client identity** (#277). `/introspect`, `/revoke` and
+  `/device_authorization` now resolve the requesting client exactly as
+  `/token` always has: HTTP Basic naming client A plus `client_id=B` in the
+  body is one request claiming two identities and is rejected with
+  `invalid_client` (previously the Basic username silently won and the body
+  value was ignored). *Migration:* drop the contradictory body `client_id`,
+  or make it match the authenticated client.
+- **The `device_code` grant re-validates the stored scope at redemption**
+  (#276): a scope removed from the client's `allowed_scopes` (or from
+  `scopes_supported`) between `/device_authorization` and the poll now fails
+  the poll with `invalid_scope`, exactly as the `authorization_code` and
+  `refresh_token` grants already re-check theirs. Previously the stale scope
+  was still minted.
+- **`/saml/attribute-query` answers an unknown NameID with a SAML error
+  status** (#275): top-level `Requester` with subordinate `UnknownPrincipal`,
+  no assertion. Previously an unknown user got a **signed assertion with
+  fabricated attributes** (`<user>@example.com`, `identity_class: INTERNAL`,
+  `entitlements: DOCUMENT_READ`) - an SP under test would pass with data
+  nanoidp invented. The endpoint's docs now also state plainly that it is
+  unauthenticated by design (the same read model as the REST API, #163):
+  it previously claimed "after JWT authentication", which the code never did.
+
+### Changed
+- `TokenService.create_token` now owns the #73 mint-side rule (#278):
+  `issue_refresh_token` defaults to "only when the token is bound"
+  (`client_id` given), and asking for a refresh token without a binding
+  raises instead of minting a credential `/token` would reject. The three
+  minting surfaces (grants, MCP `generate_token`,
+  `POST /api/users/<username>/token`) behave as before; the rule just lives
+  in one place.
+- The MCP `generate_token` and `verify_token` tool descriptions now document
+  their simulation boundary (#279): `generate_token` stamps `scope` and
+  `resource` as given with no vocabulary check and no per-client ceiling
+  (minting an out-of-ceiling token is how a resource server's rejection path
+  gets tested), and `verify_token` checks signature/expiry like a stateless
+  resource server - revocation is `/introspect`'s answer. Behavior is
+  unchanged; both exemptions are now pinned by tests.
 
 ### Added
 - **Horizontal `/authorize` login card composition** (#249). New per-client

--- a/book/src/reference/endpoints.md
+++ b/book/src/reference/endpoints.md
@@ -30,10 +30,17 @@ in the tokens - see [Tokens and claims](tokens.md#where-do-the-email--profile-cl
 | `GET /saml/metadata` | IdP Metadata |
 | `GET /saml/cert.pem` | IdP signing certificate (PEM) |
 | `GET/POST /saml/sso` | Single Sign-On (supports both HTTP-POST and HTTP-Redirect bindings) |
-| `POST /saml/attribute-query` | Attribute Query |
+| `POST /saml/attribute-query` | Attribute Query (SOAP, backend-to-backend) |
 
 Bindings, strict-binding mode, response signing, and canonicalization are
 covered in [SAML options](saml.md).
+
+`/saml/attribute-query` is **unauthenticated by design** - the same model as
+the REST read surfaces (reads are never gated): nanoidp is a testing IdP and
+its user directory is test data. On a shared instance, anyone who can reach
+the endpoint can read any configured user's attributes; deploy accordingly.
+An unknown NameID gets a SAML error status (`Requester`/`UnknownPrincipal`),
+never a fabricated assertion.
 
 ## REST API
 

--- a/e2e/test_agent.py
+++ b/e2e/test_agent.py
@@ -1938,11 +1938,22 @@ class NanoIDPTestAgent:
                 active = data.get("active", False)
                 username = data.get("username", "?")
                 scope = data.get("scope", "?")
+                # #277 negative: Basic for this client plus a CONTRADICTORY
+                # body client_id is one request claiming two identities and
+                # must be invalid_client, not silently processed as the
+                # Basic identity (the pre-3.0 behavior).
+                mismatch = self.session.post(
+                    f"{self.base_url}/introspect",
+                    data={"token": self.access_token, "client_id": "not-this-client"},
+                    timeout=5,
+                )
+                mismatch_rejected = mismatch.status_code == 401
                 return self._add_result(
                     "Token Introspection",
                     TestCategory.OAUTH,
-                    active,
-                    f"active={active}, user={username}, scope={scope}",
+                    active and mismatch_rejected,
+                    f"active={active}, user={username}, scope={scope}; "
+                    f"contradictory body client_id rejected: {mismatch_rejected}",
                     data
                 )
             return self._add_result(
@@ -2611,12 +2622,32 @@ class NanoIDPTestAgent:
             if response.status_code == 200:
                 is_xml = "xml" in response.headers.get("Content-Type", "") or response.text.strip().startswith("<")
                 has_attributes = "Attribute" in response.text
+
+                # #275 negative: an unknown NameID must get a SAML error
+                # status (Requester/UnknownPrincipal) with NO assertion,
+                # never the old fabricated-attributes fallback.
+                unknown_query = attr_query.replace(
+                    f"<saml:NameID>{self.username}</saml:NameID>",
+                    "<saml:NameID>no-such-user-e2e</saml:NameID>",
+                )
+                unknown_resp = requests.post(
+                    f"{self.base_url}/saml/attribute-query",
+                    data=unknown_query,
+                    headers={"Content-Type": "application/xml"},
+                    timeout=5,
+                )
+                unknown_ok = (
+                    unknown_resp.status_code == 200
+                    and "UnknownPrincipal" in unknown_resp.text
+                    and "Assertion" not in unknown_resp.text
+                )
                 return self._add_result(
                     "SAML Attribute Query",
                     TestCategory.SAML,
-                    is_xml,
-                    f"Response received, has_attributes={has_attributes}",
-                    {"has_attributes": has_attributes}
+                    is_xml and unknown_ok,
+                    f"Response received, has_attributes={has_attributes}; "
+                    f"unknown NameID -> UnknownPrincipal without assertion: {unknown_ok}",
+                    {"has_attributes": has_attributes, "unknown_principal_error": unknown_ok}
                 )
 
             # Some implementations might not support this

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -506,7 +506,16 @@ _TOOLS: list[Tool] = [
     # Token Operations
     Tool(
         name="generate_token",
-        description="Generate an OAuth2 access token for a user",
+        description=(
+            "Generate an OAuth2 access token for a user. Mints the token "
+            "directly (a testing/simulation affordance, not an OAuth grant): "
+            "scope and resource are stamped as given, with no "
+            "scopes_supported vocabulary check and no per-client "
+            "allowed_scopes/allowed_resources ceiling even when client_id is "
+            "supplied - minting an out-of-ceiling token is how you test a "
+            "resource server's rejection path. The ceilings live on the "
+            "grant endpoints (/authorize, /device_authorization, /token)."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -600,7 +609,13 @@ _TOOLS: list[Tool] = [
     ),
     Tool(
         name="verify_token",
-        description="Verify a JWT token's signature and expiration",
+        description=(
+            "Verify a JWT token's signature and expiration. Simulates a "
+            "STATELESS resource server (the #191 model): it does not check "
+            "revocation or the token_use claim, so a revoked access token or "
+            "an ID Token presented as an access token still reports valid. "
+            "Revocation is /introspect's answer, not this tool's."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -1366,15 +1381,21 @@ def _tool_generate_token(arguments: dict[str, Any], config: ConfigManager) -> di
         user=user,
         exp_minutes=arguments.get("expires_in_minutes", config.settings.token_expiry_minutes),
         extra_claims=arguments.get("extra_claims"),
+        # BOUNDARY (#279): like `resource` below, `scope` is passed through
+        # with no scopes_supported vocabulary check and no allowed_scopes
+        # ceiling, even when client_id is given - this tool mints a token
+        # directly (a testing / simulation affordance, not an OAuth grant),
+        # and an out-of-ceiling scope is exactly what testing a resource
+        # server's rejection path needs. The ceiling lives on the grant
+        # endpoints (resolve_scope at /authorize, /device_authorization and
+        # the /token grants), not on this admin tool.
         scope=arguments.get("scope"),
-        # Client binding (#73): with client_id, the token is bound and a
-        # refresh token is issued (spendable by that client). Without it the
-        # token is unbound and NO refresh token is issued at all - a refresh
-        # token with no client_id binding is refused since 3.0, so handing one
-        # back would be a dead credential. The unbound access token is still
-        # fine for a one-shot test.
+        # Client binding (#73): with client_id the token is bound and a
+        # spendable refresh token follows from the binding inside
+        # create_token itself (#278); unbound -> no refresh token (a refresh
+        # token with no client_id binding is refused since 3.0). The unbound
+        # access token is still fine for a one-shot test.
         client_id=client_id,
-        issue_refresh_token=client_id is not None,
         # _execute_tool is also reachable directly (see tests), bypassing
         # call_tool's input_schema validation; reject a non-list with a
         # clean error here too instead of minting a token whose malformed

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -83,11 +83,9 @@ def generate_token(username: str) -> ResponseReturnValue:
     exp_minutes = body.get("exp_minutes", config.settings.token_expiry_minutes)
 
     # Optional client binding (#73), mirroring the MCP generate_token tool: a
-    # given client_id (which must name a real client) binds the token and issues
-    # a spendable refresh token; without it the token is unbound and NO refresh
-    # token is issued - since 3.0 a refresh token with no client_id binding is
-    # refused, so returning one from this testing endpoint would be a dead
-    # credential.
+    # given client_id must name a real client. Whether a refresh token is
+    # issued follows from the binding inside create_token itself (#278):
+    # bound token -> spendable refresh token, unbound -> none.
     client_id = body.get("client_id")
     if client_id is not None and config.get_client(client_id) is None:
         return jsonify({"error": f"Client '{client_id}' not found"}), 400
@@ -101,7 +99,6 @@ def generate_token(username: str) -> ResponseReturnValue:
         exp_minutes=exp_minutes,
         issuer=effective_issuer(config.settings),
         client_id=client_id,
-        issue_refresh_token=client_id is not None,
     )
 
     return jsonify(token_response)

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -654,6 +654,43 @@ def _token_auth_failed(client_id: Optional[str], reason: str) -> ResponseReturnV
     return jsonify({"error": "invalid_client", "error_description": reason}), 401
 
 
+@dataclass(frozen=True)
+class _ClientIdentity:
+    """The client identity one request presents, resolved uniformly (#277)."""
+
+    auth: Optional[Any]
+    client_id: Optional[str]
+    body_client_secret: Optional[str]
+    # True when HTTP Basic and a body client_id name DIFFERENT clients - one
+    # request claiming two identities. Callers reject it as invalid_client.
+    mismatch: bool
+
+
+def _request_client_identity() -> _ClientIdentity:
+    """Resolve which client this request claims to be, one way for all four
+    client-facing endpoints (#277).
+
+    /token has always resolved body-first and rejected a Basic-vs-body
+    client_id mismatch; /introspect, /revoke and /device_authorization used
+    to resolve header-first and check nothing, so the same request meant
+    different things at different endpoints. The precedence is only
+    observable when the two disagree, and that is now uniformly an error -
+    what remains is one rule: a request names one client, through either
+    channel, and _enforce_registered_client_auth decides how it must prove it.
+    """
+    auth = request.authorization
+    body_client_id = request.form.get("client_id")
+    body_client_secret = request.form.get("client_secret") or None
+    client_id = body_client_id or (auth.username if auth else None)
+    mismatch = bool(auth and body_client_id and auth.username != body_client_id)
+    return _ClientIdentity(
+        auth=auth,
+        client_id=client_id,
+        body_client_secret=body_client_secret,
+        mismatch=mismatch,
+    )
+
+
 def _enforce_token_endpoint_auth(
     config: ConfigManager,
     grant_type: str,
@@ -766,15 +803,13 @@ def token() -> ResponseReturnValue:
     """OAuth2 token endpoint: shared validation, then per-grant dispatch."""
     config = get_config()
 
-    auth = request.authorization
     grant_type = request.form.get("grant_type", "client_credentials")
-    body_client_id = request.form.get("client_id")
     # client_secret_post (RFC 6749 §2.3.1, #188): discovery has always
-    # advertised it; the body secret is now actually validated instead of
-    # silently ignored.
-    body_client_secret = request.form.get("client_secret") or None
-    auth_client_id = auth.username if auth else None
-    client_id = body_client_id or auth_client_id
+    # advertised it; the body secret is validated, not silently ignored.
+    identity = _request_client_identity()
+    auth = identity.auth
+    body_client_secret = identity.body_client_secret
+    client_id = identity.client_id
 
     # Reject if client identity cannot be determined at all
     if not client_id:
@@ -787,13 +822,13 @@ def token() -> ResponseReturnValue:
         return abort(401, description="Client authentication required")
 
     # Reject if body client_id conflicts with the authenticated client in the header
-    if auth and body_client_id and auth.username != body_client_id:
+    if identity.mismatch:
         audit_event(
             "token_request",
             "failed",
             endpoint="/token",
-            client_id=auth.username,
-            details={"reason": "client_id mismatch", "body_client_id": body_client_id},
+            client_id=auth.username if auth else None,
+            details={"reason": "client_id mismatch", "body_client_id": client_id},
         )
         return abort(
             401, description="client_id in request body does not match authenticated client"
@@ -1080,13 +1115,17 @@ def introspect() -> ResponseReturnValue:
     # public clients (RFC 7662 §2.1: this endpoint must resist token scanning,
     # a public client_id is identification not authentication, and 'none' is
     # not in introspection_endpoint_auth_methods_supported).
-    auth = request.authorization
-    body_client_id = request.form.get("client_id")
-    body_client_secret = request.form.get("client_secret") or None
-    client_id = (auth.username if auth else None) or body_client_id
+    identity = _request_client_identity()
+    auth = identity.auth
+    body_client_secret = identity.body_client_secret
+    client_id = identity.client_id
     introspect_client = config.get_client(client_id) if client_id else None
-    if introspect_client is not None and introspect_client.is_public:
-        auth_error: Optional[str] = (
+    if identity.mismatch:
+        # One request, two claimed identities (#277) - same rejection as
+        # /token, where this check has always lived.
+        auth_error: Optional[str] = "client_id in request body does not match Basic username"
+    elif introspect_client is not None and introspect_client.is_public:
+        auth_error = (
             "public clients cannot authenticate to the introspection endpoint "
             "(RFC 7662 §2.1)"
         )
@@ -1191,17 +1230,23 @@ def revoke() -> ResponseReturnValue:
     # (token_endpoint_auth_method 'none', #188) is identified by client_id
     # alone, and the ownership check below is what stands in for
     # authentication (RFC 7009 §2.1).
-    auth = request.authorization
-    body_client_id = request.form.get("client_id")
-    body_client_secret = request.form.get("client_secret") or None
-    client_id = (auth.username if auth else None) or body_client_id
+    identity = _request_client_identity()
+    auth = identity.auth
+    body_client_secret = identity.body_client_secret
+    client_id = identity.client_id
     revoking_client = config.get_client(client_id) if client_id else None
     is_public = revoking_client is not None and revoking_client.is_public
 
     # A confidential client authenticates as at the token endpoint (#262):
     # registered method enforced, two auth methods in one request rejected.
-    if not is_public:
-        auth_error = _enforce_registered_client_auth(config, client_id, auth, body_client_secret)
+    # A mismatch between Basic and a body client_id is one request claiming
+    # two identities (#277) - rejected for public and confidential alike.
+    if identity.mismatch or not is_public:
+        auth_error = (
+            "client_id in request body does not match Basic username"
+            if identity.mismatch
+            else _enforce_registered_client_auth(config, client_id, auth, body_client_secret)
+        )
         if auth_error is not None:
             audit_event(
                 "revocation_request",
@@ -1369,18 +1414,22 @@ def device_authorization() -> ResponseReturnValue:
     # issued device_code is bound to that client_id and only it can poll for
     # the token, which is what stands in for client authentication here (the
     # same shape as /revoke's public relaxation).
-    auth = request.authorization
-    body_client_id = request.form.get("client_id")
-    body_client_secret = request.form.get("client_secret") or None
-    resolved_client_id = (auth.username if auth else None) or body_client_id
+    identity = _request_client_identity()
+    auth = identity.auth
+    body_client_secret = identity.body_client_secret
+    resolved_client_id = identity.client_id
     device_client = config.get_client(resolved_client_id) if resolved_client_id else None
-    if device_client is not None and device_client.is_public:
+    if identity.mismatch:
+        # One request, two claimed identities (#277) - same rejection as
+        # /token, for public and confidential clients alike.
+        auth_error: Optional[str] = "client_id in request body does not match Basic username"
+    elif device_client is not None and device_client.is_public:
         # RFC 8628 §3.1: a public client provides its client_id as a parameter,
         # not via HTTP Basic or a client_secret. The client_id is public, so
         # this is about using the right channel (as /token enforces the
         # registered method), not secrecy - presenting either is rejected.
         if auth is not None or body_client_secret is not None:
-            auth_error: Optional[str] = (
+            auth_error = (
                 "a public client presents its client_id as a parameter, without "
                 "HTTP Basic or a client_secret (RFC 8628 §3.1)"
             )

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -775,6 +775,46 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
         # The device flow authenticates an end-user, so honour the requested
         # scope and emit an ID Token when 'openid' was asked for (issue #36).
         # The user authenticated at /device, not at this poll (#42).
+        #
+        # Re-validate the stored scope against the CURRENT vocabulary and
+        # this client's allowed_scopes (#276): both may have changed between
+        # /device_authorization and this poll, exactly as they may change
+        # between /authorize and code redemption - the authorization_code and
+        # refresh grants both re-check for that reason, and this grant redeems
+        # a prior authorization the same way. validate_only=True: an absent
+        # stored scope stays absent, never defaulted (#186 review, B1).
+        device_scope: Optional[str] = grant.scope
+        device_client = ctx.config.get_client(ctx.client_id)
+        if device_client is not None:
+            scope_result = resolve_scope(
+                device_scope,
+                device_client,
+                ctx.config.settings.scopes_supported,
+                ctx.config.settings.scope_enforcement_active,
+                validate_only=True,
+            )
+            if not scope_result.ok:
+                audit_event(
+                    "token_request",
+                    "failed",
+                    endpoint="/token",
+                    username=user.username,
+                    client_id=ctx.client_id,
+                    details={
+                        "reason": scope_result.error_description,
+                        "grant_type": ctx.grant_type,
+                    },
+                )
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_scope",
+                            "error_description": scope_result.error_description,
+                        }
+                    ),
+                    400,
+                )
+            device_scope = scope_result.granted
         resource, resource_error = _resolve_token_resource(
             ctx, ctx.config.get_client(ctx.client_id), grant.resource or []
         )
@@ -783,7 +823,7 @@ def _grant_device_code(ctx: _GrantContext) -> GrantResult:
         return _GrantOutcome(
             user=user,
             username=user.username,
-            scope=grant.scope,
+            scope=device_scope,
             auth_time=grant.auth_time,
             resource=resource,
             # Full original grant on the refresh token (RFC 8707 §2.2).

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -960,6 +960,12 @@ def attribute_query() -> ResponseReturnValue:
                 request_id=request_id,
                 issuer_url=effective_saml_entity_id(config.settings),
             )
+            # Same signing path as the success response (#289 review): with
+            # saml_sign_responses on, an SP validating signatures must never
+            # meet the one response shape nanoidp forgot to sign.
+            error_xml = _sign_attribute_query_response(
+                error_xml, config.settings.saml_sign_responses
+            )
             audit_event(
                 "saml_attribute_query",
                 "failed",

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -700,6 +700,36 @@ def sso() -> ResponseReturnValue:
     return _sso_success_response(config, user, username, acs_url, in_response_to, relay_state)
 
 
+def _build_attribute_query_error_response(request_id: str, issuer_url: str) -> str:
+    """A SAML error Response for an AttributeQuery naming an unknown principal.
+
+    Top-level status Requester with subordinate UnknownPrincipal (SAML 2.0
+    Core §3.2.2.2), no assertion. Until #275 an unknown NameID got a SIGNED
+    assertion with fabricated attributes (email `<user>@example.org`-style,
+    default entitlements) - a trap for the SP under test, which would pass
+    with data nanoidp made up about a principal that does not exist.
+    """
+    now = datetime.now(timezone.utc)
+    SAML2_NS = "urn:oasis:names:tc:SAML:2.0:assertion"
+    SAML2P_NS = "urn:oasis:names:tc:SAML:2.0:protocol"
+    response = etree.Element(
+        f"{{{SAML2P_NS}}}Response",
+        nsmap={"saml2p": SAML2P_NS, "saml2": SAML2_NS},
+        ID=f"_{uuid.uuid4().hex}",
+        Version="2.0",
+        IssueInstant=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        InResponseTo=request_id,
+    )
+    issuer_el = etree.SubElement(response, f"{{{SAML2_NS}}}Issuer")
+    issuer_el.text = issuer_url
+    status = etree.SubElement(response, f"{{{SAML2P_NS}}}Status")
+    status_code = etree.SubElement(status, f"{{{SAML2P_NS}}}StatusCode")
+    status_code.set("Value", "urn:oasis:names:tc:SAML:2.0:status:Requester")
+    sub_code = etree.SubElement(status_code, f"{{{SAML2P_NS}}}StatusCode")
+    sub_code.set("Value", "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal")
+    return etree.tostring(response, pretty_print=False).decode("utf-8")
+
+
 def _build_attribute_query_response(
     user_id: str, attributes: dict, request_id: str, issuer_url: str
 ) -> str:
@@ -836,10 +866,19 @@ def attribute_query() -> ResponseReturnValue:
     """
     SAML 2.0 AttributeQuery endpoint (Backend-to-Backend).
 
-    This endpoint implements SAML AttributeQuery for backend-to-backend
-    attribute fetching after JWT authentication. It returns user attributes
-    including core fields (identity_class, entitlements, source_acl) and
-    any custom attributes defined in the user configuration.
+    Returns user attributes - core fields (identity_class, entitlements,
+    source_acl) and any custom attributes from the user configuration - for
+    the NameID in the query.
+
+    UNAUTHENTICATED BY DESIGN (#275): this endpoint verifies nothing about
+    the caller - no signature on the query, no JWT, no secret. That follows
+    the same model as the REST read surfaces (reads are never gated, #163):
+    nanoidp is a testing IdP and its user directory is test data. The flip
+    side is real: on a shared instance, anyone who can reach this endpoint
+    can read any configured user's attributes. Deploy accordingly.
+
+    An unknown NameID gets a SAML error status (Requester/UnknownPrincipal),
+    never a fabricated assertion (#275).
     """
     config = get_config()
 
@@ -913,13 +952,28 @@ def attribute_query() -> ResponseReturnValue:
                     else:
                         attributes[key] = value
         else:
-            # Fallback for unknown users - provide default attributes
-            logger.warning(f"User '{user_id}' not found, using default attributes")
-            attributes = {
-                "email": f"{user_id}@example.com",
-                "identity_class": "INTERNAL",
-                "entitlements": "DOCUMENT_READ",
-            }
+            # Unknown principal (#275): a SAML error status, not a signed
+            # assertion full of invented attributes - the SP under test must
+            # see the miss, not silently pass on data nanoidp made up.
+            logger.warning(f"AttributeQuery for unknown user '{user_id}'")
+            error_xml = _build_attribute_query_error_response(
+                request_id=request_id,
+                issuer_url=effective_saml_entity_id(config.settings),
+            )
+            audit_event(
+                "saml_attribute_query",
+                "failed",
+                endpoint="/saml/attribute-query",
+                username=user_id,
+                details={"reason": "unknown principal"},
+            )
+            soap_error = f"""<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        {error_xml}
+    </soap:Body>
+</soap:Envelope>"""
+            return Response(soap_error, mimetype="text/xml")
 
         # Build SAML Response
         issuer_url = effective_saml_entity_id(config.settings)

--- a/src/nanoidp/services/token.py
+++ b/src/nanoidp/services/token.py
@@ -217,7 +217,7 @@ class TokenService:
         id_token_claims: Optional[List[str]] = None,
         userinfo_claims: Optional[List[str]] = None,
         issuer: Optional[str] = None,
-        issue_refresh_token: bool = True,
+        issue_refresh_token: Optional[bool] = None,
         resource: Optional[List[str]] = None,
         refresh_resource: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
@@ -242,13 +242,23 @@ class TokenService:
         - a token whose ``iss`` doesn't match what discovery said is rejected by
         any spec-compliant client.
 
-        ``issue_refresh_token`` is False for grants without an end user
-        (client_credentials, RFC 6749 §4.4.3: "A refresh token SHOULD NOT be
-        included", #239): the client authenticates itself on every call, so a
-        refresh token would only be a second, long-lived credential bound to a
-        user the grant never involved. When False no refresh JWT is minted and
-        the response carries no ``refresh_token`` key at all.
+        ``issue_refresh_token`` defaults to "only when the token is bound":
+        a refresh token without a ``client_id`` binding is refused by /token
+        since 3.0 (#73), so minting one for an unbound token would hand back a
+        dead credential - this service owns that invariant (#278), not its
+        callers. Pass False for grants that bind a client but must not issue
+        one (client_credentials, RFC 6749 §4.4.3: "A refresh token SHOULD NOT
+        be included", #239). Passing True without ``client_id`` raises
+        ``ValueError``. When no refresh JWT is minted the response carries no
+        ``refresh_token`` key at all.
         """
+        if issue_refresh_token and not client_id:
+            raise ValueError(
+                "issue_refresh_token=True requires client_id: a refresh token "
+                "without a client_id binding is refused at /token (#73)"
+            )
+        if issue_refresh_token is None:
+            issue_refresh_token = client_id is not None
         settings = self.config.settings
         effective_issuer = issuer or settings.issuer
 

--- a/tests/test_client_credentials_no_refresh.py
+++ b/tests/test_client_credentials_no_refresh.py
@@ -126,9 +126,11 @@ class TestTokenServiceFlag:
         assert "refresh_token" not in result
         assert "access_token" in result
 
-    def test_flag_defaults_to_true(self, app, user):
+    def test_flag_defaults_to_issuing_for_a_bound_token(self, app, user):
+        """#278: the default follows the binding - a bound token gets a
+        refresh token without the caller asking, an unbound one gets none."""
         with app.app_context():
-            result = get_token_service().create_token(user)
+            result = get_token_service().create_token(user, client_id="demo-client")
 
         payload = pyjwt.decode(result["refresh_token"], options={"verify_signature": False})
         assert payload["token_use"] == "refresh"

--- a/tests/test_client_identity_mismatch.py
+++ b/tests/test_client_identity_mismatch.py
@@ -1,0 +1,118 @@
+"""
+One request, one client identity (#277).
+
+/token has always resolved the client as body-or-Basic and rejected a
+mismatch between the two channels. /introspect, /revoke and
+/device_authorization used to resolve header-first and check nothing, so
+HTTP Basic for client A plus client_id=B in the body was silently processed
+as A. All four endpoints now share _request_client_identity(): a request
+naming two different clients is invalid_client everywhere.
+
+Uses the shipped config's demo-client (unrestricted) and scoped-client;
+both confidential with client_secret_basic, so Basic alone stays the valid
+authentication and only the contradictory body client_id trips the check.
+"""
+
+import base64
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_device_codes():
+    yield
+    from nanoidp.services.device_code import get_device_code_store
+
+    get_device_code_store().clear()
+
+
+def _basic(client_id: str, secret: str) -> dict:
+    credentials = base64.b64encode(f"{client_id}:{secret}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+DEMO_AUTH = _basic("demo-client", "demo-secret")
+
+
+def _mint_token(client) -> str:
+    resp = client.post(
+        "/token",
+        data={"grant_type": "password", "username": "admin", "password": "admin"},
+        headers=DEMO_AUTH,
+    )
+    assert resp.status_code == 200
+    return json.loads(resp.data)["access_token"]
+
+
+class TestMismatchRejectedEverywhere:
+    def test_token_mismatch_rejected(self, client):
+        """The pre-existing /token behavior, pinned for parity."""
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "client_id": "scoped-client",
+            },
+            headers=DEMO_AUTH,
+        )
+        assert resp.status_code == 401
+
+    def test_introspect_mismatch_rejected(self, client):
+        token = _mint_token(client)
+        resp = client.post(
+            "/introspect",
+            data={"token": token, "client_id": "scoped-client"},
+            headers=DEMO_AUTH,
+        )
+        assert resp.status_code == 401
+        assert json.loads(resp.data)["error"] == "invalid_client"
+
+    def test_revoke_mismatch_rejected_and_revokes_nothing(self, client):
+        token = _mint_token(client)
+        resp = client.post(
+            "/revoke",
+            data={"token": token, "client_id": "scoped-client"},
+            headers=DEMO_AUTH,
+        )
+        assert resp.status_code == 401
+        assert json.loads(resp.data)["error"] == "invalid_client"
+        # The token must NOT have been revoked by the rejected request.
+        check = client.post("/introspect", data={"token": token}, headers=DEMO_AUTH)
+        assert check.status_code == 200
+        assert json.loads(check.data)["active"] is True
+
+    def test_device_authorization_mismatch_rejected(self, client):
+        resp = client.post(
+            "/device_authorization",
+            data={"client_id": "scoped-client"},
+            headers=DEMO_AUTH,
+        )
+        assert resp.status_code == 401
+        assert json.loads(resp.data)["error"] == "invalid_client"
+
+
+class TestMatchingBodyClientIdStillAccepted:
+    """Basic plus a body client_id naming the SAME client is one identity,
+    not two - it must keep working at every endpoint."""
+
+    def test_introspect_matching_body_id_ok(self, client):
+        token = _mint_token(client)
+        resp = client.post(
+            "/introspect",
+            data={"token": token, "client_id": "demo-client"},
+            headers=DEMO_AUTH,
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.data)["active"] is True
+
+    def test_device_authorization_matching_body_id_ok(self, client):
+        resp = client.post(
+            "/device_authorization",
+            data={"client_id": "demo-client"},
+            headers=DEMO_AUTH,
+        )
+        assert resp.status_code == 200
+        assert "device_code" in json.loads(resp.data)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -9,6 +9,7 @@ Tests cover:
 
 import json
 
+import jwt as pyjwt
 import pytest
 
 
@@ -1154,3 +1155,58 @@ class TestGenerateTokenClaims:
         )
         assert result["success"] is False
         assert "does-not-exist" in result["error"]
+
+
+class TestSimulationBoundary:
+    """#279: generate_token and verify_token deliberately diverge from the
+    grant endpoints - they simulate, they do not enforce. These pins keep the
+    exemptions EXPLICIT: if one starts enforcing, the boundary documented in
+    the tool descriptions changed and docs/tests must move together."""
+
+    async def _generate(self, arguments):
+        from nanoidp.config import get_config
+        from nanoidp.mcp_server import _execute_tool
+
+        result = await _execute_tool("generate_token", arguments, get_config())
+        assert result["success"] is True, result
+        return result
+
+    @pytest.mark.asyncio
+    async def test_generate_token_scope_has_no_ceiling_even_with_client_id(self, app):
+        """scoped-client's allowed_scopes is [openid, profile] and
+        'custom:everything' is outside the vocabulary too - the grant
+        endpoints reject both, this tool stamps them as asked (minting an
+        out-of-ceiling token is how a resource server's rejection path gets
+        tested)."""
+        result = await self._generate(
+            {
+                "username": "admin",
+                "client_id": "scoped-client",
+                "scope": "email custom:everything",
+            }
+        )
+        payload = pyjwt.decode(result["access_token"], options={"verify_signature": False})
+        assert payload["scope"] == "email custom:everything"
+
+    @pytest.mark.asyncio
+    async def test_verify_token_ignores_revocation_like_a_stateless_rs(self, app, client, auth_header):
+        """verify_token simulates a JWKS-validating resource server (the #191
+        model): revocation is /introspect's answer. A revoked token still
+        verifies here and introspects as inactive there."""
+        from nanoidp.config import get_config
+        from nanoidp.mcp_server import _execute_tool
+        from nanoidp.services.revocation import get_revocation_store
+
+        minted = await self._generate({"username": "admin", "scope": "openid"})
+        token = minted["access_token"]
+        jti = pyjwt.decode(token, options={"verify_signature": False})["jti"]
+        get_revocation_store().revoke(jti)
+        try:
+            verified = await _execute_tool("verify_token", {"token": token}, get_config())
+            assert verified["valid"] is True
+
+            resp = client.post("/introspect", data={"token": token}, headers=auth_header)
+            assert resp.status_code == 200
+            assert json.loads(resp.data)["active"] is False
+        finally:
+            get_revocation_store().clear()

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -480,24 +480,31 @@ class TestSAMLAttributeQuery:
 
         assert response.status_code == 400
 
-    def test_attribute_query_unknown_user_returns_defaults(self, client):
-        """Test that AttributeQuery for unknown user returns default attributes."""
+    def test_attribute_query_unknown_user_returns_error_status(self, client):
+        """#275: an unknown NameID gets a SAML error status
+        (Requester/UnknownPrincipal), NOT a signed assertion with fabricated
+        attributes - the SP under test must see the miss, not silently pass
+        on data nanoidp made up."""
         query = self._create_attribute_query(user_id='unknown_user_xyz')
         response = client.post('/saml/attribute-query',
             data=query,
             content_type='text/xml'
         )
 
-        # Should return 200 with default attributes (NanoIDP is permissive)
+        # SAML SOAP binding: protocol errors still ride HTTP 200.
         assert response.status_code == 200
 
         root = etree.fromstring(response.data)
-        attrs = root.findall(".//saml2:Attribute", SAML_NS)
-        attr_names = [a.get("Name") for a in attrs]
-
-        # Should have default attributes
-        assert 'email' in attr_names
-        assert 'identity_class' in attr_names
+        codes = [
+            el.get("Value")
+            for el in root.findall(".//saml2p:StatusCode", SAML_NS)
+        ]
+        assert "urn:oasis:names:tc:SAML:2.0:status:Requester" in codes
+        assert "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal" in codes
+        # No assertion, no attributes - nothing is asserted about a principal
+        # that does not exist.
+        assert root.findall(".//saml2:Assertion", SAML_NS) == []
+        assert root.findall(".//saml2:Attribute", SAML_NS) == []
 
 
 class TestSAMLSigningConfiguration:
@@ -1446,7 +1453,7 @@ class TestSAMLFlowsComprehensive:
         assert email_value.text == "admin@example.org"
 
     def test_attribute_query_unknown_user(self, client):
-        """Test Attribute Query for unknown user returns default/empty attributes."""
+        """Attribute Query for an unknown user returns a SAML error status (#275)."""
         query = """<?xml version="1.0" encoding="UTF-8"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>
@@ -1469,8 +1476,13 @@ class TestSAMLFlowsComprehensive:
             content_type='text/xml'
         )
 
-        # Should still return 200 with default attributes
+        # #275: still HTTP 200 (SAML SOAP binding), but a SAML error status
+        # instead of the old fabricated-attributes fallback.
         assert response.status_code == 200
+        root = etree.fromstring(response.data)
+        codes = [el.get("Value") for el in root.findall(".//saml2p:StatusCode", SAML_NS)]
+        assert "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal" in codes
+        assert root.findall(".//saml2:Assertion", SAML_NS) == []
 
     def test_attribute_query_requires_subject(self, client):
         """Test that Attribute Query without Subject returns error."""

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -506,6 +506,52 @@ class TestSAMLAttributeQuery:
         assert root.findall(".//saml2:Assertion", SAML_NS) == []
         assert root.findall(".//saml2:Attribute", SAML_NS) == []
 
+    def test_attribute_query_error_response_is_signed_when_signing_is_on(self, client):
+        """#289 review: the error response goes through the SAME signing path
+        as the success response. With saml_sign_responses=true an SP
+        validating signatures would otherwise reject (or worse, special-case)
+        the one response shape nanoidp forgot to sign."""
+        from nanoidp.config import get_config
+
+        config = get_config()
+        original = config.settings.saml_sign_responses
+        config.settings.saml_sign_responses = True
+        try:
+            query = self._create_attribute_query(user_id='unknown_user_xyz')
+            response = client.post('/saml/attribute-query',
+                data=query,
+                content_type='text/xml'
+            )
+            assert response.status_code == 200
+            root = etree.fromstring(response.data)
+            codes = [el.get("Value") for el in root.findall(".//saml2p:StatusCode", SAML_NS)]
+            assert "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal" in codes
+            assert root.find(".//ds:Signature", SAML_NS) is not None, (
+                "error response must be signed when saml_sign_responses is on"
+            )
+        finally:
+            config.settings.saml_sign_responses = original
+
+    def test_attribute_query_error_response_unsigned_when_signing_is_off(self, client):
+        """The negative: signing off means no signature on the error path
+        either - the flag drives both response shapes symmetrically."""
+        from nanoidp.config import get_config
+
+        config = get_config()
+        original = config.settings.saml_sign_responses
+        config.settings.saml_sign_responses = False
+        try:
+            query = self._create_attribute_query(user_id='unknown_user_xyz')
+            response = client.post('/saml/attribute-query',
+                data=query,
+                content_type='text/xml'
+            )
+            assert response.status_code == 200
+            root = etree.fromstring(response.data)
+            assert root.find(".//ds:Signature", SAML_NS) is None
+        finally:
+            config.settings.saml_sign_responses = original
+
 
 class TestSAMLSigningConfiguration:
     """Tests for configurable SAML response signing."""

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -331,6 +331,69 @@ class TestDeviceAuthorizationScopeEnforcement:
         assert "device_code" in json.loads(response.data)
 
 
+class TestDeviceCodeRedemptionScopeReValidation:
+    """#276: the device grant redeems a prior authorization exactly like
+    authorization_code and refresh do, so it must re-validate the stored
+    scope against the CURRENT vocabulary/allowed_scopes at the poll - both
+    may have changed between /device_authorization and redemption."""
+
+    @pytest.fixture(autouse=True)
+    def _cleanup_device_codes(self):
+        yield
+        from nanoidp.services.device_code import get_device_code_store
+
+        get_device_code_store().clear()
+
+    def _device_flow_authorized(self, client, scope):
+        resp = client.post(
+            "/device_authorization", data={"scope": scope}, headers=SCOPED_AUTH
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        authorize = client.post(
+            "/device",
+            data={
+                "user_code": data["user_code"],
+                "username": "admin",
+                "password": "admin",
+                "action": "authorize",
+            },
+        )
+        assert authorize.status_code == 200
+        return data["device_code"]
+
+    def _poll(self, client, device_code):
+        return client.post(
+            "/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+            },
+            headers=SCOPED_AUTH,
+        )
+
+    def test_scope_still_allowed_redeems_with_it(self, client):
+        device_code = self._device_flow_authorized(client, "openid profile")
+        resp = self._poll(client, device_code)
+        assert resp.status_code == 200
+        assert json.loads(resp.data)["scope"] == "openid profile"
+
+    def test_scope_revoked_between_authorization_and_poll_is_rejected(self, client, app):
+        """The grant was valid when authorized; allowed_scopes shrank since
+        (an operator edit) - the poll must catch it, same as the refresh
+        grant's re-check does."""
+        device_code = self._device_flow_authorized(client, "openid profile")
+
+        with app.app_context():
+            get_config().get_client("scoped-client").allowed_scopes = ["openid"]
+
+        resp = self._poll(client, device_code)
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data["error"] == "invalid_scope"
+        assert "profile" in data["error_description"]
+
+
 class TestClientCredentialsOpenidNeverMintsIdToken:
     """#186 review: create_token()'s ID Token issuance is grant-agnostic
     (any grant with 'openid' in scope gets one), but client_credentials has

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -46,7 +46,10 @@ class TestTokenCreation:
         assert "access_token" in result
         assert "token_type" in result
         assert "expires_in" in result
-        assert "refresh_token" in result
+        # No client_id -> unbound token -> NO refresh token (#73/#278): a
+        # refresh token without a client_id binding is refused at /token, so
+        # minting one here would be a dead credential.
+        assert "refresh_token" not in result
         # scope reports what was actually granted (RFC 6749 §5.1, #56):
         # no scope requested → omitted (it used to be hardcoded to "openid")
         assert "scope" not in result
@@ -159,14 +162,14 @@ class TestTokenCreation:
     def test_refresh_token_is_different(self, token_service, basic_user, app):
         """Test that refresh token is different from access token."""
         with app.app_context():
-            result = token_service.create_token(basic_user)
+            result = token_service.create_token(basic_user, client_id="demo-client")
 
         assert result["access_token"] != result["refresh_token"]
 
     def test_refresh_token_has_token_type(self, token_service, basic_user, app):
         """Test that refresh token has token_type claim."""
         with app.app_context():
-            result = token_service.create_token(basic_user)
+            result = token_service.create_token(basic_user, client_id="demo-client")
 
         decoded = pyjwt.decode(
             result["refresh_token"],
@@ -428,3 +431,44 @@ class TestGlobalTokenService:
             service = get_token_service()
 
         assert isinstance(service, TokenService)
+
+
+class TestRefreshTokenBindingInvariant:
+    """#278: the service owns the #73 mint-side rule. issue_refresh_token
+    defaults to 'only when the token is bound' (client_id is not None), and
+    an explicit True without a binding raises instead of minting a refresh
+    token that /token would unconditionally reject."""
+
+    @pytest.fixture
+    def token_service(self, app):
+        with app.app_context():
+            return get_token_service()
+
+    @pytest.fixture
+    def basic_user(self):
+        return User(username="testuser", password="testpass", email="t@example.org")
+
+    def test_bound_token_gets_refresh_token_by_default(self, token_service, basic_user, app):
+        with app.app_context():
+            result = token_service.create_token(basic_user, client_id="demo-client")
+        assert "refresh_token" in result
+        claims = pyjwt.decode(result["refresh_token"], options={"verify_signature": False})
+        assert claims["client_id"] == "demo-client"
+
+    def test_unbound_token_gets_no_refresh_token_by_default(self, token_service, basic_user, app):
+        with app.app_context():
+            result = token_service.create_token(basic_user)
+        assert "refresh_token" not in result
+
+    def test_explicit_true_without_client_id_raises(self, token_service, basic_user, app):
+        with app.app_context():
+            with pytest.raises(ValueError, match="client_id"):
+                token_service.create_token(basic_user, issue_refresh_token=True)
+
+    def test_explicit_false_with_client_id_mints_none(self, token_service, basic_user, app):
+        """client_credentials shape (#239): bound but deliberately refresh-less."""
+        with app.app_context():
+            result = token_service.create_token(
+                basic_user, client_id="demo-client", issue_refresh_token=False
+            )
+        assert "refresh_token" not in result


### PR DESCRIPTION
Implements five findings from the pre-3.0 architecture audit, all on one theme: **the same rule must mean the same thing at every entry point**. All are 3.0.0 material - three are behavior changes that belong inside the major.

Closes #275, closes #276, closes #277, closes #278, closes #279.

## Behavior changes (CHANGELOG under Breaking Changes)

- **#277 - one request, one client identity.** `/introspect`, `/revoke` and `/device_authorization` now resolve the requesting client through the same `_request_client_identity()` helper as `/token`: HTTP Basic naming client A plus `client_id=B` in the body is rejected with `invalid_client` everywhere. Previously those three endpoints resolved header-first and silently ignored the contradictory body value. The rejected `/revoke` request provably revokes nothing (pinned).
- **#276 - device_code grant re-validates scope at redemption.** A scope removed from the client's `allowed_scopes` (or the vocabulary) between `/device_authorization` and the poll now fails with `invalid_scope`, mirroring the `authorization_code` and `refresh_token` re-checks (`validate_only=True`, absent-stays-absent per the #186 B1 rule).
- **#275 - `/saml/attribute-query` stops inventing principals.** Unknown NameID now gets a SAML error status (`Requester`/`UnknownPrincipal`, no assertion) instead of a **signed assertion with fabricated attributes**. The docstring claimed "after JWT authentication" while verifying nothing; docs and docstring now state plainly that the endpoint is unauthenticated by design, per the #163 read model. Whether that read model itself should change is deliberately NOT touched here - flagging it as a separate question.

## Behavior-preserving

- **#278 - the #73 mint-side rule lives in the service.** `TokenService.create_token`'s `issue_refresh_token` now defaults to "only when the token is bound" and raises on explicit `True` without `client_id`; the duplicated caller guards in `routes/api.py` and `mcp_server.py` are gone. The three minting surfaces behave exactly as before.
- **#279 - the simulation boundary is documented and pinned.** `generate_token`'s tool description now states it applies no scope/resource ceiling even with `client_id` (same deliberate stance the #187 review put on `resource`, now extended to `scope` with the same BOUNDARY comment); `verify_token`'s states it verifies like a stateless resource server (no revocation, no `token_use` - `/introspect` is the revocation answer, per the #191 model). Both exemptions have pin tests so a future "fix" that starts enforcing shows up as a deliberate contract change.

## Verification

- 1872 unit tests green (14 new; 3 pre-existing tests updated because they encoded the pre-#73 unbound-refresh-token pattern), mypy/ruff/import-linter clean.
- Live probes on the shipped config: mismatch 401 at all three endpoints with the token provably NOT revoked after a rejected `/revoke`; matching body `client_id` still accepted; unknown-NameID attribute query returns `UnknownPrincipal` with no assertion while a known user still gets all attributes; `/api/users/<u>/token` unbound has no `refresh_token`, bound has one.
- e2e `test_agent.py` extended (same PR, per house rule): contradictory `client_id` negative in Token Introspection, UnknownPrincipal negative in SAML Attribute Query - 61/61 live.
