### PR TITLE
fix: RevocationStore entries expire and get swept (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,10 +288,12 @@ previous leniency allowed - needs a one-time adjustment.
   opportunistically on the mutating paths. A VERIFIED token's own `exp` is
   kept exactly - tokens minted via `/api/users/<u>/token` or MCP
   `generate_token` take arbitrary lifetimes, so no fixed cap is safe for
-  them; callers holding only unverified claims (the `/logout`
-  id_token_hint) pass no exp at all and get a bounded 8-day default; and
-  writes are monotonic, so re-revoking a jti can only extend its
-  retention, never shorten it.
+  them; a verified payload WITHOUT an `exp` claim (which `verify_jwt`
+  accepts) gets indefinite retention, since a token that never expires can
+  never have its revocation forgotten; callers holding only unverified
+  claims (the `/logout` id_token_hint) pass nothing and get a bounded
+  8-day default; and writes are monotonic, so re-revoking a jti can only
+  extend its retention, never shorten it.
 - **MCP `update_user` can now update custom `attributes`** (#280): the field
   was accepted by `create_user` and returned by every read surface, but the
   `update_user` schema and handler silently lacked it - an agent could set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,14 @@ previous leniency allowed - needs a one-time adjustment.
   (RFC 3986 §3, e.g. `about:`). No audience bypass or escalation.
 
 ### Fixed
+- **`RevocationStore` entries now expire** (#288): revoked jtis and rotation
+  family markers lived in two sets that were never swept - every revocation
+  and every refresh rotation on a long-lived instance was a permanent memory
+  increment. Entries now carry an expiry (the verified token's own `exp`
+  where the caller has it; a bounded 8-day default otherwise - nothing
+  outlives the 7-day refresh JWT) and the store sweeps opportunistically on
+  the mutating paths. An unverified `exp` (the `/logout` id_token_hint) can
+  only narrow retention, never extend it past the bound.
 - **MCP `update_user` can now update custom `attributes`** (#280): the field
   was accepted by `create_user` and returned by every read surface, but the
   `update_user` schema and handler silently lacked it - an agent could set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,11 +284,14 @@ previous leniency allowed - needs a one-time adjustment.
 - **`RevocationStore` entries now expire** (#288): revoked jtis and rotation
   family markers lived in two sets that were never swept - every revocation
   and every refresh rotation on a long-lived instance was a permanent memory
-  increment. Entries now carry an expiry (the verified token's own `exp`
-  where the caller has it; a bounded 8-day default otherwise - nothing
-  outlives the 7-day refresh JWT) and the store sweeps opportunistically on
-  the mutating paths. An unverified `exp` (the `/logout` id_token_hint) can
-  only narrow retention, never extend it past the bound.
+  increment. Entries now carry an expiry and the store sweeps
+  opportunistically on the mutating paths. A VERIFIED token's own `exp` is
+  kept exactly - tokens minted via `/api/users/<u>/token` or MCP
+  `generate_token` take arbitrary lifetimes, so no fixed cap is safe for
+  them; callers holding only unverified claims (the `/logout`
+  id_token_hint) pass no exp at all and get a bounded 8-day default; and
+  writes are monotonic, so re-revoking a jti can only extend its
+  retention, never shorten it.
 - **MCP `update_user` can now update custom `attributes`** (#280): the field
   was accepted by `create_user` and returned by every read surface, but the
   `update_user` schema and handler silently lacked it - an agent could set

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1300,7 +1300,9 @@ def revoke() -> ResponseReturnValue:
     # edge token is not logged as revoked (#254 review, finding 3).
     if jti:
         # The payload is verified, so its exp is the exact horizon the
-        # revocation needs remembering (#288).
+        # revocation needs remembering (#288) - and a verified payload
+        # WITHOUT exp names a token that never expires, which the store
+        # remembers indefinitely (three-state contract, #293 round 2).
         get_revocation_store().revoke(jti, expires_at=payload.get("exp"))
         logger.info(f"Token revoked: {jti[:8]}...")
         audit_event(

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1352,15 +1352,12 @@ def end_session() -> ResponseReturnValue:
             username = payload.get("sub")
 
             # Optionally revoke the token. The hint is decoded UNVERIFIED, so
-            # its exp only narrows retention; the store caps any value at the
-            # bounded default and never extends past it (#288).
+            # NO claim from it - exp included - reaches the store: the store's
+            # trust contract (#293 review) is that expires_at comes from a
+            # verified payload only; here the bounded default applies.
             jti = payload.get("jti")
-            exp = payload.get("exp")
             if jti:
-                get_revocation_store().revoke(
-                    jti,
-                    expires_at=exp if isinstance(exp, (int, float)) else None,
-                )
+                get_revocation_store().revoke(jti)
         except Exception:
             pass  # Invalid token, continue anyway
 

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -1299,7 +1299,9 @@ def revoke() -> ResponseReturnValue:
     # one); the audit reflects only what was actually revoked, so a jti-less
     # edge token is not logged as revoked (#254 review, finding 3).
     if jti:
-        get_revocation_store().revoke(jti)
+        # The payload is verified, so its exp is the exact horizon the
+        # revocation needs remembering (#288).
+        get_revocation_store().revoke(jti, expires_at=payload.get("exp"))
         logger.info(f"Token revoked: {jti[:8]}...")
         audit_event(
             "revocation_request",
@@ -1349,10 +1351,16 @@ def end_session() -> ResponseReturnValue:
             payload = pyjwt.decode(id_token_hint, options={"verify_signature": False})
             username = payload.get("sub")
 
-            # Optionally revoke the token
+            # Optionally revoke the token. The hint is decoded UNVERIFIED, so
+            # its exp only narrows retention; the store caps any value at the
+            # bounded default and never extends past it (#288).
             jti = payload.get("jti")
+            exp = payload.get("exp")
             if jti:
-                get_revocation_store().revoke(jti)
+                get_revocation_store().revoke(
+                    jti,
+                    expires_at=exp if isinstance(exp, (int, float)) else None,
+                )
         except Exception:
             pass  # Invalid token, continue anyway
 

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -360,7 +360,12 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         client is not None and client.is_public
     )
     reuse_detected = get_revocation_store().check_and_claim_refresh(
-        jti, refresh_family, rotation_enabled
+        jti,
+        refresh_family,
+        rotation_enabled,
+        # The verified refresh token's own exp: the claimed jti needs
+        # remembering exactly that long (#288).
+        expires_at=payload.get("exp"),
     )
     if reuse_detected:
         audit_event(

--- a/src/nanoidp/services/revocation.py
+++ b/src/nanoidp/services/revocation.py
@@ -5,55 +5,107 @@ Extracted from ``routes/oauth.py`` module globals (#84). Semantics are
 unchanged from #46/#56:
 
 - Plain membership tests and single additions are lock-free - individual
-  ``set`` operations are atomic under the GIL - and serve ``/userinfo``,
+  dict operations are atomic under the GIL - and serve ``/userinfo``,
   ``/introspect``, ``/revoke`` and ``/logout``.
 - The refresh grant's compound check-then-claim goes through the lock, so two
   concurrent refreshes of the same token cannot both pass the check and both
   rotate (#56). Reuse of an already-consumed token revokes its whole rotation
   family - attacker's copy and legitimate descendant alike (RFC 9700 §4.14.2).
+
+Entries expire (#288): a revoked jti only needs remembering until the token
+it names expires - after ``exp`` the signature check rejects it anyway - so
+every entry carries an expiry and the store sweeps opportunistically on the
+mutating paths (which already serialize under the lock). Before this, both
+sets grew without bound: every revocation and every rotation on a long-lived
+instance was a permanent memory increment.
 """
 
 import threading
-from typing import Optional
+import time
+from typing import Dict, Optional
 
-_UNSET = object()
+# The longest a revocation entry can matter when the caller cannot supply the
+# token's own exp: no nanoidp token outlives the 7-day refresh JWT
+# (services/token.py mints refresh tokens with a fixed 7-day expiry; access
+# and ID tokens are shorter). One extra day absorbs clock skew.
+_MAX_RETENTION_SECONDS = 8 * 24 * 3600
 
 
 class RevocationStore:
-    """Revoked token ids (jti or token hash) and revoked rotation families."""
+    """Revoked token ids (jti or token hash) and revoked rotation families,
+    each remembered until its expiry."""
 
     def __init__(self) -> None:
-        self._revoked_tokens: set[str] = set()
-        self._revoked_families: set[str] = set()
+        self._revoked_tokens: Dict[str, float] = {}
+        self._revoked_families: Dict[str, float] = {}
         self._lock = threading.Lock()
 
-    def revoke(self, token_id: str) -> None:
-        """Mark a single token id (jti or fallback hash) as revoked."""
-        self._revoked_tokens.add(token_id)
+    @staticmethod
+    def _effective_expiry(expires_at: Optional[float]) -> float:
+        """The caller's exp when it has one (a verified payload's ``exp``),
+        else the conservative retention bound."""
+        now = time.time()
+        if expires_at is None:
+            return now + _MAX_RETENTION_SECONDS
+        # Never trust an attacker-influenced exp to EXTEND retention past the
+        # bound (e.g. /logout decodes id_token_hint unverified), and treat a
+        # past exp as "still worth a short memory" rather than an instant
+        # no-op, so a just-revoked, just-expired token cannot flicker back.
+        return min(max(expires_at, now + 60), now + _MAX_RETENTION_SECONDS)
+
+    def _sweep_locked(self) -> None:
+        """Drop expired entries; caller holds the lock."""
+        now = time.time()
+        for entries in (self._revoked_tokens, self._revoked_families):
+            expired = [key for key, exp in entries.items() if exp <= now]
+            for key in expired:
+                del entries[key]
+
+    def revoke(self, token_id: str, expires_at: Optional[float] = None) -> None:
+        """Mark a single token id (jti or fallback hash) as revoked until
+        ``expires_at`` (the token's own ``exp`` when the caller has a
+        verified payload; bounded default otherwise)."""
+        with self._lock:
+            self._sweep_locked()
+            self._revoked_tokens[token_id] = self._effective_expiry(expires_at)
 
     def is_revoked(self, token_id: Optional[str]) -> bool:
-        """Lock-free membership test (single set op, atomic under the GIL)."""
+        """Lock-free membership test (single dict op, atomic under the GIL).
+
+        A swept-but-not-yet-removed entry can only concern an expired token,
+        which every verification path already rejects on ``exp``."""
         return token_id is not None and token_id in self._revoked_tokens
 
     def check_and_claim_refresh(
-        self, jti: Optional[str], family: Optional[str], rotate: bool
+        self,
+        jti: Optional[str],
+        family: Optional[str],
+        rotate: bool,
+        expires_at: Optional[float] = None,
     ) -> bool:
         """Atomic revocation check and (with rotation) consumption of a
         refresh token. Returns True when reuse was detected.
+
+        ``expires_at`` is the presented refresh token's ``exp``: the claimed
+        jti needs remembering exactly that long. A family marker set on reuse
+        detection gets the retention bound instead - descendants minted
+        before detection can outlive the presented ancestor, and the bound
+        covers the longest-lived possible descendant.
 
         Must be the LAST validation in the refresh grant: from the moment it
         claims the jti, a rejected request would have consumed the token
         (#56 review; see the call site's ordering comment).
         """
         with self._lock:
+            self._sweep_locked()
             family_revoked = bool(family) and family in self._revoked_families
             token_revoked = jti in self._revoked_tokens
             if token_revoked or family_revoked:
                 if rotate and family and not family_revoked:
-                    self._revoked_families.add(family)
+                    self._revoked_families[family] = self._effective_expiry(None)
                 return True
             if rotate and jti:
-                self._revoked_tokens.add(jti)
+                self._revoked_tokens[jti] = self._effective_expiry(expires_at)
             return False
 
     def clear(self) -> None:

--- a/src/nanoidp/services/revocation.py
+++ b/src/nanoidp/services/revocation.py
@@ -17,15 +17,19 @@ it names expires - after ``exp`` the signature check rejects it anyway - so
 every entry carries an expiry and the store sweeps opportunistically on the
 mutating paths (which already serialize under the lock). Before this, both
 sets grew without bound: every revocation and every rotation on a long-lived
-instance was a permanent memory increment. A VERIFIED exp is kept exactly
-(tokens minted via /api or MCP can legitimately outlive any fixed bound);
-callers holding only unverified claims pass no exp at all; and writes are
-monotonic - re-revoking never shortens retention (#293 review round 1).
+instance was a permanent memory increment. The expiry follows a three-state
+trust contract (#293 review rounds 1+2, spelled out on RevocationStore): a
+VERIFIED exp is kept exactly (tokens minted via /api or MCP can outlive any
+fixed bound); a verified payload WITHOUT exp - which verify_jwt accepts -
+gets indefinite retention, because a token that never expires can never
+have its revocation forgotten; callers holding only unverified claims pass
+nothing and get the bounded default. Writes are monotonic - re-revoking
+never shortens retention.
 """
 
 import threading
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 # The retention when the caller cannot supply a TRUSTED exp: covers the
 # 7-day refresh JWT (services/token.py mints refresh tokens with a fixed
@@ -37,16 +41,37 @@ from typing import Dict, Optional
 _DEFAULT_RETENTION_SECONDS = 8 * 24 * 3600
 
 
+class _Unset:
+    """Sentinel type: the caller has NO trusted expiry to offer (an
+    unverified payload, or no payload at all). Distinct from None, which a
+    verified caller passes when its payload genuinely carries no exp claim
+    (#293 review round 2): verify_jwt does not require exp, so a signed
+    token without one verifies - and such a token NEVER expires, meaning
+    its revocation can never be forgotten either."""
+
+
+_UNSET = _Unset()
+
+_ExpiresAt = Union[float, None, _Unset]
+
+
 class RevocationStore:
     """Revoked token ids (jti or token hash) and revoked rotation families,
     each remembered until its expiry.
 
-    TRUST CONTRACT: ``expires_at`` must come from a VERIFIED payload's
-    ``exp`` (crypto.verify_jwt), and is then kept exactly - however long.
-    A caller holding only unverified claims (e.g. /logout's id_token_hint)
-    passes None and gets the bounded default; the trust decision lives at
-    the call site, not in a store-side cap that would break trusted long
-    expiries.
+    TRUST CONTRACT, three states (#293 review rounds 1+2):
+
+    - ``expires_at`` OMITTED (the ``_UNSET`` default): the caller has no
+      trusted expiry - an unverified payload (/logout's id_token_hint) or
+      none at all. Bounded default retention.
+    - ``expires_at=None`` from a VERIFIED payload: the token carries no exp
+      claim, which verify_jwt accepts - it never expires, so the entry gets
+      INDEFINITE retention (never swept). This is the pre-#288 behavior for
+      exactly the tokens where forgetting would be wrong.
+    - ``expires_at=<number>`` from a VERIFIED payload: kept exactly,
+      however long (no cap - /api and MCP mint arbitrary lifetimes).
+
+    The trust decision lives at the call site, never in a store-side cap.
     """
 
     def __init__(self) -> None:
@@ -55,15 +80,24 @@ class RevocationStore:
         self._lock = threading.Lock()
 
     @staticmethod
-    def _effective_expiry(expires_at: Optional[float]) -> float:
-        """The verified exp when the caller has one, kept exactly; the
-        bounded default otherwise. A past exp still earns a short memory so
-        a just-revoked, just-expired token cannot flicker back before the
-        caller's own exp check catches it."""
+    def _effective_expiry(expires_at: _ExpiresAt) -> float:
+        """Resolve the three-state contract (see the class docstring). A
+        past numeric exp still earns a short memory so a just-revoked,
+        just-expired token cannot flicker back before the caller's own exp
+        check catches it. A trusted exp is normalized to float at this
+        boundary (PyJWT can hand back a value it merely coerced for its own
+        check); a trusted exp that does not coerce fails SAFE, toward
+        indefinite retention - never toward forgetting a revocation."""
         now = time.time()
-        if expires_at is None:
+        if isinstance(expires_at, _Unset):
             return now + _DEFAULT_RETENTION_SECONDS
-        return max(expires_at, now + 60)
+        if expires_at is None:
+            return float("inf")
+        try:
+            numeric = float(expires_at)
+        except (TypeError, ValueError):
+            return float("inf")
+        return max(numeric, now + 60)
 
     def _sweep_locked(self) -> None:
         """Drop expired entries; caller holds the lock."""
@@ -73,10 +107,11 @@ class RevocationStore:
             for key in expired:
                 del entries[key]
 
-    def revoke(self, token_id: str, expires_at: Optional[float] = None) -> None:
-        """Mark a single token id (jti or fallback hash) as revoked until
-        ``expires_at`` (a VERIFIED payload's ``exp``, kept exactly; bounded
-        default when the caller has none - see the class trust contract).
+    def revoke(self, token_id: str, expires_at: _ExpiresAt = _UNSET) -> None:
+        """Mark a single token id (jti or fallback hash) as revoked per the
+        three-state trust contract on the class: omitted = bounded default;
+        None from a verified payload = the token never expires, indefinite
+        retention; a number from a verified payload = kept exactly.
 
         Monotonic: re-revoking an id can only EXTEND its retention, never
         shorten it - the old set.add() was naturally idempotent, and a plain
@@ -103,16 +138,19 @@ class RevocationStore:
         jti: Optional[str],
         family: Optional[str],
         rotate: bool,
-        expires_at: Optional[float] = None,
+        expires_at: _ExpiresAt = _UNSET,
     ) -> bool:
         """Atomic revocation check and (with rotation) consumption of a
         refresh token. Returns True when reuse was detected.
 
-        ``expires_at`` is the presented refresh token's ``exp``: the claimed
-        jti needs remembering exactly that long. A family marker set on reuse
-        detection gets the retention bound instead - descendants minted
-        before detection can outlive the presented ancestor, and the bound
-        covers the longest-lived possible descendant.
+        ``expires_at`` is the presented refresh token's verified ``exp``
+        (three-state contract, see the class docstring): the claimed jti
+        needs remembering exactly that long - indefinitely for a verified
+        token without exp, which never stops being presentable. A family
+        marker set on reuse detection gets the retention bound when the
+        presented ancestor carries an exp (every nanoidp-minted descendant
+        lives at most 7 more days), and indefinite retention when it does
+        not (its descendants may be equally undying).
 
         Must be the LAST validation in the refresh grant: from the moment it
         claims the jti, a rejected request would have consumed the token
@@ -124,7 +162,12 @@ class RevocationStore:
             token_revoked = jti in self._revoked_tokens
             if token_revoked or family_revoked:
                 if rotate and family and not family_revoked:
-                    self._revoked_families[family] = self._effective_expiry(None)
+                    family_retention = (
+                        float("inf") if expires_at is None else _UNSET
+                    )
+                    self._revoked_families[family] = self._effective_expiry(
+                        family_retention
+                    )
                 return True
             if rotate and jti:
                 self._revoked_tokens[jti] = self._effective_expiry(expires_at)

--- a/src/nanoidp/services/revocation.py
+++ b/src/nanoidp/services/revocation.py
@@ -17,23 +17,37 @@ it names expires - after ``exp`` the signature check rejects it anyway - so
 every entry carries an expiry and the store sweeps opportunistically on the
 mutating paths (which already serialize under the lock). Before this, both
 sets grew without bound: every revocation and every rotation on a long-lived
-instance was a permanent memory increment.
+instance was a permanent memory increment. A VERIFIED exp is kept exactly
+(tokens minted via /api or MCP can legitimately outlive any fixed bound);
+callers holding only unverified claims pass no exp at all; and writes are
+monotonic - re-revoking never shortens retention (#293 review round 1).
 """
 
 import threading
 import time
 from typing import Dict, Optional
 
-# The longest a revocation entry can matter when the caller cannot supply the
-# token's own exp: no nanoidp token outlives the 7-day refresh JWT
-# (services/token.py mints refresh tokens with a fixed 7-day expiry; access
-# and ID tokens are shorter). One extra day absorbs clock skew.
-_MAX_RETENTION_SECONDS = 8 * 24 * 3600
+# The retention when the caller cannot supply a TRUSTED exp: covers the
+# 7-day refresh JWT (services/token.py mints refresh tokens with a fixed
+# 7-day expiry) plus one day of clock skew. NOT a cap on trusted expiries:
+# /api/users/<username>/token and MCP generate_token mint access tokens with
+# arbitrary exp_minutes, so a verified exp can legitimately exceed this -
+# capping it let a revoked 14-day token flicker back after the day-8 sweep
+# (#293 review round 1, blocker 1).
+_DEFAULT_RETENTION_SECONDS = 8 * 24 * 3600
 
 
 class RevocationStore:
     """Revoked token ids (jti or token hash) and revoked rotation families,
-    each remembered until its expiry."""
+    each remembered until its expiry.
+
+    TRUST CONTRACT: ``expires_at`` must come from a VERIFIED payload's
+    ``exp`` (crypto.verify_jwt), and is then kept exactly - however long.
+    A caller holding only unverified claims (e.g. /logout's id_token_hint)
+    passes None and gets the bounded default; the trust decision lives at
+    the call site, not in a store-side cap that would break trusted long
+    expiries.
+    """
 
     def __init__(self) -> None:
         self._revoked_tokens: Dict[str, float] = {}
@@ -42,16 +56,14 @@ class RevocationStore:
 
     @staticmethod
     def _effective_expiry(expires_at: Optional[float]) -> float:
-        """The caller's exp when it has one (a verified payload's ``exp``),
-        else the conservative retention bound."""
+        """The verified exp when the caller has one, kept exactly; the
+        bounded default otherwise. A past exp still earns a short memory so
+        a just-revoked, just-expired token cannot flicker back before the
+        caller's own exp check catches it."""
         now = time.time()
         if expires_at is None:
-            return now + _MAX_RETENTION_SECONDS
-        # Never trust an attacker-influenced exp to EXTEND retention past the
-        # bound (e.g. /logout decodes id_token_hint unverified), and treat a
-        # past exp as "still worth a short memory" rather than an instant
-        # no-op, so a just-revoked, just-expired token cannot flicker back.
-        return min(max(expires_at, now + 60), now + _MAX_RETENTION_SECONDS)
+            return now + _DEFAULT_RETENTION_SECONDS
+        return max(expires_at, now + 60)
 
     def _sweep_locked(self) -> None:
         """Drop expired entries; caller holds the lock."""
@@ -63,11 +75,21 @@ class RevocationStore:
 
     def revoke(self, token_id: str, expires_at: Optional[float] = None) -> None:
         """Mark a single token id (jti or fallback hash) as revoked until
-        ``expires_at`` (the token's own ``exp`` when the caller has a
-        verified payload; bounded default otherwise)."""
+        ``expires_at`` (a VERIFIED payload's ``exp``, kept exactly; bounded
+        default when the caller has none - see the class trust contract).
+
+        Monotonic: re-revoking an id can only EXTEND its retention, never
+        shorten it - the old set.add() was naturally idempotent, and a plain
+        assignment would let a later revoke with a shorter expiry (a second
+        /logout, say) cut an existing revocation short (#293 review round 1,
+        blocker 2).
+        """
         with self._lock:
             self._sweep_locked()
-            self._revoked_tokens[token_id] = self._effective_expiry(expires_at)
+            self._revoked_tokens[token_id] = max(
+                self._revoked_tokens.get(token_id, 0.0),
+                self._effective_expiry(expires_at),
+            )
 
     def is_revoked(self, token_id: Optional[str]) -> bool:
         """Lock-free membership test (single dict op, atomic under the GIL).

--- a/tests/test_revocation_expiry.py
+++ b/tests/test_revocation_expiry.py
@@ -15,7 +15,7 @@ import time
 import pytest
 
 from nanoidp.services import revocation
-from nanoidp.services.revocation import _MAX_RETENTION_SECONDS, RevocationStore
+from nanoidp.services.revocation import _DEFAULT_RETENTION_SECONDS, RevocationStore
 
 
 @pytest.fixture
@@ -43,15 +43,37 @@ class TestEntryExpiry:
         store.revoke("jti-noexp")
         assert store.is_revoked("jti-noexp")
 
-        _advance(monkeypatch, _MAX_RETENTION_SECONDS + 60)
+        _advance(monkeypatch, _DEFAULT_RETENTION_SECONDS + 60)
         store.revoke("other")
         assert not store.is_revoked("jti-noexp")
 
-    def test_attacker_supplied_far_future_exp_is_capped(self, store):
-        """/logout decodes id_token_hint UNVERIFIED: a forged exp must not
-        pin memory forever."""
-        store.revoke("jti-forged", expires_at=time.time() + 10 * 365 * 24 * 3600)
-        assert store._revoked_tokens["jti-forged"] <= time.time() + _MAX_RETENTION_SECONDS + 1
+    def test_logout_forged_exp_never_reaches_the_store(self, client):
+        """/logout decodes id_token_hint UNVERIFIED, so no claim from it -
+        exp included - reaches the store (#293 review round 1): the entry
+        gets the bounded default, not the forged 10-year exp. Route-level
+        because the trust decision lives at the call site now, not in a
+        store-side cap (which would break trusted long expiries, blocker 1)."""
+        import jwt as pyjwt
+
+        from nanoidp.services.revocation import get_revocation_store
+
+        forged = pyjwt.encode(
+            {"jti": "forged-jti", "exp": time.time() + 10 * 365 * 24 * 3600, "sub": "x"},
+            "attacker-key",
+            algorithm="HS256",
+        )
+        get_revocation_store().clear()
+        try:
+            resp = client.get("/logout", query_string={"id_token_hint": forged})
+            assert resp.status_code in (200, 302)
+            store = get_revocation_store()
+            assert store.is_revoked("forged-jti")
+            assert (
+                store._revoked_tokens["forged-jti"]
+                <= time.time() + _DEFAULT_RETENTION_SECONDS + 1
+            )
+        finally:
+            get_revocation_store().clear()
 
     def test_already_expired_token_keeps_a_short_memory(self, store):
         """A just-revoked, just-expired token must not flicker back as
@@ -100,3 +122,37 @@ class TestRefreshClaimExpiry:
         assert store.check_and_claim_refresh("r2", "famZ", True) is True
         store.clear()
         assert store.check_and_claim_refresh("r1", "famZ", True) is False
+
+
+class TestReviewRound1Blockers:
+    """#293 review round 1: two retention-semantics blockers."""
+
+    def test_trusted_exp_beyond_the_bound_survives_the_sweep(self, store, monkeypatch):
+        """B1: /api/users/<u>/token accepts arbitrary exp_minutes, so a
+        VERIFIED token can outlive the 8-day bound - capping a trusted exp
+        let a revoked 14-day token flicker back after the day-8 sweep."""
+        fourteen_days = time.time() + 14 * 24 * 3600
+        store.revoke("jti-long", expires_at=fourteen_days)
+
+        _advance(monkeypatch, 9 * 24 * 3600)
+        store.revoke("trigger-sweep")
+        assert store.is_revoked("jti-long"), (
+            "a verified 14-day token must stay revoked past day 8"
+        )
+
+        _advance(monkeypatch, 15 * 24 * 3600)
+        store.revoke("trigger-sweep-2")
+        assert not store.is_revoked("jti-long")
+
+    def test_re_revoking_never_shortens_retention(self, store, monkeypatch):
+        """B2: writes are monotonic - a second revoke of the same jti with a
+        shorter expiry must not shorten the existing retention (the old
+        set.add() was naturally idempotent; the dict assignment was not)."""
+        store.revoke("jti-twice", expires_at=time.time() + 3600)
+        store.revoke("jti-twice", expires_at=time.time() + 60)
+
+        _advance(monkeypatch, 600)
+        store.revoke("trigger-sweep")
+        assert store.is_revoked("jti-twice"), (
+            "the 1-hour revocation must survive a later 60-second re-revoke"
+        )

--- a/tests/test_revocation_expiry.py
+++ b/tests/test_revocation_expiry.py
@@ -156,3 +156,41 @@ class TestReviewRound1Blockers:
         assert store.is_revoked("jti-twice"), (
             "the 1-hour revocation must survive a later 60-second re-revoke"
         )
+
+
+class TestReviewRound2TrustedNoExp:
+    """#293 review round 2: verify_jwt does not require the exp claim, so a
+    SIGNED token without exp verifies - and such a token never expires. Its
+    revocation (or refresh consumption) must never be forgotten; None from a
+    verified payload means 'no expiry', not 'use the default'."""
+
+    def test_verified_no_exp_revocation_is_indefinite(self, store, monkeypatch):
+        store.revoke("jti-eternal", expires_at=None)
+
+        _advance(monkeypatch, 9 * 24 * 3600)
+        store.revoke("trigger-sweep")
+        assert store.is_revoked("jti-eternal"), (
+            "a verified token without exp never expires - its revocation "
+            "must survive any sweep"
+        )
+
+        _advance(monkeypatch, 10 * 365 * 24 * 3600)
+        store.revoke("trigger-sweep-2")
+        assert store.is_revoked("jti-eternal")
+
+    def test_verified_no_exp_refresh_claim_is_indefinite(self, store, monkeypatch):
+        assert store.check_and_claim_refresh("rt-eternal", "fam-e", True, expires_at=None) is False
+
+        _advance(monkeypatch, 9 * 24 * 3600)
+        store.revoke("trigger-sweep")
+        assert (
+            store.check_and_claim_refresh("rt-eternal", "fam-e", True, expires_at=None) is True
+        ), "a consumed no-exp refresh token must stay consumed forever"
+
+    def test_trusted_exp_is_normalized_to_a_number(self, store):
+        """PyJWT can hand back an exp it merely coerced for its own check;
+        the store normalizes at the boundary so retention math never
+        compares mixed types."""
+        store.revoke("jti-strexp", expires_at="4102444800")
+        assert isinstance(store._revoked_tokens["jti-strexp"], float)
+        assert store._revoked_tokens["jti-strexp"] == 4102444800.0

--- a/tests/test_revocation_expiry.py
+++ b/tests/test_revocation_expiry.py
@@ -1,0 +1,102 @@
+"""
+RevocationStore entry expiry and opportunistic sweep (#288).
+
+Before this, revoked jtis and rotation-family markers lived in two sets that
+were never swept: every revocation and every rotation on a long-lived
+instance was a permanent memory increment. A revoked jti only needs
+remembering until the token it names expires - after ``exp`` the signature
+check rejects it anyway.
+
+Time is driven by monkeypatching ``time.time`` inside the module - no sleeps.
+"""
+
+import time
+
+import pytest
+
+from nanoidp.services import revocation
+from nanoidp.services.revocation import _MAX_RETENTION_SECONDS, RevocationStore
+
+
+@pytest.fixture
+def store():
+    return RevocationStore()
+
+
+def _advance(monkeypatch, seconds):
+    real_now = time.time()
+    monkeypatch.setattr(revocation.time, "time", lambda: real_now + seconds)
+
+
+class TestEntryExpiry:
+    def test_revoked_until_exp_then_swept(self, store, monkeypatch):
+        store.revoke("jti-a", expires_at=time.time() + 100)
+        assert store.is_revoked("jti-a")
+
+        _advance(monkeypatch, 200)
+        # Sweep runs on the next mutating call.
+        store.revoke("jti-b", expires_at=revocation.time.time() + 100)
+        assert not store.is_revoked("jti-a")
+        assert store.is_revoked("jti-b")
+
+    def test_no_exp_falls_back_to_bounded_retention(self, store, monkeypatch):
+        store.revoke("jti-noexp")
+        assert store.is_revoked("jti-noexp")
+
+        _advance(monkeypatch, _MAX_RETENTION_SECONDS + 60)
+        store.revoke("other")
+        assert not store.is_revoked("jti-noexp")
+
+    def test_attacker_supplied_far_future_exp_is_capped(self, store):
+        """/logout decodes id_token_hint UNVERIFIED: a forged exp must not
+        pin memory forever."""
+        store.revoke("jti-forged", expires_at=time.time() + 10 * 365 * 24 * 3600)
+        assert store._revoked_tokens["jti-forged"] <= time.time() + _MAX_RETENTION_SECONDS + 1
+
+    def test_already_expired_token_keeps_a_short_memory(self, store):
+        """A just-revoked, just-expired token must not flicker back as
+        unrevoked before the caller's own exp check catches it."""
+        store.revoke("jti-old", expires_at=time.time() - 1000)
+        assert store.is_revoked("jti-old")
+
+
+class TestRefreshClaimExpiry:
+    def test_claimed_jti_expires_with_its_token(self, store, monkeypatch):
+        exp = time.time() + 100
+        reused = store.check_and_claim_refresh("rt-1", "fam-1", True, expires_at=exp)
+        assert reused is False
+        # Reuse before exp is detected.
+        assert store.check_and_claim_refresh("rt-1", "fam-1", True, expires_at=exp) is True
+
+        _advance(monkeypatch, 200)
+        # After the token's own exp the claim may be forgotten: the JWT is
+        # rejected on exp long before this store is consulted.
+        store.revoke("unrelated")
+        assert not store.is_revoked("rt-1")
+
+    def test_family_marker_outlives_the_presented_token(self, store, monkeypatch):
+        """Descendants minted before reuse detection can outlive the
+        presented ancestor: the family marker gets the retention bound, not
+        the ancestor's exp."""
+        near_exp = time.time() + 5
+        store.check_and_claim_refresh("rt-a", "fam-x", True, expires_at=near_exp)
+        assert store.check_and_claim_refresh("rt-a", "fam-x", True, expires_at=near_exp) is True
+
+        _advance(monkeypatch, 3600)
+        # Well past the ancestor's exp, the family is still revoked for a
+        # descendant presenting a longer-lived token.
+        assert (
+            store.check_and_claim_refresh(
+                "rt-descendant", "fam-x", True, expires_at=revocation.time.time() + 1000
+            )
+            is True
+        )
+
+    def test_rotation_semantics_unchanged(self, store):
+        """The pre-#288 contract: first claim passes, family revocation on
+        reuse hits every member."""
+        assert store.check_and_claim_refresh("r1", "famZ", True) is False
+        assert store.check_and_claim_refresh("r1", "famZ", True) is True
+        assert store.check_and_claim_refresh("r2", "famZ", True) is True
+        store.clear()
+        assert store.check_and_claim_refresh("r1", "famZ", True) is False


### PR DESCRIPTION
Closes #288. The audit's "leak by construction": revoked jtis and rotation-family markers were kept in two never-swept sets, so every revocation and every refresh rotation on a long-lived instance was a permanent memory increment.

## The three-state trust contract (final shape, review rounds 1+2)

Entries are `id -> expires_at`, resolved by a contract expressed in the store's own API (not implicitly in the callers):

- **`expires_at` omitted** (`_UNSET` sentinel, the default): the caller has no trusted expiry - an unverified payload (`/logout`'s `id_token_hint`, which is decoded without verification and passes NO claim to the store) or none at all. Bounded default retention: 8 days, covering the 7-day refresh JWT plus clock skew.
- **`expires_at=None` from a verified payload**: the token carries no `exp` claim - which `verify_jwt` accepts - so it never expires, and the entry gets **indefinite retention** (never swept). The pre-#288 behavior for exactly the tokens where forgetting would be wrong.
- **`expires_at=<number>` from a verified payload** (`/revoke` after signature verification; the refresh grant's claim): kept **exactly, however long** - `/api/users/<u>/token` and MCP `generate_token` mint arbitrary lifetimes, so no fixed cap is safe. Normalized to `float` at the boundary (PyJWT can hand back an exp it merely coerced for its own check); a non-coercible trusted exp fails SAFE toward indefinite retention, never toward forgetting a revocation.

Writes are **monotonic** (`max(existing, new)`): re-revoking a jti can only extend its retention - restoring the idempotence the old `set.add()` gave for free. The family marker set on reuse detection follows the presented ancestor: bounded when it carries an `exp` (every nanoidp-minted descendant lives at most 7 more days), indefinite when it does not. `check_and_claim_refresh` keeps its exact pre-#288 contract (pinned): first claim passes, reuse revokes the whole family, last validation in the grant.

Sweep runs opportunistically on the mutating paths, which already serialize under the store lock; `is_revoked` stays lock-free (a stale entry past `exp` can only concern a token every verification path already rejects on `exp`).

Out of scope, agreed in review: requiring `exp` globally in `verify_jwt` (a wider contract change touching every token consumer). Inheritance note for #192/#235: a future persistent store should represent "no expiry" explicitly (NULL) rather than serializing infinity - this PR's in-memory `float("inf")` is pragmatic, not a serialization format.

## Verification

12 tests in `tests/test_revocation_expiry.py` (time monkeypatched, no sleeps), including the review regressions: a verified 14-day exp survives the day-8 sweep and is swept after its own exp; a re-revoke with a shorter expiry never shortens retention; a verified no-exp revocation and a consumed no-exp refresh claim both survive a 10-year jump; a forged 10-year exp in `/logout`'s hint provably never reaches the store; string-exp normalization. Suite 1912 green, mypy/ruff/import-linter clean.
