### PR TITLE
refactor: one error shape per surface class (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,18 @@ previous leniency allowed - needs a one-time adjustment.
   it previously claimed "after JWT authentication", which the code never did.
 
 ### Changed
+- **`/saml/attribute-query` transport errors are SOAP 1.1 Faults** (#287):
+  a malformed query (missing AttributeQuery/Subject/NameID) or an internal
+  failure now answers with a proper `soap:Fault` (HTTP 500, `faultcode`
+  Client/Server per SOAP 1.1 §6.2) instead of bare plain text with a 400 -
+  a shape no SOAP stack could parse. Protocol-level conditions (unknown
+  principal) keep answering inside the SAML Response as before.
+- **The dead exception hierarchy is gone** (#287): `exceptions.py` declared
+  20 classes of which exactly one was ever raised; only `SAMLSignatureError`
+  remains (now a plain `Exception` subclass). Errors are shaped per surface
+  - the model is written down in CONTRIBUTING ("Error surfaces"), including
+  the deliberate two-layer MCP contract (dispatch refusals vs domain
+  results), now documented where the shapes are defined.
 - `TokenService.create_token` now owns the #73 mint-side rule (#278):
   `issue_refresh_token` defaults to "only when the token is bound"
   (`client_id` given), and asking for a refresh token without a binding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,11 +153,14 @@ class's shape, never invents a seventh:
   failures on the SOAP endpoint answer with a SOAP 1.1 Fault (HTTP 500,
   `faultcode` Client/Server per SOAP 1.1 §6.2). Browser-facing SSO steps may
   use Werkzeug `abort()` HTML, since the reader is a person mid-redirect.
-- **MCP**: two deliberate layers - dispatch refusals
-  (`{"error", "code", "tool"}`, `is_error=True`, the `MCP_*` code taxonomy)
-  vs domain results (`{"success": False, "error", ...}` plus `kind` for
-  typed conditions), because "not found" is an answer, not a failed call.
-  The layer contract is documented on `_reject` in `mcp_server.py`.
+- **MCP**: two deliberate SHAPES - dispatch refusals
+  (`{"error", "code", "tool"}`, the `MCP_*` code taxonomy) vs domain
+  results (`{"success": False, "error", ...}` plus `kind` for typed
+  conditions). Both come back `is_error=True` (call_tool flags
+  `success is False or "error" in result`); what stays `is_error=False`
+  are the NEGATIVE QUERIES - `found: False`, `valid: False` - because a
+  miss is an answer, not a failed call. The full table lives in the
+  `mcp_server` module docstring; the layer contract on `_reject`.
 
 Typed exceptions are not the error channel: `exceptions.py` deliberately
 holds only what is actually raised (`SAMLSignatureError`); a taxonomy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,32 @@ constraint comments teach the next contributor a wrong module graph. The one
 real import constraint is the `serialization` contract above; everything
 else imports normally at module top.
 
+### Error surfaces (#287)
+
+Each surface class has ONE error shape; a new endpoint or tool uses its
+class's shape, never invents a seventh:
+
+- **OAuth/OIDC protocol endpoints**: RFC 6749 §5.2 JSON
+  (`error`/`error_description`), except `/authorize` errors after
+  `redirect_uri` validation, which redirect with `error`, `state` and `iss`
+  (RFC 6749 §4.1.2.1, RFC 9207). Never HTML, never bare text.
+- **Browser/UI pages**: `flash(message, "error")` + redirect; conflict and
+  hook conditions render their message through the shared helpers.
+- **SAML**: protocol-level failures answer IN the protocol - a SAML `Status`
+  (e.g. `Requester`/`UnknownPrincipal`) inside a Response; transport-level
+  failures on the SOAP endpoint answer with a SOAP 1.1 Fault (HTTP 500,
+  `faultcode` Client/Server per SOAP 1.1 §6.2). Browser-facing SSO steps may
+  use Werkzeug `abort()` HTML, since the reader is a person mid-redirect.
+- **MCP**: two deliberate layers - dispatch refusals
+  (`{"error", "code", "tool"}`, `is_error=True`, the `MCP_*` code taxonomy)
+  vs domain results (`{"success": False, "error", ...}` plus `kind` for
+  typed conditions), because "not found" is an answer, not a failed call.
+  The layer contract is documented on `_reject` in `mcp_server.py`.
+
+Typed exceptions are not the error channel: `exceptions.py` deliberately
+holds only what is actually raised (`SAMLSignatureError`); a taxonomy
+nothing raises is documentation that lies.
+
 ## Code Style
 
 - Follow PEP 8 (enforced by Black and Ruff)

--- a/e2e/test_agent.py
+++ b/e2e/test_agent.py
@@ -2597,66 +2597,82 @@ class NanoIDPTestAgent:
             return self._add_result("SAML SSO (Redirect binding)", TestCategory.SAML, False, str(e))
 
     def test_saml_attribute_query(self) -> TestResult:
-        """SAML Attribute Query endpoint."""
-        try:
-            # Create minimal attribute query
-            attr_query = f"""
-            <samlp:AttributeQuery xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-                ID="_attrquery123" Version="2.0" IssueInstant="2024-01-01T00:00:00Z">
-                <saml:Issuer>test-sp</saml:Issuer>
-                <saml:Subject>
-                    <saml:NameID>{self.username}</saml:NameID>
-                </saml:Subject>
-            </samlp:AttributeQuery>
-            """.strip()
+        """SAML Attribute Query endpoint (SOAP binding).
 
-            response = requests.post(
-                f"{self.base_url}/saml/attribute-query",
-                data=attr_query,
-                headers={"Content-Type": "application/xml"},
-                timeout=5
+        The query is SOAP-enveloped, as the SAML SOAP binding requires and
+        as the route implements: a bare AttributeQuery posted without the
+        envelope is a malformed request (#295 review found this test had
+        ALWAYS sent it bare, always landed in a 400 fallback branch, and
+        never exercised the success path or the #275 unknown-user leg).
+        Three legs: valid query -> attributes; unknown NameID -> SAML
+        Requester/UnknownPrincipal status with no assertion (#275);
+        malformed query (no Subject) -> SOAP 1.1 Fault, HTTP 500,
+        faultcode soap:Client (#287).
+        """
+        def _enveloped(inner: str) -> str:
+            return (
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+                f"<soap:Body>{inner}</soap:Body></soap:Envelope>"
             )
 
-            # Should return SAML response
-            if response.status_code == 200:
-                is_xml = "xml" in response.headers.get("Content-Type", "") or response.text.strip().startswith("<")
-                has_attributes = "Attribute" in response.text
+        def _query(name_id: str) -> str:
+            return _enveloped(
+                '<samlp:AttributeQuery xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+                ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+                ' ID="_attrquery123" Version="2.0" IssueInstant="2024-01-01T00:00:00Z">'
+                "<saml:Issuer>test-sp</saml:Issuer>"
+                f"<saml:Subject><saml:NameID>{name_id}</saml:NameID></saml:Subject>"
+                "</samlp:AttributeQuery>"
+            )
 
-                # #275 negative: an unknown NameID must get a SAML error
-                # status (Requester/UnknownPrincipal) with NO assertion,
-                # never the old fabricated-attributes fallback.
-                unknown_query = attr_query.replace(
-                    f"<saml:NameID>{self.username}</saml:NameID>",
-                    "<saml:NameID>no-such-user-e2e</saml:NameID>",
-                )
-                unknown_resp = requests.post(
-                    f"{self.base_url}/saml/attribute-query",
-                    data=unknown_query,
-                    headers={"Content-Type": "application/xml"},
-                    timeout=5,
-                )
-                unknown_ok = (
-                    unknown_resp.status_code == 200
-                    and "UnknownPrincipal" in unknown_resp.text
-                    and "Assertion" not in unknown_resp.text
-                )
-                return self._add_result(
-                    "SAML Attribute Query",
-                    TestCategory.SAML,
-                    is_xml and unknown_ok,
-                    f"Response received, has_attributes={has_attributes}; "
-                    f"unknown NameID -> UnknownPrincipal without assertion: {unknown_ok}",
-                    {"has_attributes": has_attributes, "unknown_principal_error": unknown_ok}
-                )
+        try:
+            checks = {}
 
-            # Some implementations might not support this
+            valid = requests.post(
+                f"{self.base_url}/saml/attribute-query",
+                data=_query(self.username),
+                headers={"Content-Type": "text/xml"},
+                timeout=5,
+            )
+            checks["valid_query_200_with_attributes"] = (
+                valid.status_code == 200 and "Attribute" in valid.text
+            )
+
+            unknown = requests.post(
+                f"{self.base_url}/saml/attribute-query",
+                data=_query("no-such-user-e2e"),
+                headers={"Content-Type": "text/xml"},
+                timeout=5,
+            )
+            checks["unknown_nameid_unknownprincipal_no_assertion"] = (
+                unknown.status_code == 200
+                and "UnknownPrincipal" in unknown.text
+                and "Assertion" not in unknown.text
+            )
+
+            malformed = requests.post(
+                f"{self.base_url}/saml/attribute-query",
+                data=_enveloped(
+                    '<samlp:AttributeQuery xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+                    ' ID="_x" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"/>'
+                ),
+                headers={"Content-Type": "text/xml"},
+                timeout=5,
+            )
+            checks["malformed_query_soap_client_fault"] = (
+                malformed.status_code == 500
+                and "soap:Fault" in malformed.text
+                and "soap:Client" in malformed.text
+            )
+
+            success = all(checks.values())
             return self._add_result(
                 "SAML Attribute Query",
                 TestCategory.SAML,
-                response.status_code in [200, 400, 501],
-                f"Status: {response.status_code}",
-                {"status": response.status_code}
+                success,
+                "; ".join(f"{k}={v}" for k, v in checks.items()),
+                checks,
             )
         except Exception as e:
             return self._add_result("SAML Attribute Query", TestCategory.SAML, False, str(e))

--- a/src/nanoidp/exceptions.py
+++ b/src/nanoidp/exceptions.py
@@ -1,198 +1,22 @@
 """
 Typed exceptions for NanoIDP.
-Provides clear, specific error handling across the application.
+
+This module once declared a 20-class hierarchy (base NanoIDPError, per-domain
+subclasses with error codes) of which exactly one class was ever raised or
+caught; routes shape their errors per surface instead - RFC 6749 §5.2 JSON on
+the OAuth endpoints, flash messages in the UI, SAML Status / SOAP Fault on
+the SAML endpoints, the layered result shapes in the MCP server (see
+CONTRIBUTING, "Error surfaces"). The dead hierarchy was removed in #287
+rather than retrofitted: an exception taxonomy nothing raises is
+documentation that lies.
 """
 
-from typing import Optional
 
-
-class NanoIDPError(Exception):
-    """Base exception for all NanoIDP errors."""
-
-    def __init__(self, message: str, code: str = "NANOIDP_ERROR") -> None:
-        self.message = message
-        self.code = code
-        super().__init__(message)
-
-
-# Authentication Errors
-class AuthenticationError(NanoIDPError):
-    """Base class for authentication-related errors."""
-
-    def __init__(self, message: str, code: str = "AUTH_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class InvalidCredentialsError(AuthenticationError):
-    """Raised when username/password credentials are invalid."""
-
-    def __init__(self, message: str = "Invalid username or password") -> None:
-        super().__init__(message, "INVALID_CREDENTIALS")
-
-
-class UserNotFoundError(AuthenticationError):
-    """Raised when a user is not found."""
-
-    def __init__(self, username: str) -> None:
-        super().__init__(f"User not found: {username}", "USER_NOT_FOUND")
-        self.username = username
-
-
-# Client Errors
-class ClientError(NanoIDPError):
-    """Base class for OAuth client-related errors."""
-
-    def __init__(self, message: str, code: str = "CLIENT_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class ClientNotFoundError(ClientError):
-    """Raised when an OAuth client is not found."""
-
-    def __init__(self, client_id: str) -> None:
-        super().__init__(f"Client not found: {client_id}", "CLIENT_NOT_FOUND")
-        self.client_id = client_id
-
-
-class InvalidClientCredentialsError(ClientError):
-    """Raised when client credentials are invalid."""
-
-    def __init__(self, client_id: str) -> None:
-        super().__init__(
-            f"Invalid credentials for client: {client_id}",
-            "INVALID_CLIENT_CREDENTIALS"
-        )
-        self.client_id = client_id
-
-
-# Token Errors
-class TokenError(NanoIDPError):
-    """Base class for token-related errors."""
-
-    def __init__(self, message: str, code: str = "TOKEN_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class InvalidTokenError(TokenError):
-    """Raised when a token is invalid or malformed."""
-
-    def __init__(self, message: str = "Invalid token") -> None:
-        super().__init__(message, "INVALID_TOKEN")
-
-
-class ExpiredTokenError(TokenError):
-    """Raised when a token has expired."""
-
-    def __init__(self, message: str = "Token has expired") -> None:
-        super().__init__(message, "EXPIRED_TOKEN")
-
-
-class RevokedTokenError(TokenError):
-    """Raised when a token has been revoked."""
-
-    def __init__(self, message: str = "Token has been revoked") -> None:
-        super().__init__(message, "REVOKED_TOKEN")
-
-
-# Authorization Code Errors
-class AuthCodeError(NanoIDPError):
-    """Base class for authorization code errors."""
-
-    def __init__(self, message: str, code: str = "AUTH_CODE_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class InvalidAuthCodeError(AuthCodeError):
-    """Raised when an authorization code is invalid."""
-
-    def __init__(self, message: str = "Invalid authorization code") -> None:
-        super().__init__(message, "INVALID_AUTH_CODE")
-
-
-class ExpiredAuthCodeError(AuthCodeError):
-    """Raised when an authorization code has expired."""
-
-    def __init__(self, message: str = "Authorization code has expired") -> None:
-        super().__init__(message, "EXPIRED_AUTH_CODE")
-
-
-class PKCEValidationError(AuthCodeError):
-    """Raised when PKCE code_verifier validation fails."""
-
-    def __init__(self, message: str = "PKCE validation failed") -> None:
-        super().__init__(message, "PKCE_VALIDATION_FAILED")
-
-
-# Configuration Errors
-class ConfigurationError(NanoIDPError):
-    """Base class for configuration-related errors."""
-
-    def __init__(self, message: str, code: str = "CONFIG_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class ConfigFileNotFoundError(ConfigurationError):
-    """Raised when a configuration file is not found."""
-
-    def __init__(self, file_path: str) -> None:
-        super().__init__(
-            f"Configuration file not found: {file_path}",
-            "CONFIG_FILE_NOT_FOUND"
-        )
-        self.file_path = file_path
-
-
-class InvalidConfigurationError(ConfigurationError):
-    """Raised when configuration is invalid."""
-
-    def __init__(self, message: str, field: Optional[str] = None) -> None:
-        super().__init__(message, "INVALID_CONFIGURATION")
-        self.field = field
-
-
-# OAuth2 Grant Errors
-class GrantError(NanoIDPError):
-    """Base class for OAuth2 grant errors."""
-
-    def __init__(self, message: str, code: str = "GRANT_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class UnsupportedGrantTypeError(GrantError):
-    """Raised when an unsupported grant type is requested."""
-
-    def __init__(self, grant_type: str) -> None:
-        super().__init__(
-            f"Unsupported grant type: {grant_type}",
-            "UNSUPPORTED_GRANT_TYPE"
-        )
-        self.grant_type = grant_type
-
-
-class InvalidGrantError(GrantError):
-    """Raised when a grant is invalid."""
-
-    def __init__(self, message: str = "Invalid grant") -> None:
-        super().__init__(message, "INVALID_GRANT")
-
-
-# SAML Errors
-class SAMLError(NanoIDPError):
-    """Base class for SAML-related errors."""
-
-    def __init__(self, message: str, code: str = "SAML_ERROR") -> None:
-        super().__init__(message, code)
-
-
-class InvalidSAMLRequestError(SAMLError):
-    """Raised when a SAML request is invalid."""
-
-    def __init__(self, message: str = "Invalid SAML request") -> None:
-        super().__init__(message, "INVALID_SAML_REQUEST")
-
-
-class SAMLSignatureError(SAMLError):
-    """Raised when SAML signature validation fails."""
+class SAMLSignatureError(Exception):
+    """Raised when SAML request signature validation fails
+    (services/saml_verification.py); callers render str(e) into their
+    surface's own error shape."""
 
     def __init__(self, message: str = "SAML signature validation failed") -> None:
-        super().__init__(message, "SAML_SIGNATURE_ERROR")
+        self.message = message
+        super().__init__(message)

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -1206,6 +1206,22 @@ def _reject(name: str, code: str, message: str) -> CallToolResult:
     missing/invalid admin secret, unknown tool, bad arguments), which had
     drifted from each other - e.g. the admin-secret audit entry used to omit
     `tool`.
+
+    THE MCP ERROR MODEL IS TWO DELIBERATE LAYERS (#287), not one shape:
+
+    - DISPATCH refusals (this function): the call never reached a tool -
+      ``{"error", "code", "tool"}`` with ``is_error=True``. The ``code``
+      taxonomy (MCP_READONLY, MCP_ADMIN_SECRET_*, MCP_UNKNOWN_TOOL,
+      MCP_INVALID_ARGUMENTS, MCP_TOOL_FAILED) is transport-level.
+    - DOMAIN results (the handlers): the tool ran and answered -
+      ``{"success": False, "error", ...}`` (plus ``kind`` where a typed
+      condition exists: conflict, hook policy), with ``is_error`` unset,
+      because "user not found" is a valid answer, not a failed call.
+
+    Collapsing them into one shape would break every MCP consumer for a
+    cosmetic gain; what matters is that each layer has exactly one shape,
+    which this function and the handlers' shared conventions keep true.
+    See CONTRIBUTING, "Error surfaces".
     """
     _log_mcp_tool(name, success=False, details={"error": code, "tool": name})
     return _text_result({"error": message, "code": code, "tool": name}, is_error=True)

--- a/src/nanoidp/mcp_server.py
+++ b/src/nanoidp/mcp_server.py
@@ -1211,17 +1211,22 @@ def _reject(name: str, code: str, message: str) -> CallToolResult:
 
     - DISPATCH refusals (this function): the call never reached a tool -
       ``{"error", "code", "tool"}`` with ``is_error=True``. The ``code``
-      taxonomy (MCP_READONLY, MCP_ADMIN_SECRET_*, MCP_UNKNOWN_TOOL,
-      MCP_INVALID_ARGUMENTS, MCP_TOOL_FAILED) is transport-level.
+      taxonomy (MCP_READONLY_MODE, MCP_ADMIN_SECRET_REQUIRED, MCP_UNKNOWN_TOOL,
+      MCP_INVALID_ARGUMENTS, MCP_INTERNAL_ERROR) is transport-level.
     - DOMAIN results (the handlers): the tool ran and answered -
       ``{"success": False, "error", ...}`` (plus ``kind`` where a typed
-      condition exists: conflict, hook policy), with ``is_error`` unset,
-      because "user not found" is a valid answer, not a failed call.
+      condition exists: conflict, hook policy). These DO come back with
+      ``is_error=True`` as well: call_tool flags
+      ``result.get("success") is False or "error" in result`` (the
+      module-docstring isError contract). The "an answer, not an error"
+      cases are the NEGATIVE QUERIES - ``found: False`` (get_user/
+      get_client miss) and ``valid: False`` (verify_token) - which carry
+      no ``success``/``error`` key and stay ``is_error=False``.
 
-    Collapsing them into one shape would break every MCP consumer for a
-    cosmetic gain; what matters is that each layer has exactly one shape,
-    which this function and the handlers' shared conventions keep true.
-    See CONTRIBUTING, "Error surfaces".
+    Collapsing the two SHAPES into one would break every MCP consumer for
+    a cosmetic gain; what matters is that each layer has exactly one
+    shape, which this function, the handlers' conventions and the
+    module-docstring table keep true. See CONTRIBUTING, "Error surfaces".
     """
     _log_mcp_tool(name, success=False, details={"error": code, "tool": name})
     return _text_result({"error": message, "code": code, "tool": name}, is_error=True)

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -905,9 +905,16 @@ def attribute_query() -> ResponseReturnValue:
     config = get_config()
 
     try:
-        # Parse SOAP request body (using defusedxml to prevent XXE attacks)
+        # Parse SOAP request body (using defusedxml to prevent XXE attacks).
+        # Syntactically broken XML is the CLIENT's fault (#295 review): catch
+        # it here rather than letting it fall to the catch-all, which answers
+        # soap:Server for nanoidp-side failures.
         soap_body = request.data
-        root = secure_fromstring(soap_body)
+        try:
+            root = secure_fromstring(soap_body)
+        except Exception as parse_error:
+            logger.warning(f"AttributeQuery request is not well-formed XML: {parse_error}")
+            return _soap_fault("Request body is not well-formed XML")
 
         # SAML namespaces
         namespaces = {

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -861,6 +861,28 @@ def _sign_attribute_query_response(response_xml: str, sign: bool = True) -> str:
         return response_xml
 
 
+def _soap_fault(message: str, *, client_fault: bool = True) -> "ResponseReturnValue":
+    """A SOAP 1.1 Fault for the attribute-query endpoint (#287).
+
+    SOAP 1.1 §6.2: a SOAP error MUST be issued as HTTP 500, with faultcode
+    Client vs Server saying whose fault it is - the previous bare
+    ``return "text", 400`` answered a SOAP caller in a shape no SOAP stack
+    parses. Message content stays operator-facing plain text inside
+    faultstring.
+    """
+    code = "soap:Client" if client_fault else "soap:Server"
+    body = f"""<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <soap:Fault>
+            <faultcode>{code}</faultcode>
+            <faultstring>{message}</faultstring>
+        </soap:Fault>
+    </soap:Body>
+</soap:Envelope>"""
+    return Response(body, status=500, mimetype="text/xml")
+
+
 @saml_bp.route("/attribute-query", methods=["POST"])
 def attribute_query() -> ResponseReturnValue:
     """
@@ -898,18 +920,18 @@ def attribute_query() -> ResponseReturnValue:
         attr_query = root.find(".//saml2p:AttributeQuery", namespaces)
         if attr_query is None:
             logger.warning("Invalid AttributeQuery: AttributeQuery element not found")
-            return "Invalid AttributeQuery: AttributeQuery element not found", 400
+            return _soap_fault("Invalid AttributeQuery: AttributeQuery element not found")
 
         # Extract Subject/NameID (user identifier)
         subject = attr_query.find(".//saml2:Subject", namespaces)
         if subject is None:
             logger.warning("Invalid AttributeQuery: Subject not found")
-            return "Invalid AttributeQuery: Subject not found", 400
+            return _soap_fault("Invalid AttributeQuery: Subject not found")
 
         name_id_el = subject.find(".//saml2:NameID", namespaces)
         if name_id_el is None:
             logger.warning("Invalid AttributeQuery: NameID not found")
-            return "Invalid AttributeQuery: NameID not found", 400
+            return _soap_fault("Invalid AttributeQuery: NameID not found")
 
         user_id = name_id_el.text
         request_id = attr_query.get("ID", "_unknown")
@@ -1018,10 +1040,7 @@ def attribute_query() -> ResponseReturnValue:
         return Response(soap_response, mimetype="text/xml")
 
     except Exception as e:
-        logger.error(f"AttributeQuery error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"AttributeQuery error: {e}")
 
         audit_event(
             "saml_attribute_query",
@@ -1030,4 +1049,4 @@ def attribute_query() -> ResponseReturnValue:
             details={"error": str(e)},
         )
 
-        return "AttributeQuery failed", 500
+        return _soap_fault("AttributeQuery failed", client_fault=False)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,286 +1,32 @@
 """
-Unit tests for NanoIDP typed exceptions.
+Tests for the one exception nanoidp actually raises (#287).
+
+The 20-class hierarchy this file used to exercise was removed: only
+SAMLSignatureError was ever raised or caught in the codebase (the tests here
+were the hierarchy's sole consumer). Errors are shaped per surface instead -
+see CONTRIBUTING, "Error surfaces".
 """
 
 import pytest
 
-from nanoidp.exceptions import (
-    # Auth Code
-    AuthCodeError,
-    # Authentication
-    AuthenticationError,
-    # Client
-    ClientError,
-    ClientNotFoundError,
-    ConfigFileNotFoundError,
-    # Configuration
-    ConfigurationError,
-    ExpiredAuthCodeError,
-    ExpiredTokenError,
-    # Grant
-    GrantError,
-    InvalidAuthCodeError,
-    InvalidClientCredentialsError,
-    InvalidConfigurationError,
-    InvalidCredentialsError,
-    InvalidGrantError,
-    InvalidSAMLRequestError,
-    InvalidTokenError,
-    # Base
-    NanoIDPError,
-    PKCEValidationError,
-    RevokedTokenError,
-    # SAML
-    SAMLError,
-    SAMLSignatureError,
-    # Token
-    TokenError,
-    UnsupportedGrantTypeError,
-    UserNotFoundError,
-)
+from nanoidp.exceptions import SAMLSignatureError
 
 
-class TestBaseException:
-    """Tests for NanoIDPError base class."""
-
-    def test_base_exception_message(self):
-        """Test that base exception has message."""
-        exc = NanoIDPError("Something went wrong")
-        assert exc.message == "Something went wrong"
-        assert str(exc) == "Something went wrong"
-
-    def test_base_exception_code(self):
-        """Test that base exception has error code."""
-        exc = NanoIDPError("Error", code="CUSTOM_CODE")
-        assert exc.code == "CUSTOM_CODE"
-
-    def test_base_exception_default_code(self):
-        """Test default error code."""
-        exc = NanoIDPError("Error")
-        assert exc.code == "NANOIDP_ERROR"
-
-    def test_exception_is_catchable(self):
-        """Test that exceptions can be caught."""
-        with pytest.raises(NanoIDPError):
-            raise NanoIDPError("Test error")
-
-
-class TestAuthenticationErrors:
-    """Tests for authentication-related exceptions."""
-
-    def test_invalid_credentials_error(self):
-        """Test InvalidCredentialsError."""
-        exc = InvalidCredentialsError()
-        assert "Invalid" in exc.message
-        assert exc.code == "INVALID_CREDENTIALS"
-
-    def test_invalid_credentials_custom_message(self):
-        """Test InvalidCredentialsError with custom message."""
-        exc = InvalidCredentialsError("Wrong password")
-        assert exc.message == "Wrong password"
-
-    def test_user_not_found_error(self):
-        """Test UserNotFoundError."""
-        exc = UserNotFoundError("john")
-        assert "john" in exc.message
-        assert exc.username == "john"
-        assert exc.code == "USER_NOT_FOUND"
-
-    def test_authentication_error_inheritance(self):
-        """Test that auth errors inherit from AuthenticationError."""
-        exc = InvalidCredentialsError()
-        assert isinstance(exc, AuthenticationError)
-        assert isinstance(exc, NanoIDPError)
-
-
-class TestClientErrors:
-    """Tests for OAuth client-related exceptions."""
-
-    def test_client_not_found_error(self):
-        """Test ClientNotFoundError."""
-        exc = ClientNotFoundError("my-app")
-        assert "my-app" in exc.message
-        assert exc.client_id == "my-app"
-        assert exc.code == "CLIENT_NOT_FOUND"
-
-    def test_invalid_client_credentials_error(self):
-        """Test InvalidClientCredentialsError."""
-        exc = InvalidClientCredentialsError("my-app")
-        assert "my-app" in exc.message
-        assert exc.client_id == "my-app"
-        assert exc.code == "INVALID_CLIENT_CREDENTIALS"
-
-    def test_client_error_inheritance(self):
-        """Test that client errors inherit from ClientError."""
-        exc = ClientNotFoundError("test")
-        assert isinstance(exc, ClientError)
-        assert isinstance(exc, NanoIDPError)
-
-
-class TestTokenErrors:
-    """Tests for token-related exceptions."""
-
-    def test_invalid_token_error(self):
-        """Test InvalidTokenError."""
-        exc = InvalidTokenError()
-        assert exc.code == "INVALID_TOKEN"
-
-    def test_expired_token_error(self):
-        """Test ExpiredTokenError."""
-        exc = ExpiredTokenError()
-        assert "expired" in exc.message.lower()
-        assert exc.code == "EXPIRED_TOKEN"
-
-    def test_revoked_token_error(self):
-        """Test RevokedTokenError."""
-        exc = RevokedTokenError()
-        assert "revoked" in exc.message.lower()
-        assert exc.code == "REVOKED_TOKEN"
-
-    def test_token_error_inheritance(self):
-        """Test that token errors inherit from TokenError."""
-        exc = InvalidTokenError()
-        assert isinstance(exc, TokenError)
-        assert isinstance(exc, NanoIDPError)
-
-
-class TestAuthCodeErrors:
-    """Tests for authorization code exceptions."""
-
-    def test_invalid_auth_code_error(self):
-        """Test InvalidAuthCodeError."""
-        exc = InvalidAuthCodeError()
-        assert exc.code == "INVALID_AUTH_CODE"
-
-    def test_expired_auth_code_error(self):
-        """Test ExpiredAuthCodeError."""
-        exc = ExpiredAuthCodeError()
-        assert "expired" in exc.message.lower()
-        assert exc.code == "EXPIRED_AUTH_CODE"
-
-    def test_pkce_validation_error(self):
-        """Test PKCEValidationError."""
-        exc = PKCEValidationError()
-        assert "PKCE" in exc.message
-        assert exc.code == "PKCE_VALIDATION_FAILED"
-
-    def test_pkce_custom_message(self):
-        """Test PKCEValidationError with custom message."""
-        exc = PKCEValidationError("Invalid code_verifier")
-        assert exc.message == "Invalid code_verifier"
-
-    def test_auth_code_error_inheritance(self):
-        """Test that auth code errors inherit from AuthCodeError."""
-        exc = PKCEValidationError()
-        assert isinstance(exc, AuthCodeError)
-        assert isinstance(exc, NanoIDPError)
-
-
-class TestConfigurationErrors:
-    """Tests for configuration exceptions."""
-
-    def test_config_file_not_found_error(self):
-        """Test ConfigFileNotFoundError."""
-        exc = ConfigFileNotFoundError("/path/to/config.yaml")
-        assert "/path/to/config.yaml" in exc.message
-        assert exc.file_path == "/path/to/config.yaml"
-        assert exc.code == "CONFIG_FILE_NOT_FOUND"
-
-    def test_invalid_configuration_error(self):
-        """Test InvalidConfigurationError."""
-        exc = InvalidConfigurationError("Invalid port number", field="port")
-        assert "Invalid port" in exc.message
-        assert exc.field == "port"
-        assert exc.code == "INVALID_CONFIGURATION"
-
-    def test_configuration_error_inheritance(self):
-        """Test that config errors inherit from ConfigurationError."""
-        exc = ConfigFileNotFoundError("test")
-        assert isinstance(exc, ConfigurationError)
-        assert isinstance(exc, NanoIDPError)
-
-
-class TestGrantErrors:
-    """Tests for OAuth2 grant exceptions."""
-
-    def test_unsupported_grant_type_error(self):
-        """Test UnsupportedGrantTypeError."""
-        exc = UnsupportedGrantTypeError("implicit")
-        assert "implicit" in exc.message
-        assert exc.grant_type == "implicit"
-        assert exc.code == "UNSUPPORTED_GRANT_TYPE"
-
-    def test_invalid_grant_error(self):
-        """Test InvalidGrantError."""
-        exc = InvalidGrantError()
-        assert exc.code == "INVALID_GRANT"
-
-    def test_grant_error_inheritance(self):
-        """Test that grant errors inherit from GrantError."""
-        exc = InvalidGrantError()
-        assert isinstance(exc, GrantError)
-        assert isinstance(exc, NanoIDPError)
-
-
-class TestSAMLErrors:
-    """Tests for SAML exceptions."""
-
-    def test_invalid_saml_request_error(self):
-        """Test InvalidSAMLRequestError."""
-        exc = InvalidSAMLRequestError()
-        assert exc.code == "INVALID_SAML_REQUEST"
-
-    def test_saml_signature_error(self):
-        """Test SAMLSignatureError."""
+class TestSAMLSignatureError:
+    def test_default_message(self):
         exc = SAMLSignatureError()
-        assert "signature" in exc.message.lower()
-        assert exc.code == "SAML_SIGNATURE_ERROR"
+        assert str(exc) == "SAML signature validation failed"
+        assert exc.message == "SAML signature validation failed"
 
-    def test_saml_error_inheritance(self):
-        """Test that SAML errors inherit from SAMLError."""
-        exc = InvalidSAMLRequestError()
-        assert isinstance(exc, SAMLError)
-        assert isinstance(exc, NanoIDPError)
+    def test_custom_message(self):
+        exc = SAMLSignatureError("bad digest")
+        assert str(exc) == "bad digest"
 
+    def test_is_a_plain_exception(self):
+        """No hidden hierarchy: catching Exception is enough, and there is
+        no removed base class to accidentally depend on."""
+        assert SAMLSignatureError.__mro__[1] is Exception
 
-class TestExceptionHierarchy:
-    """Tests for exception hierarchy and catch-all behavior."""
-
-    def test_catch_all_with_base_class(self):
-        """Test that all exceptions can be caught with NanoIDPError."""
-        exceptions = [
-            InvalidCredentialsError(),
-            UserNotFoundError("test"),
-            ClientNotFoundError("test"),
-            InvalidTokenError(),
-            PKCEValidationError(),
-            ConfigFileNotFoundError("test"),
-            UnsupportedGrantTypeError("test"),
-            InvalidSAMLRequestError(),
-        ]
-
-        for exc in exceptions:
-            assert isinstance(exc, NanoIDPError)
-
-    def test_specific_catch(self):
-        """Test that specific exceptions can be caught separately."""
-        def raise_auth_error():
-            raise InvalidCredentialsError()
-
-        def raise_token_error():
-            raise ExpiredTokenError()
-
-        # AuthenticationError should catch InvalidCredentialsError
-        with pytest.raises(AuthenticationError):
-            raise_auth_error()
-
-        # TokenError should catch ExpiredTokenError
-        with pytest.raises(TokenError):
-            raise_token_error()
-
-        # But AuthenticationError should NOT catch TokenError
-        with pytest.raises(TokenError):
-            try:
-                raise_token_error()
-            except AuthenticationError:
-                pytest.fail("TokenError should not be caught by AuthenticationError")
+    def test_raisable_and_catchable(self):
+        with pytest.raises(SAMLSignatureError, match="bad digest"):
+            raise SAMLSignatureError("bad digest")

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -484,6 +484,19 @@ class TestSAMLAttributeQuery:
         assert b"soap:Client" in response.data
         assert b"Subject not found" in response.data
 
+    def test_attribute_query_broken_xml_is_a_client_fault(self, client):
+        """#295 review: syntactically broken XML is the CLIENT's invalid
+        input, not a nanoidp-side failure - soap:Client, never the
+        catch-all's soap:Server."""
+        response = client.post('/saml/attribute-query',
+            data="<soap:Envelope><not-closed",
+            content_type='text/xml'
+        )
+        assert response.status_code == 500
+        assert b"soap:Fault" in response.data
+        assert b"soap:Client" in response.data
+        assert b"soap:Server" not in response.data
+
     def test_attribute_query_unknown_user_returns_error_status(self, client):
         """#275: an unknown NameID gets a SAML error status
         (Requester/UnknownPrincipal), NOT a signed assertion with fabricated

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -478,7 +478,11 @@ class TestSAMLAttributeQuery:
             content_type='text/xml'
         )
 
-        assert response.status_code == 400
+        # SOAP 1.1 §6.2 (#287): errors ride HTTP 500 with a Fault whose
+        # faultcode says whose fault it is - a malformed query is Client's.
+        assert response.status_code == 500
+        assert b"soap:Client" in response.data
+        assert b"Subject not found" in response.data
 
     def test_attribute_query_unknown_user_returns_error_status(self, client):
         """#275: an unknown NameID gets a SAML error status
@@ -1551,7 +1555,9 @@ class TestSAMLFlowsComprehensive:
             content_type='text/xml'
         )
 
-        assert response.status_code == 400
+        # SOAP Fault (#287): HTTP 500, faultcode soap:Client.
+        assert response.status_code == 500
+        assert b"soap:Client" in response.data
 
     # =========================================================================
     # METADATA


### PR DESCRIPTION
Closes #287. Net -351 lines. Three moves, one behavior change:

- **Dead exception hierarchy removed.** `exceptions.py` declared 20 classes; a usage census (part of the audit) found exactly one ever raised or caught anywhere - `SAMLSignatureError` (the other apparent hits were pyjwt's own `InvalidTokenError` and a same-named test class). It stays, as a plain `Exception` subclass; the other 19 and their only consumer (their own 286-line test file) are gone. A taxonomy nothing raises is documentation that lies.
- **`/saml/attribute-query` transport errors are SOAP 1.1 Faults** (behavior change, CHANGELOGed): a malformed query or internal failure now answers `soap:Fault` on HTTP 500 with `faultcode` Client/Server per SOAP 1.1 §6.2, replacing `return "text", 400` - a shape no SOAP stack parses. Protocol-level conditions (UnknownPrincipal, #275) stay inside the SAML Response, signed as of #289. Also: the inline `import traceback` in the handler is now `logger.exception`.
- **The MCP error model is documented as the two-layer contract it already is** - dispatch refusals (`is_error` + `MCP_*` code taxonomy) vs domain results (`success: false` + `kind`), stated on `_reject` where the shape is defined. Deliberately NOT collapsed: "user not found" is an answer, not a failed call, and one wire shape would break every MCP consumer for cosmetic gain.

CONTRIBUTING gains an **"Error surfaces"** section naming the shape for each surface class (OAuth JSON/redirect per RFC 6749/9207, UI flash, SAML Status vs SOAP Fault, MCP layers) - the review criterion that stops a seventh mechanism from appearing, which is the real point before a second HTTP transport (#193, #286).

Suite 1873 green (31 dead-hierarchy tests replaced by 4 real ones), mypy/ruff/import-linter clean; verified live: a malformed query answers `soap:Fault`/`soap:Client` on HTTP 500 with the message in `faultstring`.