### PR TITLE
test+docs: parity contracts and the one-home rule (#283 #284 #285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,24 @@ previous leniency allowed - needs a one-time adjustment.
   unchanged; both exemptions are now pinned by tests.
 
 ### Added
+- **Access-point parity contract for token issuance** (#283,
+  `tests/test_token_issuance_parity.py`): the set of modules calling
+  `TokenService.create_token` must equal a declared registry (AST-checked),
+  and every (surface, policy) pair - client binding, scope ceiling, resource
+  ceiling - must declare `enforced` (behaviorally asserted) or `exempt`
+  (the exemption itself pinned, with its documented reason). A new minting
+  surface fails the suite until it takes a stance; this mechanizes the
+  #269/#272 bug class out of existence.
+- **User-field parity test** (#284, `tests/test_user_field_parity.py`):
+  the nine user shapes (model, YAML entry, MCP read/create/update surfaces,
+  UI form, REST read) are held to field-set equality with documented,
+  asserted exclusions - the guard whose absence let #280 drift silently.
+  Found and recorded #291 (the UI users form has no `attributes` input).
+- **"Domain invariants have one home" review rule** (#285) in CONTRIBUTING,
+  echoed from VISION principle 4; five deferred imports claiming
+  nonexistent circular dependencies hoisted to module top, and the one
+  legitimately special case (`services/audit.py`) now documents its real
+  reason (never construct config from a log path).
 - **Horizontal `/authorize` login card composition** (#249). New per-client
   `layout` field, `"vertical"` (default, unchanged) or `"horizontal"`: the
   latter places the client info block and the login form side by side in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,13 +105,14 @@ previous leniency allowed - needs a one-time adjustment.
 
 ### Added
 - **Access-point parity contract for token issuance** (#283,
-  `tests/test_token_issuance_parity.py`): the set of modules calling
-  `TokenService.create_token` must equal a declared registry (AST-checked),
-  and every (surface, policy) pair - client binding, scope ceiling, resource
-  ceiling - must declare `enforced` (behaviorally asserted) or `exempt`
-  (the exemption itself pinned, with its documented reason). A new minting
-  surface fails the suite until it takes a stance; this mechanizes the
-  #269/#272 bug class out of existence.
+  `tests/test_token_issuance_parity.py`): the set of CALL SITES of
+  `TokenService.create_token` (`file::function`, AST-checked) must equal a
+  declared registry, and every (surface, policy) pair - client binding,
+  scope ceiling, resource ceiling - must declare `enforced` (behaviorally
+  asserted) or `exempt` (the exemption itself pinned, with its documented
+  reason). A new minting call site - even a second function in an
+  already-registered module - fails the suite until it takes a stance;
+  this mechanizes the #269/#272 bug class out of existence.
 - **User-field parity test** (#284, `tests/test_user_field_parity.py`):
   the nine user shapes (model, YAML entry, MCP read/create/update surfaces,
   UI form, REST read) are held to field-set equality with documented,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,26 @@ what lets `config.py` import it without a cycle). The contracts live in
 count. If a change needs a new edge between layers, adjust the contract in the
 same PR and say why.
 
+### Domain invariants have one home (#285)
+
+OAuth/OIDC/SAML policy belongs in services and domain logic; routes and the
+MCP server are adapters and must not independently reinterpret the same rule.
+If a PR implements the same policy separately at two surfaces - say, a check
+written once in `/token` and again, slightly differently, in an MCP tool -
+that is an architectural smell to flag in review: extract the rule to one
+place (or delegate to the existing one) instead of keeping the copies in
+sync by hand. The bug class this prevents is real and recurring here: a
+capability exposed by N entry points with a rule updated at N-1 of them
+(#269/#272). `tests/test_token_issuance_parity.py` enforces it mechanically
+for token issuance: a new surface that mints tokens fails the suite until it
+is registered and declares a stance on every policy.
+
+A related rule for comments: never claim a "circular dependency" (or any
+structural constraint) a deferred import does not actually avoid - false
+constraint comments teach the next contributor a wrong module graph. The one
+real import constraint is the `serialization` contract above; everything
+else imports normally at module top.
+
 ## Code Style
 
 - Follow PEP 8 (enforced by Black and Ruff)

--- a/VISION.md
+++ b/VISION.md
@@ -49,7 +49,10 @@ implicitly throughout the project's history; this writes them down.
    and models wherever possible so equivalent surfaces cannot drift (see
    #40: the shared discovery builder). Protocol surfaces themselves,
    authorization redirects, SAML SSO, UserInfo, are exercised over HTTP,
-   as a real client would.
+   as a real client would. The same rule generalizes past MCP: a domain
+   policy has ONE home, and routes/tools are adapters that delegate to it
+   rather than reinterpret it - CONTRIBUTING's "Domain invariants have
+   one home" (#285) is this principle stated as a review criterion.
 5. **Features ship whole.** A feature lands together with its MCP exposure
    (where applicable), its `e2e/test_agent.py` e2e coverage and its
    docs, in the same PR.

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -9,7 +9,7 @@ from flask.typing import ResponseReturnValue
 
 from ..config import get_config
 from ..hooks import HookError
-from ..services import get_audit_log, get_token_service
+from ..services import get_audit_log, get_crypto_service, get_token_service
 from ._auth import management_secret_required_for_api
 from ._issuer import effective_issuer, effective_saml_entity_id, effective_saml_sso_url
 
@@ -244,8 +244,6 @@ def rotate_keys() -> ResponseReturnValue:
     Returns:
         JSON with old_kid, new_kid, and rotation details.
     """
-    from ..services import get_crypto_service
-
     config = get_config()
     crypto = get_crypto_service(config.settings.keys_dir)
 
@@ -273,8 +271,6 @@ def rotate_keys() -> ResponseReturnValue:
 @api_bp.route("/keys/info")
 def keys_info() -> ResponseReturnValue:
     """Get information about current cryptographic keys."""
-    from ..services import get_crypto_service
-
     config = get_config()
     crypto = get_crypto_service(config.settings.keys_dir)
 

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -5,8 +5,11 @@ Web UI routes for the NanoIDP dashboard.
 import csv
 import json
 import logging
+import os
 import secrets
+from datetime import datetime
 from io import StringIO
+from pathlib import Path
 
 from flask import (
     Blueprint,
@@ -25,7 +28,7 @@ from ..branding import effective_logos_dir
 from ..config import OAuthClient, User, get_config
 from ..config_writer import ConflictError, current_revision
 from ..hooks import HookError
-from ..services import get_audit_log, get_token_service, get_yaml_writer
+from ..services import get_audit_log, get_crypto_service, get_token_service, get_yaml_writer
 from ._audit import audit_event
 from ._auth import (
     management_secret_required_for_ui,
@@ -775,12 +778,7 @@ def settings() -> ResponseReturnValue:
 @ui_bp.route("/keys")
 def keys() -> ResponseReturnValue:
     """Keys and certificates management page."""
-    import os
-    from datetime import datetime
-    from pathlib import Path
     config = get_config()
-    from ..services import get_crypto_service
-
     crypto = get_crypto_service(config.settings.keys_dir)
 
     # Get key file modification time as proxy for creation date
@@ -816,8 +814,6 @@ def keys() -> ResponseReturnValue:
 def keys_regenerate() -> ResponseReturnValue:
     """Regenerate RSA keys and certificate."""
     config = get_config()
-    from ..services import get_crypto_service
-
     try:
         crypto = get_crypto_service(config.settings.keys_dir)
         crypto.regenerate_keys()
@@ -835,8 +831,6 @@ def keys_regenerate() -> ResponseReturnValue:
 def keys_download(key_type: str) -> ResponseReturnValue:
     """Download key or certificate."""
     config = get_config()
-    from ..services import get_crypto_service
-
     crypto = get_crypto_service(config.settings.keys_dir)
 
     if key_type == "public_key":

--- a/src/nanoidp/services/audit.py
+++ b/src/nanoidp/services/audit.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from threading import Lock
 from typing import Any, Dict, List, Optional
 
+from ..config import get_config_if_loaded
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,11 +91,12 @@ class AuditLog:
             self._entries.append(entry)
             self._update_stats(event_type, status)
 
-        # Verbose logging controlled by settings (late import to avoid circular dependency)
-        # Never construct the configuration from a log call: an audit event
-        # logged while the singleton is being built (a plugin's on_before_load)
-        # would block on the non-reentrant init lock (review before 2.7.0rc4).
-        from ..config import get_config_if_loaded
+        # Verbose logging controlled by settings. No cycle (#285: config
+        # never imports services; the old comment claimed one). What DOES
+        # matter is never constructing the configuration from a log call: an
+        # audit event logged while the singleton is being built (a plugin's
+        # on_before_load) would block on the non-reentrant init lock (review
+        # before 2.7.0rc4) - hence get_config_if_loaded, never get_config.
         loaded = get_config_if_loaded()
         verbose = loaded.settings.verbose_logging if loaded is not None else True
 

--- a/src/nanoidp/services/auth_code.py
+++ b/src/nanoidp/services/auth_code.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
+from ..config import get_config_if_loaded
+
 logger = logging.getLogger(__name__)
 
 
@@ -105,12 +107,12 @@ class AuthCodeStore:
             self._cleanup_expired()
             self._codes[code] = auth_code
 
-        # Verbose logging controlled by settings (late import to avoid circular dependency)
-        try:
-            from ..config import get_config
-            verbose = get_config().settings.verbose_logging
-        except Exception:
-            verbose = True  # Default to verbose if config not available
+        # Verbose logging controlled by settings. No cycle here (#285: the
+        # old deferred import claimed one; config never imports services) -
+        # but never CONSTRUCT the configuration from a log path, same rule
+        # as audit.py: default to verbose when it is not loaded yet.
+        loaded = get_config_if_loaded()
+        verbose = loaded.settings.verbose_logging if loaded is not None else True
 
         if verbose:
             logger.debug(f"Created authorization code for user '{username}', client '{client_id}'")

--- a/src/nanoidp/services/device_code.py
+++ b/src/nanoidp/services/device_code.py
@@ -23,7 +23,10 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple
 
 if TYPE_CHECKING:
-    from ..config import User
+    # From the model's real home (#285): config only re-exports it for
+    # compatibility, and importing through the facade teaches a dependency
+    # that does not need to exist.
+    from ..models import User
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_token_issuance_parity.py
+++ b/tests/test_token_issuance_parity.py
@@ -11,11 +11,14 @@ test_discovery_parity.
 
 Two mechanisms:
 
-1. **Caller registry**: the set of modules that call
-   ``TokenService.create_token`` (found by AST walk, not grep, so comments
-   cannot fool it) must equal ``ISSUANCE_SURFACES``. Adding a fourth minting
-   surface fails this test until the surface is registered AND takes a
-   stance on every policy below.
+1. **Call-site registry**: the set of CALL SITES of
+   ``TokenService.create_token`` - ``file::enclosing_function``, found by
+   AST walk, so comments cannot fool it - must equal ``ISSUANCE_SURFACES``.
+   Registering files alone was not enough (#292 review round 1): a second
+   function minting tokens inside an already-registered module would have
+   stayed invisible, which is precisely the access-point class this file
+   exists to catch. A new minting call site fails this test until it is
+   registered AND takes a stance on every policy below.
 
 2. **Policy stance matrix**: every (surface, policy) pair must be declared
    ``enforced`` or ``exempt`` in ``POLICY_STANCE``. Enforced pairs run a
@@ -36,14 +39,15 @@ import pytest
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "nanoidp"
 
-# The modules allowed to mint tokens, i.e. to call TokenService.create_token.
-# services/token.py itself (the definition and its internal helpers) is not a
-# caller. If you are here because the caller-registry test failed: register
-# the new surface AND add a row per policy to POLICY_STANCE below.
+# The call sites allowed to mint tokens (file::enclosing_function, dotted for
+# nested functions, <module> for module level). services/token.py itself (the
+# definition and its internal helpers) is not a caller. If you are here
+# because the call-site registry test failed: register the new site AND add a
+# row per policy to POLICY_STANCE below.
 ISSUANCE_SURFACES = {
-    "routes/oauth.py": "the /token grant funnel",
-    "routes/api.py": "POST /api/users/<username>/token",
-    "mcp_server.py": "MCP generate_token",
+    "routes/oauth.py::token": "the /token grant funnel",
+    "routes/api.py::generate_token": "POST /api/users/<username>/token",
+    "mcp_server.py::_tool_generate_token": "MCP generate_token",
 }
 
 POLICIES = ("mint_binding", "scope_ceiling", "resource_ceiling")
@@ -51,16 +55,22 @@ POLICIES = ("mint_binding", "scope_ceiling", "resource_ceiling")
 # enforced -> the behavioral assertion below must hold.
 # exempt:<reason> -> the surface deliberately does not apply the policy, and
 # the exemption itself is pinned.
+# NOTE (#292 review): the stance strings and the behavioral test methods
+# below are linked by convention, not mechanically - each "enforced" pair has
+# a corresponding assertion in the surface's test class, maintained by hand.
+# That is deliberate: nine combinations do not justify a mini-framework. If
+# this matrix ever grows past what a reviewer can eyeball, revisit; do not
+# bolt a runner onto it.
 POLICY_STANCE = {
-    ("routes/oauth.py", "mint_binding"): "enforced",
-    ("routes/oauth.py", "scope_ceiling"): "enforced",
-    ("routes/oauth.py", "resource_ceiling"): "enforced",
-    ("routes/api.py", "mint_binding"): "enforced",
-    ("routes/api.py", "scope_ceiling"): "exempt: the endpoint has no scope parameter at all",
-    ("routes/api.py", "resource_ceiling"): "exempt: the endpoint has no resource parameter at all",
-    ("mcp_server.py", "mint_binding"): "enforced",
-    ("mcp_server.py", "scope_ceiling"): "exempt: simulation affordance (#279 boundary)",
-    ("mcp_server.py", "resource_ceiling"): "exempt: simulation affordance (#187/#279 boundary)",
+    ("routes/oauth.py::token", "mint_binding"): "enforced",
+    ("routes/oauth.py::token", "scope_ceiling"): "enforced",
+    ("routes/oauth.py::token", "resource_ceiling"): "enforced",
+    ("routes/api.py::generate_token", "mint_binding"): "enforced",
+    ("routes/api.py::generate_token", "scope_ceiling"): "exempt: the endpoint has no scope parameter at all",
+    ("routes/api.py::generate_token", "resource_ceiling"): "exempt: the endpoint has no resource parameter at all",
+    ("mcp_server.py::_tool_generate_token", "mint_binding"): "enforced",
+    ("mcp_server.py::_tool_generate_token", "scope_ceiling"): "exempt: simulation affordance (#279 boundary)",
+    ("mcp_server.py::_tool_generate_token", "resource_ceiling"): "exempt: simulation affordance (#187/#279 boundary)",
 }
 
 
@@ -72,36 +82,74 @@ def _basic(client_id: str, secret: str) -> dict:
 SCOPED_AUTH = _basic("scoped-client", "scoped-secret")
 
 
-def _create_token_caller_files() -> set:
-    """Every file under src/nanoidp with a call whose callee is named
-    create_token (attribute or bare), excluding services/token.py."""
-    callers = set()
+def _create_token_call_sites() -> set:
+    """Every ``file::enclosing_function`` under src/nanoidp with a call whose
+    callee is named create_token (attribute or bare), excluding
+    services/token.py. The enclosing name is the dotted chain of
+    FunctionDef/AsyncFunctionDef ancestors (``<module>`` at module level), so
+    a SECOND minting function in an already-registered file is a new entry -
+    files alone would hide it (#292 review round 1)."""
+    sites = set()
     for path in sorted(_SRC.rglob("*.py")):
         rel = path.relative_to(_SRC).as_posix()
         if rel == "services/token.py":
             continue
         tree = ast.parse(path.read_text(), filename=str(path))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                callee = node.func
-                name = (
-                    callee.attr
-                    if isinstance(callee, ast.Attribute)
-                    else callee.id if isinstance(callee, ast.Name) else None
-                )
-                if name == "create_token":
-                    callers.add(rel)
-    return callers
+        _walk_for_create_token(tree, rel, [], sites)
+    return sites
+
+
+def _walk_for_create_token(node, rel: str, stack: list, sites: set) -> None:
+    entered = isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    if entered:
+        stack.append(node.name)
+    if isinstance(node, ast.Call):
+        callee = node.func
+        name = (
+            callee.attr
+            if isinstance(callee, ast.Attribute)
+            else callee.id if isinstance(callee, ast.Name) else None
+        )
+        if name == "create_token":
+            enclosing = ".".join(stack) if stack else "<module>"
+            sites.add(f"{rel}::{enclosing}")
+    for child in ast.iter_child_nodes(node):
+        _walk_for_create_token(child, rel, stack, sites)
+    if entered:
+        stack.pop()
 
 
 class TestCallerRegistry:
-    def test_create_token_callers_match_the_registry(self):
-        found = _create_token_caller_files()
+    def test_create_token_call_sites_match_the_registry(self):
+        found = _create_token_call_sites()
         assert found == set(ISSUANCE_SURFACES), (
-            "Token-issuing surfaces changed. Register the surface in "
+            "Token-minting call sites changed. Register the site in "
             "ISSUANCE_SURFACES and declare its stance on every policy in "
             f"POLICY_STANCE. Found: {sorted(found)}"
         )
+
+    def test_collector_sees_a_new_function_in_a_registered_file(self, tmp_path,
+                                                                monkeypatch):
+        """The tripwire the file-level registry lacked: a SECOND minting
+        function inside an already-registered module must surface as a new
+        registry entry."""
+        import tests.test_token_issuance_parity as mod
+
+        fake = tmp_path / "src"
+        (fake / "routes").mkdir(parents=True)
+        (fake / "routes" / "api.py").write_text(
+            "def generate_token():\n"
+            "    return svc.create_token(user)\n"
+            "\n"
+            "def sneaky_new_endpoint():\n"
+            "    return svc.create_token(user)\n"
+        )
+        monkeypatch.setattr(mod, "_SRC", fake)
+        found = _create_token_call_sites()
+        assert found == {
+            "routes/api.py::generate_token",
+            "routes/api.py::sneaky_new_endpoint",
+        }
 
     def test_every_surface_declares_every_policy(self):
         expected = set(product(ISSUANCE_SURFACES, POLICIES))

--- a/tests/test_token_issuance_parity.py
+++ b/tests/test_token_issuance_parity.py
@@ -1,0 +1,258 @@
+"""
+Access-point parity for token issuance (#283) - the #269/#272 tripwire.
+
+The bug class this closes: a capability exposed by N entry points, a policy
+updated at N-1 of them (#73 was enforced at /token but initially forgotten
+at /api/users/<u>/token, fixed in #272). Every policy so far has been
+verified by hand-enumerated per-endpoint tests whose completeness was a
+review property; this file makes it a suite property, following the
+table-driven precedent of test_settings_plumbing_parity and
+test_discovery_parity.
+
+Two mechanisms:
+
+1. **Caller registry**: the set of modules that call
+   ``TokenService.create_token`` (found by AST walk, not grep, so comments
+   cannot fool it) must equal ``ISSUANCE_SURFACES``. Adding a fourth minting
+   surface fails this test until the surface is registered AND takes a
+   stance on every policy below.
+
+2. **Policy stance matrix**: every (surface, policy) pair must be declared
+   ``enforced`` or ``exempt`` in ``POLICY_STANCE``. Enforced pairs run a
+   behavioral assertion against that surface; exempt pairs assert the
+   exemption STILL HOLDS (with the documented reason), so silently starting
+   to enforce - or silently stopping - both show up as a deliberate contract
+   change, never as drift.
+"""
+
+import ast
+import base64
+import json
+from itertools import product
+from pathlib import Path
+
+import jwt as pyjwt
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "nanoidp"
+
+# The modules allowed to mint tokens, i.e. to call TokenService.create_token.
+# services/token.py itself (the definition and its internal helpers) is not a
+# caller. If you are here because the caller-registry test failed: register
+# the new surface AND add a row per policy to POLICY_STANCE below.
+ISSUANCE_SURFACES = {
+    "routes/oauth.py": "the /token grant funnel",
+    "routes/api.py": "POST /api/users/<username>/token",
+    "mcp_server.py": "MCP generate_token",
+}
+
+POLICIES = ("mint_binding", "scope_ceiling", "resource_ceiling")
+
+# enforced -> the behavioral assertion below must hold.
+# exempt:<reason> -> the surface deliberately does not apply the policy, and
+# the exemption itself is pinned.
+POLICY_STANCE = {
+    ("routes/oauth.py", "mint_binding"): "enforced",
+    ("routes/oauth.py", "scope_ceiling"): "enforced",
+    ("routes/oauth.py", "resource_ceiling"): "enforced",
+    ("routes/api.py", "mint_binding"): "enforced",
+    ("routes/api.py", "scope_ceiling"): "exempt: the endpoint has no scope parameter at all",
+    ("routes/api.py", "resource_ceiling"): "exempt: the endpoint has no resource parameter at all",
+    ("mcp_server.py", "mint_binding"): "enforced",
+    ("mcp_server.py", "scope_ceiling"): "exempt: simulation affordance (#279 boundary)",
+    ("mcp_server.py", "resource_ceiling"): "exempt: simulation affordance (#187/#279 boundary)",
+}
+
+
+def _basic(client_id: str, secret: str) -> dict:
+    credentials = base64.b64encode(f"{client_id}:{secret}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+SCOPED_AUTH = _basic("scoped-client", "scoped-secret")
+
+
+def _create_token_caller_files() -> set:
+    """Every file under src/nanoidp with a call whose callee is named
+    create_token (attribute or bare), excluding services/token.py."""
+    callers = set()
+    for path in sorted(_SRC.rglob("*.py")):
+        rel = path.relative_to(_SRC).as_posix()
+        if rel == "services/token.py":
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                callee = node.func
+                name = (
+                    callee.attr
+                    if isinstance(callee, ast.Attribute)
+                    else callee.id if isinstance(callee, ast.Name) else None
+                )
+                if name == "create_token":
+                    callers.add(rel)
+    return callers
+
+
+class TestCallerRegistry:
+    def test_create_token_callers_match_the_registry(self):
+        found = _create_token_caller_files()
+        assert found == set(ISSUANCE_SURFACES), (
+            "Token-issuing surfaces changed. Register the surface in "
+            "ISSUANCE_SURFACES and declare its stance on every policy in "
+            f"POLICY_STANCE. Found: {sorted(found)}"
+        )
+
+    def test_every_surface_declares_every_policy(self):
+        expected = set(product(ISSUANCE_SURFACES, POLICIES))
+        assert set(POLICY_STANCE) == expected
+        for pair, stance in POLICY_STANCE.items():
+            assert stance == "enforced" or stance.startswith("exempt: "), pair
+
+
+class TestOAuthTokenSurface:
+    """routes/oauth.py: all three policies enforced."""
+
+    def test_mint_binding_enforced(self, client):
+        """A grant-minted refresh token carries the client_id binding."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers=SCOPED_AUTH,
+        )
+        assert resp.status_code == 200
+        refresh = json.loads(resp.data)["refresh_token"]
+        claims = pyjwt.decode(refresh, options={"verify_signature": False})
+        assert claims["client_id"] == "scoped-client"
+
+    def test_scope_ceiling_enforced(self, client):
+        """scoped-client's allowed_scopes is [openid, profile]: email is
+        inside the vocabulary but outside the ceiling."""
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "password",
+                "username": "admin",
+                "password": "admin",
+                "scope": "email",
+            },
+            headers=SCOPED_AUTH,
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_scope"
+
+    def test_resource_ceiling_enforced(self, client, app):
+        from nanoidp.config import get_config
+
+        with app.app_context():
+            get_config().get_client("scoped-client").allowed_resources = [
+                "https://allowed.example/api"
+            ]
+        try:
+            resp = client.post(
+                "/token",
+                data={
+                    "grant_type": "password",
+                    "username": "admin",
+                    "password": "admin",
+                    "resource": "https://forbidden.example/api",
+                },
+                headers=SCOPED_AUTH,
+            )
+            assert resp.status_code == 400
+            assert json.loads(resp.data)["error"] == "invalid_target"
+        finally:
+            with app.app_context():
+                get_config().get_client("scoped-client").allowed_resources = []
+
+
+class TestApiUserTokenSurface:
+    """routes/api.py: binding enforced; scope/resource do not exist there."""
+
+    def test_mint_binding_enforced(self, client):
+        bound = client.post(
+            "/api/users/admin/token",
+            json={"client_id": "demo-client"},
+        )
+        assert bound.status_code == 200
+        bound_data = bound.get_json()
+        claims = pyjwt.decode(
+            bound_data["refresh_token"], options={"verify_signature": False}
+        )
+        assert claims["client_id"] == "demo-client"
+
+        unbound = client.post("/api/users/admin/token", json={})
+        assert unbound.status_code == 200
+        assert "refresh_token" not in unbound.get_json()
+
+    def test_scope_exemption_still_holds(self, client):
+        """The endpoint has no scope parameter: a scope key in the body is
+        ignored and the minted token carries no scope claim. If this fails
+        because scope IS now honoured, update POLICY_STANCE - that is a
+        contract change, not a fix."""
+        resp = client.post("/api/users/admin/token", json={"scope": "email admin"})
+        assert resp.status_code == 200
+        claims = pyjwt.decode(
+            resp.get_json()["access_token"], options={"verify_signature": False}
+        )
+        assert "scope" not in claims
+
+    def test_resource_exemption_still_holds(self, client):
+        """Same for resource: ignored, aud stays the configured audience."""
+        resp = client.post(
+            "/api/users/admin/token", json={"resource": "https://x.example/api"}
+        )
+        assert resp.status_code == 200
+        claims = pyjwt.decode(
+            resp.get_json()["access_token"], options={"verify_signature": False}
+        )
+        assert claims["aud"] != "https://x.example/api"
+
+
+class TestMcpGenerateTokenSurface:
+    """mcp_server.py: binding enforced; scope/resource deliberately free
+    (#279 simulation boundary - the detailed pins live in
+    test_mcp.py::TestSimulationBoundary; these keep the matrix complete)."""
+
+    async def _generate(self, arguments):
+        from nanoidp.config import get_config
+        from nanoidp.mcp_server import _execute_tool
+
+        result = await _execute_tool("generate_token", arguments, get_config())
+        assert result["success"] is True, result
+        return result
+
+    @pytest.mark.asyncio
+    async def test_mint_binding_enforced(self, app):
+        bound = await self._generate({"username": "admin", "client_id": "demo-client"})
+        claims = pyjwt.decode(
+            bound["refresh_token"], options={"verify_signature": False}
+        )
+        assert claims["client_id"] == "demo-client"
+
+        unbound = await self._generate({"username": "admin"})
+        assert "refresh_token" not in unbound
+
+    @pytest.mark.asyncio
+    async def test_scope_exemption_still_holds(self, app):
+        result = await self._generate(
+            {"username": "admin", "client_id": "scoped-client", "scope": "email"}
+        )
+        claims = pyjwt.decode(
+            result["access_token"], options={"verify_signature": False}
+        )
+        assert claims["scope"] == "email"
+
+    @pytest.mark.asyncio
+    async def test_resource_exemption_still_holds(self, app):
+        result = await self._generate(
+            {
+                "username": "admin",
+                "client_id": "scoped-client",
+                "resource": ["https://anything.example/api"],
+            }
+        )
+        claims = pyjwt.decode(
+            result["access_token"], options={"verify_signature": False}
+        )
+        assert claims["aud"] == "https://anything.example/api"

--- a/tests/test_user_field_parity.py
+++ b/tests/test_user_field_parity.py
@@ -1,0 +1,77 @@
+"""
+User-field parity across the declared surfaces of the user-field flow (#284).
+
+The user record is the widest shape family in the codebase (nine shapes) and
+had NO parity coverage: the drift was not hypothetical - the MCP update_user
+schema and handler silently lost `attributes` (#280) with nothing to notice.
+Same philosophy as test_client_field_parity.py: cover the DECLARATIVE
+surfaces cheaply so a forgotten leg is a suite failure, leave the imperative
+legs (user_to_yaml, the UI parsers, the MCP handler bodies) to per-feature
+tests.
+
+Documented exclusions, each intentional and each asserted (so an exclusion
+that stops being true also fails):
+
+- ``username`` is the YAML mapping key, not a UserEntry field.
+- ``password`` never appears on a read surface (_user_to_dict, /api/users).
+- The MCP _USER_COMMON_PROPERTIES block omits username/password because the
+  create/update schemas declare those two separately.
+- The UI users form has no input for ``attributes`` - the one write surface
+  that cannot touch the field, recorded as #291 rather than silently skipped.
+- ``/api/users/<u>`` adds derived ``authorities`` (not a stored field).
+"""
+
+import re
+from pathlib import Path
+
+from nanoidp.config_documents import UserEntry
+from nanoidp.mcp_server import _TOOL_SCHEMAS, _USER_COMMON_PROPERTIES, _user_to_dict
+from nanoidp.models import User
+
+_MODEL_FIELDS = set(User.model_fields)
+
+_TEMPLATE = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "nanoidp"
+    / "templates"
+    / "users_form.html"
+)
+
+
+class TestUserFieldParity:
+    def test_yaml_load_contract_matches_the_model(self):
+        # username is the mapping key in users.yaml, not an entry field.
+        assert set(UserEntry.model_fields) == _MODEL_FIELDS - {"username"}
+
+    def test_mcp_read_surface_matches_the_model(self):
+        user = User(username="parity", password="p")
+        # password is the one intentional omission on every read surface.
+        assert set(_user_to_dict(user)) == _MODEL_FIELDS - {"password"}
+
+    def test_mcp_common_properties_match_the_model(self):
+        # The shared block omits username/password: the create/update schemas
+        # declare those two separately (asserted below).
+        assert set(_USER_COMMON_PROPERTIES) == _MODEL_FIELDS - {"username", "password"}
+
+    def test_mcp_tool_schemas_match_the_model(self):
+        for tool in ("create_user", "update_user"):
+            assert set(_TOOL_SCHEMAS[tool]["properties"]) == _MODEL_FIELDS, tool
+
+    def test_users_form_has_an_input_per_field(self):
+        html = _TEMPLATE.read_text()
+        form_names = set(re.findall(r'name="([a-z_]+)"', html))
+        # attributes: the UI form cannot set custom attributes today - the
+        # only write surface with that gap, tracked as #291. If this
+        # assertion starts failing because the input EXISTS, close #291 and
+        # delete the exclusion.
+        missing = _MODEL_FIELDS - form_names - {"attributes"}
+        assert not missing, f"users_form.html has no input for: {sorted(missing)}"
+        assert "attributes" not in form_names, "attributes input exists: close #291"
+
+    def test_api_read_surface_matches_the_model(self, client):
+        resp = client.get("/api/users/admin")
+        assert resp.status_code == 200
+        keys = set(resp.get_json())
+        # password elided; authorities is derived, not a stored field.
+        assert keys == (_MODEL_FIELDS - {"password"}) | {"authorities"}


### PR DESCRIPTION
The discipline half of the pre-3.0 audit: two contract tests and the review rule. Closes #283, closes #284, closes #285.

## #283 - access-point parity for token issuance

`tests/test_token_issuance_parity.py`, following the table-driven precedent of `test_settings_plumbing_parity` and `test_discovery_parity`:

1. **Call-site registry**: the set of CALL SITES of `TokenService.create_token` - `file::enclosing_function`, discovered by AST walk (comments cannot fool it) - must equal `ISSUANCE_SURFACES`: `routes/oauth.py::token`, `routes/api.py::generate_token`, `mcp_server.py::_tool_generate_token`. A new minting call site - including a second function inside an already-registered module (review round 1) - fails the suite until registered; a collector self-test pins that exact scenario.
2. **Policy stance matrix**: every (call site x policy) pair - mint-side client binding, scope ceiling, resource ceiling - must declare `enforced` or `exempt: <reason>`. Enforced pairs have a behavioral assertion against that surface; exempt pairs pin the exemption itself (e.g. MCP `generate_token`'s #279 simulation boundary), so silently starting OR stopping enforcement both surface as deliberate contract changes. The stance strings and the assertions are linked by convention, deliberately - nine combinations do not justify a mini-framework (documented in place).

This turns the #269/#272 bug class ("rule updated at N-1 of N surfaces") from a review property into a suite property. Known theoretical limit, accepted in review: the collector matches any callee named `create_token`, not a proven `TokenService` receiver - a future same-named method would be a false POSITIVE with an immediate, legible failure, which is the right failure mode for a tripwire.

## #284 - user-field parity

`tests/test_user_field_parity.py`, mirroring the client one: field-set equality across the nine user shapes (model, YAML `UserEntry`, MCP `_user_to_dict`/create/update schemas + `_USER_COMMON_PROPERTIES`, UI form, REST read surface), with every exclusion documented AND asserted - `username` as YAML key, `password` on read surfaces, derived `authorities`, and the one real gap found while writing it: the UI users form has no `attributes` input, recorded as #291 with an assertion that fails if the input appears (so the exclusion cannot outlive the gap).

## #285 - one-home rule + honest imports

- CONTRIBUTING gains "Domain invariants have one home": routes and MCP are adapters; the same policy implemented twice is a review smell. Echoed from VISION principle 4.
- Five deferred imports claiming circular dependencies that do not exist hoisted to module top (`services/auth_code.py` on the same `get_config_if_loaded` never-construct rule as audit, `services/device_code.py` typing import from `models`, `routes/ui.py` x3 plus stdlib-in-function, `routes/api.py` x2); `services/audit.py`'s comment now names its real constraint instead of mislabeling it circularity.

## Verification

1900 unit tests green on the rebased head (base: current `main`), mypy/ruff/import-linter clean.
