### PR TITLE
fix: UI edit no longer corrupts non-string user attributes (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,10 @@ previous leniency allowed - needs a one-time adjustment.
   the nine user shapes (model, YAML entry, MCP read/create/update surfaces,
   UI form, REST read) are held to field-set equality with documented,
   asserted exclusions - the guard whose absence let #280 drift silently.
-  Found and recorded #291 (the UI users form has no `attributes` input).
+  Found #291 - originally misfiled as "no `attributes` input in the UI
+  form" (the dynamic `attr_key[]`/`attr_value[]` widget was there all
+  along, invisible to the single-name regex); the real defect behind it is
+  fixed below.
 - **"Domain invariants have one home" review rule** (#285) in CONTRIBUTING,
   echoed from VISION principle 4; five deferred imports claiming
   nonexistent circular dependencies hoisted to module top, and the one
@@ -306,6 +309,16 @@ previous leniency allowed - needs a one-time adjustment.
   claims (the `/logout` id_token_hint) pass nothing and get a bounded
   8-day default; and writes are monotonic, so re-revoking a jti can only
   extend its retention, never shorten it.
+- **The UI users form no longer corrupts non-string attributes on edit**
+  (#291): a list- or mapping-valued custom attribute (settable via YAML and
+  MCP) rendered in the edit form as its Python repr, so an untouched edit
+  round-trip silently replaced `{"teams": ["alpha", "beta"]}` with the
+  string `"['alpha', 'beta']"`. Non-string values now render as JSON and a
+  value starting with `[` or `{` is parsed back as JSON (malformed JSON
+  stays the literal string; plain scalars typed in the UI remain strings).
+  The duplicated attribute-row parser in the create and edit routes is now
+  one shared helper, and the user-field parity test recognizes the widget
+  explicitly instead of excluding the field.
 - **MCP `update_user` can now update custom `attributes`** (#280): the field
   was accepted by `create_user` and returned by every read surface, but the
   `update_user` schema and handler silently lacked it - an agent could set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,9 +313,12 @@ previous leniency allowed - needs a one-time adjustment.
   (#291): a list- or mapping-valued custom attribute (settable via YAML and
   MCP) rendered in the edit form as its Python repr, so an untouched edit
   round-trip silently replaced `{"teams": ["alpha", "beta"]}` with the
-  string `"['alpha', 'beta']"`. Non-string values now render as JSON and a
-  value starting with `[` or `{` is parsed back as JSON (malformed JSON
-  stays the literal string; plain scalars typed in the UI remain strings).
+  string `"['alpha', 'beta']"`. Each row now carries an explicit
+  `attr_encoding[]` (review round 1): `string` values stay verbatim even
+  when they LOOK like JSON (so the string `'["a"]'` survives an edit as a
+  string), `json` rows (container values rendered as JSON) parse back, and
+  rows typed fresh in the browser use `auto` - the `[`/`{` heuristic, with
+  malformed JSON degrading to the literal string.
   The duplicated attribute-row parser in the create and edit routes is now
   one shared helper, and the user-field parity test recognizes the widget
   explicitly instead of excluding the field.

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -239,15 +239,8 @@ def user_create() -> ResponseReturnValue:
         entitlements = [e.strip() for e in request.form.get("entitlements", "").split("\n") if e.strip()]
         source_acl = [a.strip() for a in request.form.get("source_acl", "").split("\n") if a.strip()]
 
-        # Parse dynamic attributes
-        attr_keys = request.form.getlist("attr_key[]")
-        attr_values = request.form.getlist("attr_value[]")
-        attributes = {}
-        for key, value in zip(attr_keys, attr_values, strict=False):
-            key = key.strip()
-            value = value.strip()
-            if key and value:
-                attributes[key] = value
+        # Parse dynamic attributes (shared with the edit route, #291)
+        attributes = _parse_attribute_rows()
 
         user = User(
             username=username,
@@ -340,15 +333,8 @@ def user_edit(username: str) -> ResponseReturnValue:
         entitlements = [e.strip() for e in request.form.get("entitlements", "").split("\n") if e.strip()]
         source_acl = [a.strip() for a in request.form.get("source_acl", "").split("\n") if a.strip()]
 
-        # Parse dynamic attributes
-        attr_keys = request.form.getlist("attr_key[]")
-        attr_values = request.form.getlist("attr_value[]")
-        attributes = {}
-        for key, value in zip(attr_keys, attr_values, strict=False):
-            key = key.strip()
-            value = value.strip()
-            if key and value:
-                attributes[key] = value
+        # Parse dynamic attributes (shared with the edit route, #291)
+        attributes = _parse_attribute_rows()
 
         updated_user = User(
             username=username,
@@ -414,6 +400,39 @@ def clients() -> ResponseReturnValue:
         current_user=session.get("user"),
         revision=current_revision(get_yaml_writer().settings_file),
     )
+
+
+def _parse_attribute_rows() -> dict:
+    """Parse the users form's dynamic attr_key[]/attr_value[] rows (#291).
+
+    Values follow a JSON convention for non-string types: the template
+    renders a container-valued attribute (list/dict, settable via YAML and
+    MCP) as JSON, and a value starting with '[' or '{' is parsed back as
+    JSON here - so a list attribute survives an untouched edit round-trip
+    instead of being stored as its Python repr (the #291 corruption).
+    Anything else stays the literal string the operator typed; a malformed
+    JSON container also stays a string rather than erroring, matching the
+    form's permissive style. Blank key or value drops the row (blank value
+    = remove the attribute).
+    """
+    attributes = {}
+    for key, value in zip(
+        request.form.getlist("attr_key[]"),
+        request.form.getlist("attr_value[]"),
+        strict=False,
+    ):
+        key = key.strip()
+        value = value.strip()
+        if not (key and value):
+            continue
+        if value[0] in "[{":
+            try:
+                attributes[key] = json.loads(value)
+                continue
+            except ValueError:
+                pass
+        attributes[key] = value
+    return attributes
 
 
 def _parse_textarea_list(form_value: str) -> list[str]:

--- a/src/nanoidp/routes/ui.py
+++ b/src/nanoidp/routes/ui.py
@@ -403,29 +403,40 @@ def clients() -> ResponseReturnValue:
 
 
 def _parse_attribute_rows() -> dict:
-    """Parse the users form's dynamic attr_key[]/attr_value[] rows (#291).
+    """Parse the users form's dynamic attr_key[]/attr_value[]/attr_encoding[]
+    rows (#291, reshaped by the #294 review).
 
-    Values follow a JSON convention for non-string types: the template
-    renders a container-valued attribute (list/dict, settable via YAML and
-    MCP) as JSON, and a value starting with '[' or '{' is parsed back as
-    JSON here - so a list attribute survives an untouched edit round-trip
-    instead of being stored as its Python repr (the #291 corruption).
-    Anything else stays the literal string the operator typed; a malformed
-    JSON container also stays a string rather than erroring, matching the
-    form's permissive style. Blank key or value drops the row (blank value
-    = remove the attribute).
+    A text box cannot distinguish the STRING '["a"]' from the LIST ["a"]
+    once both are rendered as text, so each row carries an explicit
+    encoding, stamped by the template for prefilled rows and 'auto' for
+    rows typed fresh in the browser:
+
+    - 'string': kept verbatim, even when it looks like JSON - this is what
+      protects a JSON-looking string attribute across an untouched edit.
+    - 'json': the template rendered a container value (list/dict, settable
+      via YAML and MCP) as JSON; parsed back. If the operator edited it
+      into something that no longer parses, it degrades to the literal
+      string rather than erroring, matching the form's permissive style.
+    - 'auto' (or absent - a scripted POST without the hidden field): the
+      convenience heuristic - a value starting with '[' or '{' is tried as
+      JSON, anything else is a string.
+
+    Blank key or value drops the row (blank value = remove the attribute).
     """
+    keys = request.form.getlist("attr_key[]")
+    values = request.form.getlist("attr_value[]")
+    encodings = request.form.getlist("attr_encoding[]")
     attributes = {}
-    for key, value in zip(
-        request.form.getlist("attr_key[]"),
-        request.form.getlist("attr_value[]"),
-        strict=False,
-    ):
+    for index, (key, value) in enumerate(zip(keys, values, strict=False)):
         key = key.strip()
         value = value.strip()
         if not (key and value):
             continue
-        if value[0] in "[{":
+        encoding = encodings[index] if index < len(encodings) else "auto"
+        if encoding == "string":
+            attributes[key] = value
+            continue
+        if encoding == "json" or value[0] in "[{":
             try:
                 attributes[key] = json.loads(value)
                 continue

--- a/src/nanoidp/templates/users_form.html
+++ b/src/nanoidp/templates/users_form.html
@@ -99,7 +99,15 @@
                                 <input type="text" class="form-control form-control-sm" name="attr_key[]" value="{{ key }}" placeholder="Key">
                             </div>
                             <div class="col-5">
-                                <input type="text" class="form-control form-control-sm" name="attr_value[]" value="{{ value }}" placeholder="Value">
+                                {# Non-string values (a list/dict attribute set via
+                                   YAML or MCP) render as JSON so an untouched edit
+                                   round-trip preserves them; the route parses a
+                                   value starting with [ or { back as JSON (#291).
+                                   Plain strings stay verbatim. #}
+                                {# |forceescape after |tojson: tojson marks its
+                                   output safe and does NOT escape double quotes,
+                                   which would break this double-quoted attribute. #}
+                                <input type="text" class="form-control form-control-sm" name="attr_value[]" value="{{ value if value is string else value|tojson|forceescape }}" placeholder="Value">
                             </div>
                             <div class="col-2">
                                 <button type="button" class="btn btn-outline-danger btn-sm w-100" onclick="removeAttribute(this)">

--- a/src/nanoidp/templates/users_form.html
+++ b/src/nanoidp/templates/users_form.html
@@ -108,6 +108,13 @@
                                    output safe and does NOT escape double quotes,
                                    which would break this double-quoted attribute. #}
                                 <input type="text" class="form-control form-control-sm" name="attr_value[]" value="{{ value if value is string else value|tojson|forceescape }}" placeholder="Value">
+                                {# attr_encoding[] (#294 review): the value box has
+                                   no way to distinguish the STRING '["a"]' from the
+                                   LIST ["a"] once both are rendered as text, so each
+                                   row states how its value is encoded. 'auto' (rows
+                                   typed fresh in the browser) keeps the [/{ JSON
+                                   heuristic for operator convenience. #}
+                                <input type="hidden" name="attr_encoding[]" value="{{ 'string' if value is string else 'json' }}">
                             </div>
                             <div class="col-2">
                                 <button type="button" class="btn btn-outline-danger btn-sm w-100" onclick="removeAttribute(this)">
@@ -261,6 +268,7 @@ function addAttribute() {
         </div>
         <div class="col-5">
             <input type="text" class="form-control form-control-sm" name="attr_value[]" placeholder="Value">
+            <input type="hidden" name="attr_encoding[]" value="auto">
         </div>
         <div class="col-2">
             <button type="button" class="btn btn-outline-danger btn-sm w-100" onclick="removeAttribute(this)">

--- a/tests/test_ui_user_attributes.py
+++ b/tests/test_ui_user_attributes.py
@@ -1,0 +1,118 @@
+"""
+UI users form: non-string attributes survive an edit round-trip (#291).
+
+Reproduced before the fix: the template rendered ``value="{{ value }}"``, so
+a list-valued attribute (settable via YAML and MCP) rendered as its Python
+repr and an UNTOUCHED edit stored ``"['alpha', 'beta']"`` (a string) in its
+place. The fix is a JSON convention: the template renders non-string values
+as JSON, and the shared parser reads a value starting with ``[`` or ``{``
+back as JSON.
+"""
+
+import re
+
+from werkzeug.datastructures import MultiDict
+
+from nanoidp.config import get_config
+
+
+def _resubmit_edit_form_unchanged(client, html, extra=None):
+    """Post the edit form back exactly as a browser would (entities decoded)."""
+    import html as html_mod
+
+    keys = [html_mod.unescape(v) for v in re.findall(r'name="attr_key\[\]" value="([^"]*)"', html)]
+    values = [html_mod.unescape(v) for v in re.findall(r'name="attr_value\[\]" value="([^"]*)"', html)]
+    md = MultiDict(
+        {
+            "password": "",
+            "description": "",
+            "email": "admin@example.org",
+            "tenant": "default",
+            "roles": "USER",
+            "groups": "",
+            "entitlements": "",
+            "source_acl": "",
+        }
+    )
+    for k in keys:
+        md.add("attr_key[]", k)
+    for v in values:
+        md.add("attr_value[]", v)
+    m = re.search(r'name="expected_revision" value="([^"]*)"', html)
+    if m:
+        md.add("expected_revision", m.group(1))
+    if extra:
+        for k, v in extra.items():
+            md.add(k, v)
+    return client.post("/users/admin/edit", data=md)
+
+
+class TestAttributeRoundTrip:
+    def _login(self, client):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+
+    def test_list_attribute_survives_untouched_edit(self, client, app):
+        with app.app_context():
+            get_config().get_user("admin").attributes = {
+                "teams": ["alpha", "beta"],
+                "plain": "x",
+            }
+        self._login(client)
+
+        page = client.get("/users/admin/edit")
+        html = page.data.decode()
+        resp = _resubmit_edit_form_unchanged(client, html)
+        assert resp.status_code == 302
+
+        with app.app_context():
+            stored = get_config().get_user("admin").attributes
+        assert stored == {"teams": ["alpha", "beta"], "plain": "x"}
+
+    def test_mapping_attribute_survives_untouched_edit(self, client, app):
+        with app.app_context():
+            get_config().get_user("admin").attributes = {"limits": {"rate": 5}}
+        self._login(client)
+
+        html = client.get("/users/admin/edit").data.decode()
+        assert _resubmit_edit_form_unchanged(client, html).status_code == 302
+        with app.app_context():
+            assert get_config().get_user("admin").attributes == {"limits": {"rate": 5}}
+
+    def test_operator_typed_json_container_is_parsed(self, client, app):
+        """Typing a JSON list into the value box stores a list - the same
+        convention in the write direction."""
+        self._login(client)
+        html = client.get("/users/admin/edit").data.decode()
+        # Wipe any prefilled attribute rows; submit exactly one typed row.
+        html_no_attrs = re.sub(r'name="attr_(?:key|value)\[\]" value="[^"]*"', "", html)
+        resp = _resubmit_edit_form_unchanged(
+            client, html_no_attrs, extra={"attr_key[]": "regions", "attr_value[]": '["eu", "us"]'}
+        )
+        assert resp.status_code == 302
+        with app.app_context():
+            assert get_config().get_user("admin").attributes == {"regions": ["eu", "us"]}
+
+    def test_malformed_json_container_stays_a_string(self, client, app):
+        self._login(client)
+        html = client.get("/users/admin/edit").data.decode()
+        html_no_attrs = re.sub(r'name="attr_(?:key|value)\[\]" value="[^"]*"', "", html)
+        resp = _resubmit_edit_form_unchanged(
+            client, html_no_attrs, extra={"attr_key[]": "oops", "attr_value[]": "[not json"}
+        )
+        assert resp.status_code == 302
+        with app.app_context():
+            assert get_config().get_user("admin").attributes == {"oops": "[not json"}
+
+    def test_plain_string_value_stays_verbatim(self, client, app):
+        self._login(client)
+        html = client.get("/users/admin/edit").data.decode()
+        html_no_attrs = re.sub(r'name="attr_(?:key|value)\[\]" value="[^"]*"', "", html)
+        resp = _resubmit_edit_form_unchanged(
+            client, html_no_attrs, extra={"attr_key[]": "note", "attr_value[]": "123"}
+        )
+        assert resp.status_code == 302
+        with app.app_context():
+            # Scalars typed in the UI are strings by design; only [ / { opt
+            # into the JSON convention.
+            assert get_config().get_user("admin").attributes == {"note": "123"}

--- a/tests/test_ui_user_attributes.py
+++ b/tests/test_ui_user_attributes.py
@@ -22,6 +22,7 @@ def _resubmit_edit_form_unchanged(client, html, extra=None):
 
     keys = [html_mod.unescape(v) for v in re.findall(r'name="attr_key\[\]" value="([^"]*)"', html)]
     values = [html_mod.unescape(v) for v in re.findall(r'name="attr_value\[\]" value="([^"]*)"', html)]
+    encodings = re.findall(r'name="attr_encoding\[\]" value="([^"]*)"', html)
     md = MultiDict(
         {
             "password": "",
@@ -38,6 +39,8 @@ def _resubmit_edit_form_unchanged(client, html, extra=None):
         md.add("attr_key[]", k)
     for v in values:
         md.add("attr_value[]", v)
+    for e in encodings:
+        md.add("attr_encoding[]", e)
     m = re.search(r'name="expected_revision" value="([^"]*)"', html)
     if m:
         md.add("expected_revision", m.group(1))
@@ -85,7 +88,7 @@ class TestAttributeRoundTrip:
         self._login(client)
         html = client.get("/users/admin/edit").data.decode()
         # Wipe any prefilled attribute rows; submit exactly one typed row.
-        html_no_attrs = re.sub(r'name="attr_(?:key|value)\[\]" value="[^"]*"', "", html)
+        html_no_attrs = re.sub(r'name="attr_(?:key|value|encoding)\[\]" value="[^"]*"', "", html)
         resp = _resubmit_edit_form_unchanged(
             client, html_no_attrs, extra={"attr_key[]": "regions", "attr_value[]": '["eu", "us"]'}
         )
@@ -96,7 +99,7 @@ class TestAttributeRoundTrip:
     def test_malformed_json_container_stays_a_string(self, client, app):
         self._login(client)
         html = client.get("/users/admin/edit").data.decode()
-        html_no_attrs = re.sub(r'name="attr_(?:key|value)\[\]" value="[^"]*"', "", html)
+        html_no_attrs = re.sub(r'name="attr_(?:key|value|encoding)\[\]" value="[^"]*"', "", html)
         resp = _resubmit_edit_form_unchanged(
             client, html_no_attrs, extra={"attr_key[]": "oops", "attr_value[]": "[not json"}
         )
@@ -107,7 +110,7 @@ class TestAttributeRoundTrip:
     def test_plain_string_value_stays_verbatim(self, client, app):
         self._login(client)
         html = client.get("/users/admin/edit").data.decode()
-        html_no_attrs = re.sub(r'name="attr_(?:key|value)\[\]" value="[^"]*"', "", html)
+        html_no_attrs = re.sub(r'name="attr_(?:key|value|encoding)\[\]" value="[^"]*"', "", html)
         resp = _resubmit_edit_form_unchanged(
             client, html_no_attrs, extra={"attr_key[]": "note", "attr_value[]": "123"}
         )
@@ -116,3 +119,31 @@ class TestAttributeRoundTrip:
             # Scalars typed in the UI are strings by design; only [ / { opt
             # into the JSON convention.
             assert get_config().get_user("admin").attributes == {"note": "123"}
+
+
+class TestJsonLookingString:
+    """#294 review round 1: a STRING attribute whose value merely looks like
+    JSON ('["alpha","beta"]' the string) rendered verbatim and was then
+    re-parsed as JSON on submit - an untouched edit silently turned it into
+    a real list. Rows now carry an explicit attr_encoding[] (string/json;
+    'auto' for rows typed fresh in the browser), so the type survives."""
+
+    def _login(self, client):
+        with client.session_transaction() as sess:
+            sess["user"] = "admin"
+
+    def test_json_looking_string_survives_untouched_edit(self, client, app):
+        with app.app_context():
+            get_config().get_user("admin").attributes = {
+                "note": '["alpha", "beta"]',
+                "real": ["alpha", "beta"],
+            }
+        self._login(client)
+
+        html = client.get("/users/admin/edit").data.decode()
+        resp = _resubmit_edit_form_unchanged(client, html)
+        assert resp.status_code == 302
+
+        with app.app_context():
+            stored = get_config().get_user("admin").attributes
+        assert stored == {"note": '["alpha", "beta"]', "real": ["alpha", "beta"]}, stored

--- a/tests/test_user_field_parity.py
+++ b/tests/test_user_field_parity.py
@@ -16,8 +16,9 @@ that stops being true also fails):
 - ``password`` never appears on a read surface (_user_to_dict, /api/users).
 - The MCP _USER_COMMON_PROPERTIES block omits username/password because the
   create/update schemas declare those two separately.
-- The UI users form has no input for ``attributes`` - the one write surface
-  that cannot touch the field, recorded as #291 rather than silently skipped.
+- ``attributes`` in the UI is a dynamic ``attr_key[]``/``attr_value[]``
+  widget, not a single named input - recognized explicitly (#291 corrected:
+  the input was never missing, the single-name regex just could not see it).
 - ``/api/users/<u>`` adds derived ``authorities`` (not a stored field).
 """
 
@@ -61,13 +62,17 @@ class TestUserFieldParity:
     def test_users_form_has_an_input_per_field(self):
         html = _TEMPLATE.read_text()
         form_names = set(re.findall(r'name="([a-z_]+)"', html))
-        # attributes: the UI form cannot set custom attributes today - the
-        # only write surface with that gap, tracked as #291. If this
-        # assertion starts failing because the input EXISTS, close #291 and
-        # delete the exclusion.
+        # attributes is a dynamic key/value widget, not a single named input:
+        # attr_key[]/attr_value[] rows (brackets, so the regex above cannot
+        # see them - the #291 premise error: this test originally declared
+        # the input missing without reading the template). Recognized
+        # explicitly instead of excluded.
+        widget_names = set(re.findall(r'name="([a-z_\[\]]+)"', html))
+        assert {"attr_key[]", "attr_value[]"} <= widget_names, (
+            "the users form lost its attributes widget"
+        )
         missing = _MODEL_FIELDS - form_names - {"attributes"}
         assert not missing, f"users_form.html has no input for: {sorted(missing)}"
-        assert "attributes" not in form_names, "attributes input exists: close #291"
 
     def test_api_read_surface_matches_the_model(self, client):
         resp = client.get("/api/users/admin")


### PR DESCRIPTION
Closes #291 - with a premise correction that reshaped the issue (see the retitle and comment there): the users form has had a dynamic `attr_key[]`/`attr_value[]` attributes widget all along; the audit's "no input" claim came from a single-name regex that cannot see brackets, asserted without reading the template.

The **real defect**, reproduced empirically before fixing: the edit form rendered `value="{{ value }}"`, so a list- or mapping-valued attribute (settable via YAML and MCP) rendered as its Python repr - an **untouched** edit round-trip silently replaced `{"teams": ["alpha", "beta"]}` with the string `"['alpha', 'beta']"`.

## The fix (final shape, review round 1)

Each attribute row carries an explicit hidden **`attr_encoding[]`**, because a text box cannot distinguish the STRING `'["a"]'` from the LIST `["a"]` once both are rendered as text:

- **`string`** (stamped by the template for string values): kept verbatim on submit, even when the value looks like JSON - the round-1 blocker was exactly this string being re-parsed into a real list by the `[`/`{` heuristic;
- **`json`** (stamped for container values, rendered via `|tojson|forceescape` - `tojson` marks its output safe and does NOT escape double quotes, which would break the double-quoted attribute): parsed back on submit; edited into non-JSON, it degrades to the literal string, matching the form's permissive style;
- **`auto`** (rows typed fresh in the browser, and the per-row fallback for scripted POSTs without the hidden field): the `[`/`{` convenience heuristic - a typed JSON container stores as a container, plain scalars stay strings.

The attribute-row parser, previously duplicated verbatim in the create and edit routes, is one shared `_parse_attribute_rows()`. `test_user_field_parity.py` recognizes the widget explicitly (asserting `attr_key[]`/`attr_value[]` exist) instead of excluding the field on a false premise, and the misleading CHANGELOG line from #292 is corrected.

## Verification

6 round-trip tests in `tests/test_ui_user_attributes.py`, browser-realistic (HTML entities decoded, encodings carried like a browser would): list and mapping surviving an untouched edit; **the JSON-looking string surviving next to the real list** (the round-1 regression, reproduced red first); typed JSON container parsed; malformed JSON kept literal; plain scalar verbatim. Verified live both rounds: seeded via explicit encodings, untouched round-trip preserves both types. Suite 1892 on the rebased head (current `main`), mypy/ruff clean.
