### PR TITLE
feat: the nanoidp token profile requires exp (#306, BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,10 +142,11 @@ previous leniency allowed - needs a one-time adjustment.
   affected. *Migration:* add an `exp` to such fixtures. No other claim is
   newly required.
 - **An unverifiable refresh token now answers RFC 6749 §5.2 JSON**
-  (`invalid_grant`, HTTP 400) instead of a Werkzeug 401 HTML page - the
-  one protocol-endpoint error that still violated the "Error surfaces"
-  rule (#287). *Migration:* read `error` from the JSON body; the status
-  moves from 401 to 400.
+  (`invalid_grant`, HTTP 400) instead of a Werkzeug 401 HTML page, per
+  the "Error surfaces" rule (#287). Other /token error branches still
+  answer Werkzeug HTML; converting them is tracked separately.
+  *Migration:* read `error` from the JSON body; the status moves from 401
+  to 400.
 
 ### Added
 - **Access-point parity contract for token issuance** (#283,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,24 @@ previous leniency allowed - needs a one-time adjustment.
   resource server - revocation is `/introspect`'s answer. Behavior is
   unchanged; both exemptions are now pinned by tests.
 
+- **The `exp` claim is required on every token nanoidp accepts** (#306).
+  `verify_jwt` now enforces `require: ["exp"]` - a correctly signed JWT
+  WITHOUT an expiry is rejected everywhere (`/userinfo`, `/introspect`,
+  `/revoke`, the refresh grant, MCP `verify_token`). This is nanoidp's
+  token-profile policy, not a JWT-spec rule (RFC 7519 leaves `exp`
+  optional; OIDC Core and RFC 9068 require it on the profiles that
+  matter): a token accepted by an IdP should have a finite lifetime, and
+  an eternal bearer token would let an integration test pass here and
+  fail against any real IdP. Everything nanoidp mints has always carried
+  `exp`; only hand-crafted tokens signed with the nanoidp key are
+  affected. *Migration:* add an `exp` to such fixtures. No other claim is
+  newly required.
+- **An unverifiable refresh token now answers RFC 6749 §5.2 JSON**
+  (`invalid_grant`, HTTP 400) instead of a Werkzeug 401 HTML page - the
+  one protocol-endpoint error that still violated the "Error surfaces"
+  rule (#287). *Migration:* read `error` from the JSON body; the status
+  moves from 401 to 400.
+
 ### Added
 - **Access-point parity contract for token issuance** (#283,
   `tests/test_token_issuance_parity.py`): the set of CALL SITES of

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -173,11 +173,17 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
         # "Error surfaces" rule: protocol endpoints never answer HTML). An
         # unverifiable refresh token - bad signature, expired, or missing
         # the exp the nanoidp token profile requires - is invalid_grant.
+        # The description is FIXED text (CodeQL on this PR, same rule as
+        # the #200 review): the underlying library's exception message goes
+        # to the audit trail above, never to the external caller.
         return (
             jsonify(
                 {
                     "error": "invalid_grant",
-                    "error_description": f"Invalid refresh token: {str(e)}",
+                    "error_description": (
+                        "Refresh token is invalid: bad signature, expired, "
+                        "or not acceptable under the nanoidp token profile"
+                    ),
                 }
             ),
             400,

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -169,7 +169,19 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
                 "grant_type": ctx.grant_type,
             },
         )
-        return abort(401, description=f"Invalid refresh token: {str(e)}")
+        # RFC 6749 §5.2 JSON, not Werkzeug HTML (#306 review, per the #287
+        # "Error surfaces" rule: protocol endpoints never answer HTML). An
+        # unverifiable refresh token - bad signature, expired, or missing
+        # the exp the nanoidp token profile requires - is invalid_grant.
+        return (
+            jsonify(
+                {
+                    "error": "invalid_grant",
+                    "error_description": f"Invalid refresh token: {str(e)}",
+                }
+            ),
+            400,
+        )
 
     # Check if it's actually a refresh token
     if payload.get("token_type") != "refresh":

--- a/src/nanoidp/services/crypto.py
+++ b/src/nanoidp/services/crypto.py
@@ -342,7 +342,19 @@ class CryptoService:
     def verify_jwt(
         self, token: str, audience: Optional[Union[str, List[str]]]
     ) -> Dict[str, Any]:
-        """Verify and decode a JWT token.
+        """Verify a JWT acceptable as a NANOIDP token - not any valid RS256
+        JWT.
+
+        The ``exp`` claim is REQUIRED (#306). That is nanoidp's token-profile
+        policy, not a JWT-spec requirement (RFC 7519 leaves exp optional):
+        OIDC Core requires exp on ID Tokens and RFC 9068 requires it on JWT
+        access tokens, ``create_jwt`` has always stamped one on everything
+        nanoidp mints, and a token accepted here must have a finite lifetime
+        - an eternal bearer token would let an integration test pass against
+        nanoidp and fail against any real IdP. Only hand-crafted tokens
+        signed with the nanoidp key ever lacked it. No other claim is
+        required here; widening the enforced profile (iss, iat, jti, ...)
+        is a separate discussion.
 
         ``audience`` accepts a list as well as a string (PyJWT semantics:
         the token is valid if its ``aud`` matches any of the values), so ID
@@ -362,7 +374,11 @@ class CryptoService:
                 self.pub_pem,
                 algorithms=["RS256"],
                 audience=audience,
-                options={"verify_signature": True, "verify_aud": audience is not None},
+                options={
+                    "verify_signature": True,
+                    "verify_aud": audience is not None,
+                    "require": ["exp"],
+                },
             )
             return payload
         except jwt.ExpiredSignatureError as e:

--- a/tests/test_oauth_flows.py
+++ b/tests/test_oauth_flows.py
@@ -445,13 +445,15 @@ class TestRefreshTokenGrant:
         assert response.status_code == 400
 
     def test_refresh_token_invalid_token(self, client, auth_header):
-        """Test refresh token grant with invalid token."""
+        """An unverifiable refresh token is invalid_grant, RFC 6749 §5.2
+        JSON - it used to be a Werkzeug 401 HTML abort (#306/#287)."""
         response = client.post('/token', data={
             'grant_type': 'refresh_token',
             'refresh_token': 'invalid-token'
         }, headers=auth_header)
 
-        assert response.status_code == 401
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_grant"
 
     def test_refresh_token_with_access_token_fails(self, client, auth_header):
         """Test that using access_token as refresh_token fails."""

--- a/tests/test_token_profile_exp.py
+++ b/tests/test_token_profile_exp.py
@@ -1,0 +1,102 @@
+"""
+NanoIDP token profile: exp is required (#306).
+
+Policy decision, option (a): a JWT accepted by verify_jwt must have a
+finite lifetime. This is nanoidp's token-profile policy, not a JWT-spec
+requirement - RFC 7519 leaves exp optional, but OIDC Core requires it on ID
+Tokens, RFC 9068 requires it on JWT access tokens, and create_jwt has
+always stamped one on everything nanoidp mints. The only tokens this
+rejects are hand-crafted ones signed with the nanoidp key and no expiry -
+an eternal bearer that would let an integration test pass here and fail
+against any real IdP.
+"""
+
+import base64
+import json
+import time
+
+import jwt as pyjwt
+import pytest
+
+from nanoidp.config import get_config
+from nanoidp.services.crypto import get_crypto_service
+
+
+def _mint(app, claims):
+    with app.app_context():
+        crypto = get_crypto_service(get_config().settings.keys_dir)
+    return pyjwt.encode(claims, crypto.priv_pem, algorithm="RS256")
+
+
+def _base_claims(**over):
+    claims = {
+        "sub": "admin",
+        "iss": "http://localhost:8000",
+        "aud": "my-app",
+        "jti": "no-exp-test",
+        "iat": int(time.time()),
+        "token_use": "access",
+        "token_type": "access",
+    }
+    claims.update(over)
+    return claims
+
+
+def _basic(client_id, secret):
+    credentials = base64.b64encode(f"{client_id}:{secret}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+class TestVerifyJwtRequiresExp:
+    def test_signed_token_without_exp_is_rejected(self, app):
+        token = _mint(app, _base_claims())
+        with app.app_context():
+            crypto = get_crypto_service(get_config().settings.keys_dir)
+        with pytest.raises(ValueError):
+            crypto.verify_jwt(token, None)
+
+    def test_signed_token_with_future_exp_is_accepted(self, app):
+        token = _mint(app, _base_claims(exp=int(time.time()) + 300))
+        with app.app_context():
+            crypto = get_crypto_service(get_config().settings.keys_dir)
+        payload = crypto.verify_jwt(token, None)
+        assert payload["sub"] == "admin"
+
+
+class TestEndpointsRejectNoExpTokens:
+    def test_introspect_reports_inactive(self, client, app):
+        """The error contract of the surface, not a new shape: an
+        unacceptable token introspects as active: false (RFC 7662)."""
+        token = _mint(app, _base_claims())
+        resp = client.post(
+            "/introspect",
+            data={"token": token},
+            headers=_basic("demo-client", "demo-secret"),
+        )
+        assert resp.status_code == 200
+        assert json.loads(resp.data)["active"] is False
+
+    def test_userinfo_rejects(self, client, app):
+        token = _mint(app, _base_claims())
+        resp = client.get("/userinfo", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+
+    def test_refresh_grant_rejects_a_no_exp_refresh_token(self, client, app):
+        """The case that surfaced #306 (#293 round 2): an eternal refresh
+        token. It must fail verification, never reach the grant."""
+        token = _mint(
+            app,
+            _base_claims(
+                token_use="refresh",
+                token_type="refresh",
+                client_id="demo-client",
+                rt_family="fam-no-exp",
+            ),
+        )
+        resp = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": token},
+            headers=_basic("demo-client", "demo-secret"),
+        )
+        assert resp.status_code == 400
+        assert json.loads(resp.data)["error"] == "invalid_grant"


### PR DESCRIPTION
Implements decision (a) from #306, in exactly the frame agreed there: **this is nanoidp's token-profile policy, not a JWT-spec rule**. RFC 7519 leaves `exp` optional; OIDC Core requires it on ID Tokens and RFC 9068 on JWT access tokens; `create_jwt` has always stamped one on everything nanoidp mints. The single security property: a token accepted by nanoidp has a finite lifetime - an eternal bearer would let an integration test pass here and fail against any real IdP.

- `verify_jwt` adds `require: ["exp"]` and its docstring now states what it verifies: a JWT acceptable **as a nanoidp token**, not any valid RS256 JWT. No other claim is newly required (`iss`/`iat`/`nbf`/`jti` stay a separate token-profile discussion, per the decision); no escape hatch. Only hand-crafted tokens signed with the nanoidp key are affected - *migration:* add an `exp` to such fixtures.
- The #293 'verified no-exp -> indefinite retention' branch in RevocationStore **stays**, deliberately: the store does not assume every future caller applied this validation policy (the fail-safe property named in the round-3 review).
- **Adjacent fix the new refresh test surfaced**: an unverifiable refresh token answered with a Werkzeug 401 HTML abort. Now RFC 6749 §5.2 JSON (`invalid_grant`, 400); CHANGELOG breaking note, old pin updated. NOT the only such branch (review round 1 corrected my 'the one' claim): the /token shell and the grant handlers still hold ~20 abort() HTML branches contradicting the #287 error-surfaces contract - tracked as #308 rather than widened into this PR.

Tests, per the decision's list: signed no-exp -> `verify_jwt` rejects; signed future-exp -> accepted; no-exp at representative endpoints through their own error contracts (`/introspect` -> `active: false`, `/userinfo` -> 401); and the refresh case that surfaced the issue -> `invalid_grant`. Suite 1898 green, mypy/ruff clean; verified live with a discriminating pair (same claims, only exp differs: `active` False/True at `/introspect`), full e2e 61/61.

(Verification note: an initial live probe showed false negatives that turned out to be a leftover server from another worktree answering on the probe port - re-run against a verified-fresh instance before concluding anything. Process lesson recorded.)
