### PR TITLE
fix: three audit bugs for the 3.0 clean base (#280 #281 #282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,22 @@ previous leniency allowed - needs a one-time adjustment.
 ## [2.8.0] - 2026-08-29
 
 ### Fixed
+- **MCP `update_user` can now update custom `attributes`** (#280): the field
+  was accepted by `create_user` and returned by every read surface, but the
+  `update_user` schema and handler silently lacked it - an agent could set
+  attributes at creation and never change them again. The new mapping
+  replaces the whole `attributes` object, like every other field there.
+- **`get_crypto_service` honours `keys_dir` on every call** (#281): once the
+  singleton existed the argument was silently ignored, so a config reload
+  that changed `keys_dir` kept signing tokens and serving JWKS from the old
+  directory. The service is now recreated when the requested directory
+  differs; operator-provided external keys (`init_crypto_service`) stay
+  authoritative and are never discarded over a `keys_dir` change.
+- **The wizard and `init` write configuration atomically and validated**
+  (#282): both used to write raw template text with `open()`, bypassing the
+  temp-then-replace primitive every other config writer uses - a crash could
+  leave a torn file, and a template error reached disk unvalidated. Both now
+  validate through the document models before anything touches disk.
 - **`client_credentials` no longer returns a refresh token** (#239). RFC
   6749 §4.4.3: "A refresh token SHOULD NOT be included" - the client
   authenticates itself on every request, and the token handed out was a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,8 +224,6 @@ previous leniency allowed - needs a one-time adjustment.
   opt-in feature; it also stops rejecting a valid path-empty absolute URI
   (RFC 3986 §3, e.g. `about:`). No audience bypass or escalation.
 
-## [2.8.0] - 2026-08-29
-
 ### Fixed
 - **MCP `update_user` can now update custom `attributes`** (#280): the field
   was accepted by `create_user` and returned by every read surface, but the
@@ -243,6 +241,10 @@ previous leniency allowed - needs a one-time adjustment.
   temp-then-replace primitive every other config writer uses - a crash could
   leave a torn file, and a template error reached disk unvalidated. Both now
   validate through the document models before anything touches disk.
+
+## [2.8.0] - 2026-08-29
+
+### Fixed
 - **`client_credentials` no longer returns a refresh token** (#239). RFC
   6749 §4.4.3: "A refresh token SHOULD NOT be included" - the client
   authenticates itself on every request, and the token handed out was a

--- a/src/nanoidp/__main__.py
+++ b/src/nanoidp/__main__.py
@@ -109,8 +109,12 @@ def init_config(config_dir: str) -> None:
     if os.path.exists(users_path):
         print(f"  [skip] {users_path} already exists")
     else:
-        with open(users_path, "w") as f:
-            f.write(DEFAULT_USERS_YAML)
+        # Same validate-then-atomic-write path as the wizard (#282): the
+        # template is static, but validating it here means a drifted default
+        # fails init loudly instead of shipping a directory that will not load.
+        from nanoidp.wizard import _validate_and_write
+
+        _validate_and_write(users_path, DEFAULT_USERS_YAML, kind="users")
         print(f"  [created] {users_path}")
 
     # Create settings.yaml
@@ -118,8 +122,9 @@ def init_config(config_dir: str) -> None:
     if os.path.exists(settings_path):
         print(f"  [skip] {settings_path} already exists")
     else:
-        with open(settings_path, "w") as f:
-            f.write(DEFAULT_SETTINGS_YAML)
+        from nanoidp.wizard import _validate_and_write
+
+        _validate_and_write(settings_path, DEFAULT_SETTINGS_YAML, kind="settings")
         print(f"  [created] {settings_path}")
 
     # Create keys directory

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -499,6 +499,13 @@ _TOOLS: list[Tool] = [
                     "items": {"type": "string"},
                     "description": "New source ACL entries (optional)",
                 },
+                "attributes": {
+                    "type": "object",
+                    "description": (
+                        "New custom key-value attributes (optional; replaces the "
+                        "whole mapping, like every other field here - #280)"
+                    ),
+                },
             },
             "required": ["username"],
         },
@@ -1341,6 +1348,10 @@ def _tool_update_user(arguments: dict[str, Any], config: ConfigManager) -> dict[
         candidate.entitlements = arguments["entitlements"]
     if "source_acl" in arguments:
         candidate.source_acl = arguments["source_acl"]
+    if "attributes" in arguments:
+        # create_user accepted this from day one; update_user silently lacked
+        # it (#280) - the parity drift the user-field audit found.
+        candidate.attributes = arguments["attributes"]
     user = config.users[username] = candidate
 
     return {"success": True, "user": _user_to_dict(user)}

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -675,3 +675,27 @@ def atomic_write_yaml(file_path: Path, data: Dict[str, Any]) -> None:
             shutil.copy2(backup_path, file_path)
             logger.warning(f"Restored {file_path} from backup after write failure")
         raise RuntimeError(f"Failed to write {file_path}: {e}") from e
+
+
+def atomic_write_text(file_path: Path, text: str) -> None:
+    """Atomically write literal text with the same temp-then-replace shape as
+    ``atomic_write_yaml``, minus the YAML dump (#282).
+
+    For writers that own an exact byte representation - the wizard's and
+    ``init``'s commented templates - where a ruamel round-trip would be a
+    needless re-serialization. Same guarantee: on failure the target is left
+    exactly as it was and the temp file is cleaned up. Callers are expected
+    to have validated ``text`` (the document models) BEFORE calling.
+    """
+    fd, temp_path = tempfile.mkstemp(
+        suffix=".yaml", prefix=file_path.stem + "_", dir=file_path.parent
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        _replace_with_retry(temp_path, file_path)
+        logger.info(f"Successfully wrote {file_path}")
+    except Exception as e:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise RuntimeError(f"Failed to write {file_path}: {e}") from e

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -73,6 +73,12 @@ class CryptoService:
 
         self._ensure_keys()
 
+    @property
+    def uses_external_keys(self) -> bool:
+        """True when this service signs with operator-provided PEM keys
+        (loaded by init_crypto_service) rather than keys_dir-generated ones."""
+        return bool(self._external_private_key and self._external_public_key)
+
     def _ensure_keys(self) -> None:
         """Ensure RSA keys and certificate exist."""
         self.keys_dir.mkdir(parents=True, exist_ok=True)
@@ -475,13 +481,30 @@ _crypto_service_lock = threading.Lock()
 
 
 def get_crypto_service(keys_dir: str = "./keys") -> CryptoService:
-    """Get or create the global crypto service (thread-safe lazy init, #43)."""
+    """Get or create the global crypto service (thread-safe lazy init, #43).
+
+    The requested ``keys_dir`` is honoured on EVERY call, not only the first
+    (#281): when a config reload changes ``keys_dir``, the next call recreates
+    the service for the new directory instead of silently signing and serving
+    JWKS from the old one. External keys are the exception - they are loaded
+    from their own PEM paths by ``init_crypto_service`` and merely hosted
+    alongside ``keys_dir``, so an externally-keyed service is never discarded
+    over a ``keys_dir`` change (init stays authoritative).
+    """
     global _crypto_service
-    if _crypto_service is None:
-        with _crypto_service_lock:
-            if _crypto_service is None:
-                _crypto_service = CryptoService(keys_dir)
-    return _crypto_service
+    service = _crypto_service
+    if service is not None and (
+        service.keys_dir == Path(keys_dir) or service.uses_external_keys
+    ):
+        return service
+    with _crypto_service_lock:
+        service = _crypto_service
+        if service is None or (
+            service.keys_dir != Path(keys_dir) and not service.uses_external_keys
+        ):
+            service = CryptoService(keys_dir)
+            _crypto_service = service
+        return service
 
 
 def init_crypto_service(

--- a/src/nanoidp/wizard.py
+++ b/src/nanoidp/wizard.py
@@ -216,8 +216,7 @@ users:
 default_user: "{admin_user}"
 """
 
-    with open(os.path.join(config_path, "users.yaml"), "w") as f:
-        f.write(users_yaml)
+    _validate_and_write(os.path.join(config_path, "users.yaml"), users_yaml, kind="users")
 
     # settings.yaml
     settings_yaml = f"""# NanoIDP Settings Configuration
@@ -260,8 +259,34 @@ authority_prefixes:
 """
 
     # Development tool - credentials stored in plaintext intentionally for ease of use
-    with open(os.path.join(config_path, "settings.yaml"), "w") as f:  # noqa: S101
-        f.write(settings_yaml)
+    _validate_and_write(
+        os.path.join(config_path, "settings.yaml"), settings_yaml, kind="settings"
+    )
+
+
+def _validate_and_write(path: str, text: str, kind: str) -> None:
+    """Validate a rendered template through the document models, then write it
+    atomically (#282).
+
+    The wizard used to write raw f-strings with open(): a template typo (or a
+    hostile value surviving the prompts) reached disk unvalidated, and a crash
+    mid-write could leave a torn file. Validation runs BEFORE anything touches
+    disk; the write goes through the same temp-then-replace primitive as every
+    other config writer.
+    """
+    from pathlib import Path
+
+    import yaml as _yaml
+
+    from .config_documents import SettingsDocument, UsersDocument
+    from .serialization import atomic_write_text
+
+    data = _yaml.safe_load(text)
+    if kind == "settings":
+        SettingsDocument.model_validate(data)
+    else:
+        UsersDocument.model_validate(data)
+    atomic_write_text(Path(path), text)
 
 
 if __name__ == "__main__":

--- a/tests/test_key_management.py
+++ b/tests/test_key_management.py
@@ -429,3 +429,53 @@ class TestKeyRotationAPI:
         assert new_kid in new_kids
         # Old key should still be in JWKS (for token validation)
         assert old_kid in new_kids
+
+
+class TestKeysDirFollowsConfig:
+    """#281: get_crypto_service used to ignore keys_dir once the singleton
+    existed - after a config reload changing keys_dir, all 19 call sites kept
+    signing and serving JWKS from the old directory."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_singleton(self):
+        from nanoidp.services import crypto
+
+        crypto._crypto_service = None
+        yield
+        crypto._crypto_service = None
+
+    def test_same_keys_dir_returns_same_instance(self, tmp_path):
+        from nanoidp.services.crypto import get_crypto_service
+
+        first = get_crypto_service(str(tmp_path / "k1"))
+        assert get_crypto_service(str(tmp_path / "k1")) is first
+
+    def test_changed_keys_dir_recreates_the_service(self, tmp_path):
+        from pathlib import Path
+
+        from nanoidp.services.crypto import get_crypto_service
+
+        first = get_crypto_service(str(tmp_path / "k1"))
+        second = get_crypto_service(str(tmp_path / "k2"))
+        assert second is not first
+        assert second.keys_dir == Path(str(tmp_path / "k2"))
+        # And the new service signs with the NEW directory's key.
+        assert (tmp_path / "k2" / "rsa_private.pem").exists()
+
+    def test_external_keys_are_never_discarded_over_keys_dir(self, tmp_path):
+        """init_crypto_service (external PEMs) stays authoritative: a
+        keys_dir-only divergence must not silently swap the operator's keys
+        for generated ones."""
+        from nanoidp.services.crypto import CryptoService, get_crypto_service, init_crypto_service
+
+        # Generate a pair to stand in for operator-provided PEMs.
+        seed = CryptoService(str(tmp_path / "seed"))
+        assert seed is not None
+        external = init_crypto_service(
+            keys_dir=str(tmp_path / "hosted"),
+            external_private_key=str(tmp_path / "seed" / "rsa_private.pem"),
+            external_public_key=str(tmp_path / "seed" / "rsa_public.pem"),
+            external_key_id="op-key",
+        )
+        assert external.uses_external_keys
+        assert get_crypto_service(str(tmp_path / "elsewhere")) is external

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -864,6 +864,36 @@ class TestMCPUserDescription:
         assert config.get_user("carol").description == "Updated note"
 
     @pytest.mark.asyncio
+    async def test_update_user_updates_attributes(self, tmp_path):
+        """#280: create_user accepted custom attributes from day one, but
+        update_user's schema and handler silently lacked the field - an agent
+        could set attributes at creation and never change them again."""
+        from nanoidp.mcp_server import _execute_tool
+        config = self._config(tmp_path)
+        await _execute_tool(
+            "create_user",
+            {"username": "erin", "password": "pw", "attributes": {"dept": "eng"}},
+            config,
+        )
+
+        result = await _execute_tool(
+            "update_user",
+            {"username": "erin", "attributes": {"dept": "sales", "region": "emea"}},
+            config,
+        )
+
+        assert result["success"] is True
+        assert result["user"]["attributes"] == {"dept": "sales", "region": "emea"}
+        assert config.get_user("erin").attributes == {"dept": "sales", "region": "emea"}
+
+    @pytest.mark.asyncio
+    async def test_update_user_schema_includes_attributes(self, mcp_list_tools):
+        """#280: the schema half of the same gap."""
+        tools = await mcp_list_tools()
+        update_user = next(t for t in tools if t.name == "update_user")
+        assert "attributes" in update_user.input_schema["properties"]
+
+    @pytest.mark.asyncio
     async def test_get_user_returns_description(self, tmp_path):
         from nanoidp.mcp_server import _execute_tool
         config = self._config(tmp_path)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -159,3 +159,45 @@ class TestPromptHelpers:
         monkeypatch.setattr("getpass.getpass", broken)
         feed(["visible"])
         assert wizard._prompt_password("Password") == "visible"
+
+
+class TestValidateAndWrite:
+    """#282: the wizard used to write raw f-strings with open() - no
+    validation, no atomicity. _validate_and_write validates through the
+    document models BEFORE anything touches disk and then writes through
+    the shared temp-then-replace primitive."""
+
+    def test_valid_settings_template_lands_and_loads(self, tmp_path):
+        from nanoidp.wizard import _validate_and_write
+
+        text = 'config_version: 1\noauth:\n  issuer: "http://localhost:1234"\n'
+        target = tmp_path / "settings.yaml"
+        _validate_and_write(str(target), text, kind="settings")
+        # Byte-exact: no re-serialization of the template.
+        assert target.read_text() == text
+
+    def test_invalid_template_raises_and_writes_nothing(self, tmp_path):
+        import pydantic
+        import pytest as _pytest
+
+        from nanoidp.wizard import _validate_and_write
+
+        target = tmp_path / "settings.yaml"
+        with _pytest.raises(pydantic.ValidationError):
+            _validate_and_write(
+                str(target), "config_version: 1\noauth: not-a-mapping\n", kind="settings"
+            )
+        assert not target.exists()
+
+    def test_invalid_users_template_raises(self, tmp_path):
+        import pydantic
+        import pytest as _pytest
+
+        from nanoidp.wizard import _validate_and_write
+
+        target = tmp_path / "users.yaml"
+        with _pytest.raises(pydantic.ValidationError):
+            _validate_and_write(
+                str(target), "config_version: 1\nusers: not-a-mapping\n", kind="users"
+            )
+        assert not target.exists()


### PR DESCRIPTION
Three bugs found by the pre-3.0 architecture audit, each verified live before and after. Closes #280, closes #281, closes #282.

- **#280 - MCP `update_user` can now update `attributes`.** The field was accepted by `create_user` and returned by `_user_to_dict`, but the `update_user` schema and handler silently lacked it: an agent could set custom attributes at creation and never change them again. The handler applies it on the same validate-on-scratch-copy path as every other field; the new mapping replaces the whole object, consistent with the tool's replace semantics. This is the concrete drift that motivates the user-field parity test (#284).
- **#281 - `get_crypto_service` honours `keys_dir` on every call.** Once the singleton existed, the argument was silently dropped: after a config reload changing `keys_dir`, all 19 call sites kept signing and serving JWKS from the old directory. The service is now recreated (under the existing lock) when the requested directory differs. Operator-provided external keys stay authoritative: a service created by `init_crypto_service` with external PEMs is never discarded over a `keys_dir` divergence (new `uses_external_keys` property, pinned by test). Verified live: `jwt.keys_dir` edit + `POST /api/config/reload` now rotates the served JWKS kid; before the fix the kid stayed stale.
- **#282 - the wizard and `init` write configuration atomically and validated.** Both used raw `open(..., "w")` with f-string templates: no atomicity (a crash could leave a torn file) and no validation (a template error reached disk unseen). They now validate the rendered text through the document models BEFORE anything touches disk and write via a new `serialization.atomic_write_text` (same temp-then-replace shape as `atomic_write_yaml`, byte-exact so the commented templates survive verbatim). Negative pinned: an invalid template raises and writes nothing.

Verification: 1866 unit tests green (8 new), mypy/ruff/import-linter clean; live probes: fresh `init` loads and validates clean, keys_dir reload probe above.

Note: independent of #289 (different hunks of `mcp_server.py`); either merges first.
