### PR TITLE
fix: every /token error branch answers RFC 6749 §5.2 JSON (#308, BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,11 @@ previous leniency allowed - needs a one-time adjustment.
   revoked or foreign code/refresh-token - and invalid resource-owner
   credentials on the password grant - are `invalid_grant` (400); an
   unknown or profile-disabled grant type is `unsupported_grant_type`
-  (400); client-authentication failures stay `invalid_client` (401) and,
-  when the client attempted HTTP Basic, now carry the `WWW-Authenticate:
-  Basic` challenge §5.2 requires. Descriptions are fixed text (no library
+  (400); client-authentication failures are `invalid_client` - 401 with
+  the `WWW-Authenticate: Basic` challenge when the client attempted HTTP
+  Basic (the §5.2 MUST), 400 otherwise (§5.2's default; RFC 9110 §11.6.1
+  forbids a challenge-less 401, and a Basic challenge would be wrong for
+  a `client_secret_post` client anyway). Descriptions are fixed text (no library
   detail and no reflected caller input - the unsupported grant type's raw
   value lives in the audit event, not the response). *Migration:* branches that used to answer 401 for GRANT problems
   (revoked/foreign refresh token, unknown user, wrong password) now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,11 @@ previous leniency allowed - needs a one-time adjustment.
   revoked or foreign code/refresh-token - and invalid resource-owner
   credentials on the password grant - are `invalid_grant` (400); an
   unknown or profile-disabled grant type is `unsupported_grant_type`
-  (400); client-authentication failures stay `invalid_client` (401).
-  Descriptions are fixed text (no library detail; the audit events keep
-  it). *Migration:* branches that used to answer 401 for GRANT problems
+  (400); client-authentication failures stay `invalid_client` (401) and,
+  when the client attempted HTTP Basic, now carry the `WWW-Authenticate:
+  Basic` challenge §5.2 requires. Descriptions are fixed text (no library
+  detail and no reflected caller input - the unsupported grant type's raw
+  value lives in the audit event, not the response). *Migration:* branches that used to answer 401 for GRANT problems
   (revoked/foreign refresh token, unknown user, wrong password) now
   answer 400 with `error: invalid_grant` - §5.2 reserves 401 for client
   authentication; read `error` from the JSON body instead of matching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,10 +143,21 @@ previous leniency allowed - needs a one-time adjustment.
   newly required.
 - **An unverifiable refresh token now answers RFC 6749 §5.2 JSON**
   (`invalid_grant`, HTTP 400) instead of a Werkzeug 401 HTML page, per
-  the "Error surfaces" rule (#287). Other /token error branches still
-  answer Werkzeug HTML; converting them is tracked separately.
-  *Migration:* read `error` from the JSON body; the status moves from 401
-  to 400.
+  the "Error surfaces" rule (#287).
+- **Every `/token` error branch now answers RFC 6749 §5.2 JSON** (#308):
+  roughly twenty conditions across the endpoint shell and all five grant
+  handlers used to answer Werkzeug HTML via `abort()`. Now: missing or
+  malformed parameters are `invalid_request` (400); a bad, expired,
+  revoked or foreign code/refresh-token - and invalid resource-owner
+  credentials on the password grant - are `invalid_grant` (400); an
+  unknown or profile-disabled grant type is `unsupported_grant_type`
+  (400); client-authentication failures stay `invalid_client` (401).
+  Descriptions are fixed text (no library detail; the audit events keep
+  it). *Migration:* branches that used to answer 401 for GRANT problems
+  (revoked/foreign refresh token, unknown user, wrong password) now
+  answer 400 with `error: invalid_grant` - §5.2 reserves 401 for client
+  authentication; read `error` from the JSON body instead of matching
+  HTML.
 
 ### Added
 - **Access-point parity contract for token issuance** (#283,

--- a/e2e/test_agent.py
+++ b/e2e/test_agent.py
@@ -2667,11 +2667,21 @@ class NanoIDPTestAgent:
             )
 
             success = all(checks.values())
+            message = "; ".join(f"{k}={v}" for k, v in checks.items())
+            if not success:
+                # Flake forensics (#309): on failure, capture what the agent
+                # actually SAW - statuses and body prefixes - since the
+                # server log cannot show response bodies.
+                message += (
+                    f" | valid: {valid.status_code} {valid.text[:160]!r}"
+                    f" | unknown: {unknown.status_code} {unknown.text[:160]!r}"
+                    f" | malformed: {malformed.status_code} {malformed.text[:160]!r}"
+                )
             return self._add_result(
                 "SAML Attribute Query",
                 TestCategory.SAML,
                 success,
-                "; ".join(f"{k}={v}" for k, v in checks.items()),
+                message,
                 checks,
             )
         except Exception as e:

--- a/src/nanoidp/routes/_oauth_error.py
+++ b/src/nanoidp/routes/_oauth_error.py
@@ -29,16 +29,21 @@ def oauth_error(error: str, description: str, status: int = 400) -> Tuple[Respon
 def invalid_client_error(
     description: str, *, basic_attempted: bool
 ) -> Tuple[Response, int]:
-    """A §5.2 ``invalid_client`` 401.
+    """A §5.2 ``invalid_client`` response, status per BOTH specs (#310
+    review round 2).
 
-    When the client ATTEMPTED authentication via the Authorization header,
-    §5.2 says the response MUST be 401 and MUST include a WWW-Authenticate
-    header matching the scheme the client used (#310 review) - nanoidp
-    supports Basic there, so that is the challenge issued. A client that
-    never sent the header gets the JSON alone: the MUST is conditional on
-    the attempt.
+    RFC 6749 §5.2: invalid_client is 400 by default; when the client
+    ATTEMPTED authentication via the Authorization header the response
+    MUST be 401 and MUST include a WWW-Authenticate challenge for the
+    scheme used (Basic here). RFC 9110 §11.6.1 closes the other door: ANY
+    401 must carry at least one challenge - so a failure with no
+    Authorization header attempted (a missing client_id, a wrong
+    client_secret_post body secret) answers 400, never a challenge-less
+    401 and never a Basic challenge for a client whose registered method
+    is not Basic.
     """
-    body, status = oauth_error("invalid_client", description, 401)
     if basic_attempted:
+        body, status = oauth_error("invalid_client", description, 401)
         body.headers["WWW-Authenticate"] = 'Basic realm="nanoidp"'
-    return body, status
+        return body, status
+    return oauth_error("invalid_client", description, 400)

--- a/src/nanoidp/routes/_oauth_error.py
+++ b/src/nanoidp/routes/_oauth_error.py
@@ -1,0 +1,44 @@
+"""
+RFC 6749 §5.2 error responses - the one home (#310 review) for the shape
+both the /token shell (routes/oauth.py) and the grant handlers
+(routes/oauth_grants.py) answer errors with.
+
+Descriptions are FIXED text: §5.2 restricts error_description to a narrow
+ASCII subset, so caller-controlled values (a grant_type of emoji, quotes,
+newlines) and library/exception detail never belong here - both go to the
+audit events instead (the #200/#307/#310 rule). §5.2 semantics used across
+the endpoint: invalid_request = missing/malformed parameter; invalid_grant
+= the presented grant (code, refresh token, resource-owner credentials) is
+invalid, expired, revoked or issued to another client; invalid_client =
+client authentication failed (401).
+"""
+
+from typing import Tuple
+
+from flask import Response, jsonify
+
+
+def oauth_error(error: str, description: str, status: int = 400) -> Tuple[Response, int]:
+    """An RFC 6749 §5.2 error JSON body."""
+    return (
+        jsonify({"error": error, "error_description": description}),
+        status,
+    )
+
+
+def invalid_client_error(
+    description: str, *, basic_attempted: bool
+) -> Tuple[Response, int]:
+    """A §5.2 ``invalid_client`` 401.
+
+    When the client ATTEMPTED authentication via the Authorization header,
+    §5.2 says the response MUST be 401 and MUST include a WWW-Authenticate
+    header matching the scheme the client used (#310 review) - nanoidp
+    supports Basic there, so that is the challenge issued. A client that
+    never sent the header gets the JSON alone: the MUST is conditional on
+    the attempt.
+    """
+    body, status = oauth_error("invalid_client", description, 401)
+    if basic_attempted:
+        body.headers["WWW-Authenticate"] = 'Basic realm="nanoidp"'
+    return body, status

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -819,7 +819,15 @@ def token() -> ResponseReturnValue:
             endpoint="/token",
             details={"reason": "Client authentication required", "grant_type": grant_type},
         )
-        return abort(401, description="Client authentication required")
+        return (
+            jsonify(
+                {
+                    "error": "invalid_client",
+                    "error_description": "Client authentication required",
+                }
+            ),
+            401,
+        )
 
     # Reject if body client_id conflicts with the authenticated client in the header
     if identity.mismatch:
@@ -830,8 +838,16 @@ def token() -> ResponseReturnValue:
             client_id=auth.username if auth else None,
             details={"reason": "client_id mismatch", "body_client_id": client_id},
         )
-        return abort(
-            401, description="client_id in request body does not match authenticated client"
+        return (
+            jsonify(
+                {
+                    "error": "invalid_client",
+                    "error_description": (
+                        "client_id in request body does not match authenticated client"
+                    ),
+                }
+            ),
+            401,
         )
 
     # One client-authentication boundary for every grant (#188, #254
@@ -861,7 +877,15 @@ def token() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": "Invalid 'exp' parameter", "grant_type": grant_type},
         )
-        return abort(400, description="'exp' must be an integer number of minutes")
+        return (
+            jsonify(
+                {
+                    "error": "invalid_request",
+                    "error_description": "'exp' must be an integer number of minutes",
+                }
+            ),
+            400,
+        )
     # Same bounds the Settings model enforces for token_expiry_minutes
     if not 1 <= exp_minutes <= 1440:
         audit_event(
@@ -871,7 +895,15 @@ def token() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": "'exp' out of range", "grant_type": grant_type},
         )
-        return abort(400, description="'exp' must be between 1 and 1440 minutes")
+        return (
+            jsonify(
+                {
+                    "error": "invalid_request",
+                    "error_description": "'exp' must be between 1 and 1440 minutes",
+                }
+            ),
+            400,
+        )
 
     extra_claims = None
     extra_raw = request.form.get("extra")
@@ -886,7 +918,15 @@ def token() -> ResponseReturnValue:
                 client_id=client_id,
                 details={"reason": "Invalid JSON in 'extra'", "grant_type": grant_type},
             )
-            return abort(400, description="Invalid JSON in 'extra'")
+            return (
+                jsonify(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "Invalid JSON in 'extra'",
+                    }
+                ),
+                400,
+            )
         # Any JSON scalar/array parses fine but is not a claims mapping
         if not isinstance(parsed_extra, dict):
             audit_event(
@@ -896,7 +936,15 @@ def token() -> ResponseReturnValue:
                 client_id=client_id,
                 details={"reason": "'extra' is not a JSON object", "grant_type": grant_type},
             )
-            return abort(400, description="'extra' must be a JSON object")
+            return (
+                jsonify(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "'extra' must be a JSON object",
+                    }
+                ),
+                400,
+            )
         extra_claims = parsed_extra
 
     # Per-grant dispatch
@@ -909,7 +957,17 @@ def token() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": f"Unsupported grant type: {grant_type}", "grant_type": grant_type},
         )
-        return abort(400, description=f"Unsupported grant_type: {grant_type}")
+        # The echoed value is the caller's own request parameter, not
+        # internal detail - fine in a JSON body (#308).
+        return (
+            jsonify(
+                {
+                    "error": "unsupported_grant_type",
+                    "error_description": f"Unsupported grant_type: {grant_type}",
+                }
+            ),
+            400,
+        )
 
     ctx = _GrantContext(
         config=config,

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -50,6 +50,7 @@ from ..services.scope import resolve_scope
 from ..services.token import resolve_user_claim, sanitize_claim_names
 from ._audit import audit_event
 from ._issuer import effective_issuer
+from ._oauth_error import invalid_client_error, oauth_error
 from .oauth_grants import _GRANT_HANDLERS, _GrantContext, _GrantOutcome
 
 logger = logging.getLogger(__name__)
@@ -643,7 +644,9 @@ def client_logo(client_id: str) -> ResponseReturnValue:
 # ============================================================================
 
 
-def _token_auth_failed(client_id: Optional[str], reason: str) -> ResponseReturnValue:
+def _token_auth_failed(
+    client_id: Optional[str], reason: str, *, basic_attempted: bool
+) -> ResponseReturnValue:
     audit_event(
         "token_request",
         "failed",
@@ -651,7 +654,9 @@ def _token_auth_failed(client_id: Optional[str], reason: str) -> ResponseReturnV
         client_id=client_id,
         details={"reason": reason},
     )
-    return jsonify({"error": "invalid_client", "error_description": reason}), 401
+    # WWW-Authenticate on an attempted-Basic failure is a §5.2 MUST
+    # (#310 review); see invalid_client_error.
+    return invalid_client_error(reason, basic_attempted=basic_attempted)
 
 
 @dataclass(frozen=True)
@@ -739,7 +744,11 @@ def _enforce_token_endpoint_auth(
         return None
 
     reason = _enforce_registered_client_auth(config, client_id, auth, body_client_secret)
-    return _token_auth_failed(client_id, reason) if reason is not None else None
+    return (
+        _token_auth_failed(client_id, reason, basic_attempted=auth is not None)
+        if reason is not None
+        else None
+    )
 
 
 def _enforce_registered_client_auth(
@@ -819,14 +828,8 @@ def token() -> ResponseReturnValue:
             endpoint="/token",
             details={"reason": "Client authentication required", "grant_type": grant_type},
         )
-        return (
-            jsonify(
-                {
-                    "error": "invalid_client",
-                    "error_description": "Client authentication required",
-                }
-            ),
-            401,
+        return invalid_client_error(
+            "Client authentication required", basic_attempted=auth is not None
         )
 
     # Reject if body client_id conflicts with the authenticated client in the header
@@ -838,16 +841,11 @@ def token() -> ResponseReturnValue:
             client_id=auth.username if auth else None,
             details={"reason": "client_id mismatch", "body_client_id": client_id},
         )
-        return (
-            jsonify(
-                {
-                    "error": "invalid_client",
-                    "error_description": (
-                        "client_id in request body does not match authenticated client"
-                    ),
-                }
-            ),
-            401,
+        # identity.mismatch implies Basic was presented, so the §5.2
+        # WWW-Authenticate MUST applies (#310 review).
+        return invalid_client_error(
+            "client_id in request body does not match authenticated client",
+            basic_attempted=True,
         )
 
     # One client-authentication boundary for every grant (#188, #254
@@ -877,15 +875,7 @@ def token() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": "Invalid 'exp' parameter", "grant_type": grant_type},
         )
-        return (
-            jsonify(
-                {
-                    "error": "invalid_request",
-                    "error_description": "'exp' must be an integer number of minutes",
-                }
-            ),
-            400,
-        )
+        return oauth_error("invalid_request", "'exp' must be an integer number of minutes")
     # Same bounds the Settings model enforces for token_expiry_minutes
     if not 1 <= exp_minutes <= 1440:
         audit_event(
@@ -895,15 +885,7 @@ def token() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": "'exp' out of range", "grant_type": grant_type},
         )
-        return (
-            jsonify(
-                {
-                    "error": "invalid_request",
-                    "error_description": "'exp' must be between 1 and 1440 minutes",
-                }
-            ),
-            400,
-        )
+        return oauth_error("invalid_request", "'exp' must be between 1 and 1440 minutes")
 
     extra_claims = None
     extra_raw = request.form.get("extra")
@@ -918,15 +900,7 @@ def token() -> ResponseReturnValue:
                 client_id=client_id,
                 details={"reason": "Invalid JSON in 'extra'", "grant_type": grant_type},
             )
-            return (
-                jsonify(
-                    {
-                        "error": "invalid_request",
-                        "error_description": "Invalid JSON in 'extra'",
-                    }
-                ),
-                400,
-            )
+            return oauth_error("invalid_request", "Invalid JSON in 'extra'")
         # Any JSON scalar/array parses fine but is not a claims mapping
         if not isinstance(parsed_extra, dict):
             audit_event(
@@ -936,15 +910,7 @@ def token() -> ResponseReturnValue:
                 client_id=client_id,
                 details={"reason": "'extra' is not a JSON object", "grant_type": grant_type},
             )
-            return (
-                jsonify(
-                    {
-                        "error": "invalid_request",
-                        "error_description": "'extra' must be a JSON object",
-                    }
-                ),
-                400,
-            )
+            return oauth_error("invalid_request", "'extra' must be a JSON object")
         extra_claims = parsed_extra
 
     # Per-grant dispatch
@@ -957,16 +923,12 @@ def token() -> ResponseReturnValue:
             client_id=client_id,
             details={"reason": f"Unsupported grant type: {grant_type}", "grant_type": grant_type},
         )
-        # The echoed value is the caller's own request parameter, not
-        # internal detail - fine in a JSON body (#308).
-        return (
-            jsonify(
-                {
-                    "error": "unsupported_grant_type",
-                    "error_description": f"Unsupported grant_type: {grant_type}",
-                }
-            ),
-            400,
+        # FIXED text (#310 review, blocker 1): §5.2 restricts
+        # error_description to a narrow ASCII subset, so the caller's
+        # arbitrary grant_type value (emoji, quotes, newlines) must not be
+        # reflected here - it is already recorded in the audit event above.
+        return oauth_error(
+            "unsupported_grant_type", "The requested grant_type is not supported"
         )
 
     ctx = _GrantContext(

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from flask import (
-    abort,
     jsonify,
     request,
 )
@@ -141,6 +140,21 @@ def _resolve_token_resource(
     return (result.granted or None), None
 
 
+def _oauth_error(error: str, description: str, status: int = 400) -> GrantResult:
+    """RFC 6749 §5.2 error JSON - the #287 "Error surfaces" shape for every
+    /token error branch (#308: these used to be Werkzeug abort() HTML).
+    Descriptions are FIXED text; library/exception detail belongs in the
+    audit events, never here (the #200/#307 rule). §5.2 semantics used:
+    invalid_request = missing/malformed parameter; invalid_grant = the
+    presented grant (code, refresh token, resource-owner credentials) is
+    invalid, expired, revoked or issued to another client; invalid_client
+    stays with the authentication helpers in oauth.py."""
+    return (
+        jsonify({"error": error, "error_description": description}),
+        status,
+    )
+
+
 def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
     """refresh_token grant (RFC 6749 §6; rotation per RFC 9700 §4.14)."""
     refresh_token = request.form.get("refresh_token", "")
@@ -152,7 +166,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Missing refresh_token", "grant_type": ctx.grant_type},
         )
-        return abort(400, description="refresh_token is required")
+        return _oauth_error("invalid_request", "refresh_token is required")
 
     # Verify and decode refresh token
     crypto = get_crypto_service(ctx.config.settings.keys_dir)
@@ -198,7 +212,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Not a refresh token", "grant_type": ctx.grant_type},
         )
-        return abort(400, description="Invalid token type")
+        return _oauth_error("invalid_grant", "The presented token is not a refresh token")
 
     # A refresh token may only be spent by the client it was issued to
     # (RFC 9700 §4.14, #56). Since 3.0 the binding claim is MANDATORY (#73):
@@ -241,12 +255,12 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
                 "bound_client": bound_client,
             },
         )
-        return abort(401, description="Refresh token was not issued to this client")
+        return _oauth_error("invalid_grant", "Refresh token was not issued to this client")
 
     # Extract username and get user data
     username = payload.get("sub")
     if not username:
-        return abort(400, description="Invalid token: missing subject")
+        return _oauth_error("invalid_grant", "Refresh token carries no subject")
 
     user = ctx.config.get_user(username)
     if not user:
@@ -258,7 +272,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "User not found", "grant_type": ctx.grant_type},
         )
-        return abort(401, description="User not found")
+        return _oauth_error("invalid_grant", "The user this grant was issued for no longer exists")
 
     # Recover the originally granted scope persisted in the refresh token
     # so an ID Token is re-issued when 'openid' was granted (OIDC Core
@@ -397,7 +411,7 @@ def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:
                 "grant_type": ctx.grant_type,
             },
         )
-        return abort(401, description="Refresh token has been revoked")
+        return _oauth_error("invalid_grant", "Refresh token has been revoked")
 
     # Resource indicators (#187): the refresh may narrow the bound resources
     # to a subset of what the refresh token remembers, never widen them - a
@@ -439,10 +453,9 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
                 "grant_type": ctx.grant_type,
             },
         )
-        return abort(
-            400,
-            description="Unsupported grant_type: the password grant is "
-            "disabled by the oauth21 profile",
+        return _oauth_error(
+            "unsupported_grant_type",
+            "The password grant is disabled by the oauth21 profile",
         )
 
     username = request.form.get("username", "").strip()
@@ -459,7 +472,7 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
                 "grant_type": ctx.grant_type,
             },
         )
-        return abort(400, description="username and password required for password grant")
+        return _oauth_error("invalid_request", "username and password are required for the password grant")
 
     user = ctx.config.authenticate(username, password)
     if not user:
@@ -471,7 +484,7 @@ def _grant_password(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Invalid credentials", "grant_type": ctx.grant_type},
         )
-        return abort(401, description="Invalid credentials")
+        return _oauth_error("invalid_grant", "Invalid resource owner credentials")
 
     # Scope validation (issue #186), same rule as every other grant.
     client = ctx.config.get_client(ctx.client_id)
@@ -533,7 +546,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Missing authorization code", "grant_type": ctx.grant_type},
         )
-        return abort(400, description="code is required")
+        return _oauth_error("invalid_request", "code is required")
 
     if not redirect_uri:
         audit_event(
@@ -543,7 +556,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "Missing redirect_uri", "grant_type": ctx.grant_type},
         )
-        return abort(400, description="redirect_uri is required")
+        return _oauth_error("invalid_request", "redirect_uri is required")
 
     # Consume the authorization code
     auth_code_store = get_auth_code_store()
@@ -565,7 +578,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
                 "grant_type": ctx.grant_type,
             },
         )
-        return abort(400, description="Invalid or expired authorization code")
+        return _oauth_error("invalid_grant", "Invalid or expired authorization code")
 
     # Get the user from the authorization code
     username = auth_code.username
@@ -579,7 +592,7 @@ def _grant_authorization_code(ctx: _GrantContext) -> GrantResult:
             client_id=ctx.client_id,
             details={"reason": "User not found", "grant_type": ctx.grant_type},
         )
-        return abort(401, description="User not found")
+        return _oauth_error("invalid_grant", "The user this grant was issued for no longer exists")
 
     # Re-validate against the vocabulary and this client's allowed_scopes
     # (issue #186): both may have changed between /authorize issuing the

--- a/src/nanoidp/routes/oauth_grants.py
+++ b/src/nanoidp/routes/oauth_grants.py
@@ -28,6 +28,7 @@ from ..services import (
 from ..services.resource import resolve_resources
 from ..services.scope import resolve_scope
 from ._audit import audit_event
+from ._oauth_error import oauth_error as _oauth_error
 
 
 @dataclass
@@ -138,21 +139,6 @@ def _resolve_token_resource(
             400,
         )
     return (result.granted or None), None
-
-
-def _oauth_error(error: str, description: str, status: int = 400) -> GrantResult:
-    """RFC 6749 §5.2 error JSON - the #287 "Error surfaces" shape for every
-    /token error branch (#308: these used to be Werkzeug abort() HTML).
-    Descriptions are FIXED text; library/exception detail belongs in the
-    audit events, never here (the #200/#307 rule). §5.2 semantics used:
-    invalid_request = missing/malformed parameter; invalid_grant = the
-    presented grant (code, refresh token, resource-owner credentials) is
-    invalid, expired, revoked or issued to another client; invalid_client
-    stays with the authentication helpers in oauth.py."""
-    return (
-        jsonify({"error": error, "error_description": description}),
-        status,
-    )
 
 
 def _grant_refresh_token(ctx: _GrantContext) -> GrantResult:

--- a/tests/test_client_credentials_no_refresh.py
+++ b/tests/test_client_credentials_no_refresh.py
@@ -72,7 +72,9 @@ class TestClientCredentialsResponse:
         )
 
         assert response.status_code == 400
-        assert b"Invalid token type" in response.data
+        body = response.get_json()
+        assert body["error"] == "invalid_grant"
+        assert "not a refresh token" in body["error_description"]
 
     def test_grant_outcome_defaults_to_issuing_a_refresh_token(self):
         """Only client_credentials opts out; a new handler gets a refresh token

--- a/tests/test_client_identity_mismatch.py
+++ b/tests/test_client_identity_mismatch.py
@@ -58,7 +58,11 @@ class TestMismatchRejectedEverywhere:
             },
             headers=DEMO_AUTH,
         )
+        # §5.2 JSON with the Basic challenge since #310 (the old
+        # status-only assertion was exactly the kind of pin #308 blamed).
         assert resp.status_code == 401
+        assert resp.get_json()["error"] == "invalid_client"
+        assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
 
     def test_introspect_mismatch_rejected(self, client):
         token = _mint_token(client)

--- a/tests/test_issue_56_review.py
+++ b/tests/test_issue_56_review.py
@@ -50,8 +50,11 @@ class TestRefreshTokenClientBinding:
     ):
         tokens = _password_grant(client, auth_header)  # issued to demo-client
         resp = _refresh(client, test_auth_header, tokens["refresh_token"])
-        assert resp.status_code == 401
-        assert b"not issued to this client" in resp.data
+        # invalid_grant JSON since #308 (was a 401 HTML abort): §5.2 keeps
+        # 401 for client authentication, not grant validity.
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid_grant"
+        assert "not issued to this client" in resp.get_json()["error_description"]
 
     def test_issuing_client_can_refresh_and_aud_is_preserved(self, client, auth_header):
         import jwt as pyjwt
@@ -202,7 +205,7 @@ class TestAtomicRotationAndFamilies:
             f"{statuses.count(200)} concurrent refreshes rotated the same token; "
             "atomic consumption requires exactly 1"
         )
-        assert statuses.count(401) == n - 1
+        assert statuses.count(400) == n - 1  # invalid_grant (#308)
 
     def test_reuse_revokes_the_whole_family(self, client, auth_header):
         """RFC 9700 §4.14.2: reusing a consumed token must also kill the
@@ -212,10 +215,10 @@ class TestAtomicRotationAndFamilies:
 
         rotated = json.loads(_refresh(client, auth_header, old).data)["refresh_token"]
 
-        # Attacker replays the consumed token...
-        assert _refresh(client, auth_header, old).status_code == 401
+        # Attacker replays the consumed token... (invalid_grant 400, #308)
+        assert _refresh(client, auth_header, old).status_code == 400
         # ...and the live descendant is now dead too.
-        assert _refresh(client, auth_header, rotated).status_code == 401
+        assert _refresh(client, auth_header, rotated).status_code == 400
 
     def test_separate_grants_are_separate_families(self, client, auth_header):
         """Reuse in one family must not affect tokens from other grants."""
@@ -223,7 +226,7 @@ class TestAtomicRotationAndFamilies:
         family_b = _password_grant(client, auth_header)["refresh_token"]
 
         _refresh(client, auth_header, family_a)               # rotate A
-        assert _refresh(client, auth_header, family_a).status_code == 401  # reuse A
+        assert _refresh(client, auth_header, family_a).status_code == 400  # reuse A (#308)
 
         assert _refresh(client, auth_header, family_b).status_code == 200  # B unaffected
 

--- a/tests/test_oauth21_profile.py
+++ b/tests/test_oauth21_profile.py
@@ -108,7 +108,9 @@ class TestTokenEndpoint:
             },
         )
         assert response.status_code == 400
-        assert b"disabled by the oauth21 profile" in response.data
+        body = response.get_json()
+        assert body["error"] == "unsupported_grant_type"
+        assert "disabled by the oauth21 profile" in body["error_description"]
 
     def test_client_credentials_still_works_under_oauth21(self, client, oauth21):
         response = client.post(

--- a/tests/test_oauth_errors.py
+++ b/tests/test_oauth_errors.py
@@ -60,7 +60,10 @@ class TestInvalidClientError:
             'grant_type': 'client_credentials'
         })
 
-        assert response.status_code == 401
+        # 400 since #310: no Authorization header attempted, and RFC 9110
+        # forbids a challenge-less 401.
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_client"
 
     def test_wrong_client_secret_returns_error(self, client):
         """Test that wrong client secret returns error."""

--- a/tests/test_oauth_flows.py
+++ b/tests/test_oauth_flows.py
@@ -348,7 +348,10 @@ class TestPasswordGrant:
             'password': 'wrong-password'
         }, headers=auth_header)
 
-        assert response.status_code == 401
+        # invalid_grant JSON since #308 (was a 401 HTML abort): §5.2 keeps
+        # 401 for client authentication, not resource-owner credentials.
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_grant"
 
     def test_password_grant_missing_username(self, client, auth_header):
         """Test password grant without username."""

--- a/tests/test_oauth_flows.py
+++ b/tests/test_oauth_flows.py
@@ -269,7 +269,8 @@ class TestAuthorizationCodeFlowWithPKCE:
             'code_verifier': pkce_verifier
         })
 
-        assert response.status_code == 401
+        # 400 since #310: no Authorization header attempted (RFC 9110).
+        assert response.status_code == 400
 
     def test_pkce_missing_verifier_fails(self, client, auth_header, pkce_challenge_s256):
         """Test that missing code_verifier fails when challenge was provided."""
@@ -379,7 +380,8 @@ class TestPasswordGrant:
             'password': 'admin'
         })
 
-        assert response.status_code == 401
+        # 400 since #310: no Authorization header attempted (RFC 9110).
+        assert response.status_code == 400
 
 
 class TestClientCredentialsGrant:
@@ -411,7 +413,8 @@ class TestClientCredentialsGrant:
             'grant_type': 'client_credentials'
         })
 
-        assert response.status_code == 401
+        # 400 since #310: no Authorization header attempted (RFC 9110).
+        assert response.status_code == 400
 
 
 class TestRefreshTokenGrant:

--- a/tests/test_public_clients.py
+++ b/tests/test_public_clients.py
@@ -353,7 +353,9 @@ class TestMethodEnforcement:
                 "client_secret": "demo-secret",
             },
         )
-        assert resp.status_code == 401
+        # 400 since #310: no Basic was attempted (RFC 9110 forbids a
+        # challenge-less 401).
+        assert resp.status_code == 400
 
     def test_basic_client_rejects_valid_basic_plus_a_body_secret(self, client):
         """#254 review round 2: two authentication methods in one request is
@@ -387,7 +389,7 @@ class TestMethodEnforcement:
         )
         assert resp.status_code == 401
 
-    def test_post_client_with_wrong_body_secret_is_401(self, client, post_client):
+    def test_post_client_with_wrong_body_secret_is_400(self, client, post_client):
         resp = client.post(
             "/token",
             data={
@@ -396,7 +398,11 @@ class TestMethodEnforcement:
                 "client_secret": "wrong",
             },
         )
-        assert resp.status_code == 401
+        # 400 since #310: the secret travelled in the BODY, no Authorization
+        # header attempted - and a Basic challenge would be wrong for a
+        # client_secret_post client anyway.
+        assert resp.status_code == 400
+        assert "WWW-Authenticate" not in resp.headers
 
     def test_confidential_authorization_code_requires_client_auth(self, client):
         """A confidential client cannot redeem a code with client_id alone
@@ -423,7 +429,9 @@ class TestMethodEnforcement:
                 "client_id": "demo-client",
             },
         )
-        assert resp.status_code == 401
+        # 400 since #310: no Basic was attempted (RFC 9110 forbids a
+        # challenge-less 401).
+        assert resp.status_code == 400
 
     def test_introspect_with_post_client_body_secret_works(self, client, post_client):
         token = json.loads(

--- a/tests/test_refresh_rotation.py
+++ b/tests/test_refresh_rotation.py
@@ -73,7 +73,9 @@ class TestRotationEnabled:
         assert first.status_code == 200
 
         reuse = _refresh(client, auth_header, tokens["refresh_token"])
-        assert reuse.status_code == 401
+        # invalid_grant JSON since #308 (was a 401 HTML abort).
+        assert reuse.status_code == 400
+        assert reuse.get_json()["error"] == "invalid_grant"
 
     def test_rotated_replacement_works(self, client, auth_header):
         tokens = _password_grant(client, auth_header)

--- a/tests/test_token_error_contract.py
+++ b/tests/test_token_error_contract.py
@@ -1,0 +1,224 @@
+"""
+Every /token error branch answers RFC 6749 §5.2 JSON (#308).
+
+The #287 "Error surfaces" contract said protocol endpoints never answer
+HTML - and roughly twenty /token branches still did, via Werkzeug abort().
+The pre-existing suite only ever asserted status codes, so the HTML bodies
+were invisible (the #307 review's example: a 400 assertion that never
+looked at the body). This file is the parametric guard: one table of
+(request, expected status, expected error code), each case asserting the
+BODY is §5.2 JSON.
+
+Status changes vs the old aborts are deliberate and CHANGELOGed: grant
+failures that used to 401 (revoked/foreign refresh token, unknown user,
+bad resource-owner credentials) are invalid_grant 400 - §5.2 reserves 401
+for CLIENT authentication (invalid_client), not for grant validity.
+"""
+
+import base64
+import time
+
+import jwt as pyjwt
+import pytest
+
+from nanoidp.config import get_config
+from nanoidp.services.crypto import get_crypto_service
+
+
+def _basic(client_id: str, secret: str) -> dict:
+    credentials = base64.b64encode(f"{client_id}:{secret}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+AUTH = _basic("demo-client", "demo-secret")
+
+
+def _sign(app, claims):
+    with app.app_context():
+        crypto = get_crypto_service(get_config().settings.keys_dir)
+    return pyjwt.encode(claims, crypto.priv_pem, algorithm="RS256")
+
+
+def _refresh_claims(**over):
+    claims = {
+        "sub": "admin",
+        "jti": f"contract-{time.time()}",
+        "token_use": "refresh",
+        "token_type": "refresh",
+        "client_id": "demo-client",
+        "exp": int(time.time()) + 300,
+    }
+    claims.update(over)
+    return claims
+
+
+# (case id, form data or callable(app)->data, headers, status, error code)
+CASES = [
+    ("no_client_auth", {"grant_type": "client_credentials"}, {}, 401, "invalid_client"),
+    (
+        "unsupported_grant_type",
+        {"grant_type": "carrier-pigeon"},
+        AUTH,
+        400,
+        "unsupported_grant_type",
+    ),
+    (
+        "exp_not_integer",
+        {"grant_type": "client_credentials", "exp": "soon"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "exp_out_of_bounds",
+        {"grant_type": "client_credentials", "exp": "99999"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "extra_invalid_json",
+        {"grant_type": "client_credentials", "extra": "{nope"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "extra_not_object",
+        {"grant_type": "client_credentials", "extra": "[1,2]"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "refresh_token_missing",
+        {"grant_type": "refresh_token"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "refresh_unverifiable",
+        {"grant_type": "refresh_token", "refresh_token": "not-a-jwt"},
+        AUTH,
+        400,
+        "invalid_grant",
+    ),
+    (
+        "access_token_used_as_refresh",
+        lambda app: {
+            "grant_type": "refresh_token",
+            "refresh_token": _sign(
+                app, _refresh_claims(token_use="access", token_type="access")
+            ),
+        },
+        AUTH,
+        400,
+        "invalid_grant",
+    ),
+    (
+        "refresh_of_unknown_user",
+        lambda app: {
+            "grant_type": "refresh_token",
+            "refresh_token": _sign(app, _refresh_claims(sub="ghost-user")),
+        },
+        AUTH,
+        400,
+        "invalid_grant",
+    ),
+    (
+        "password_missing_credentials",
+        {"grant_type": "password"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "password_bad_credentials",
+        {"grant_type": "password", "username": "admin", "password": "wrong"},
+        AUTH,
+        400,
+        "invalid_grant",
+    ),
+    (
+        "authorization_code_missing_code",
+        {"grant_type": "authorization_code", "redirect_uri": "http://localhost/cb"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "authorization_code_missing_redirect_uri",
+        {"grant_type": "authorization_code", "code": "whatever"},
+        AUTH,
+        400,
+        "invalid_request",
+    ),
+    (
+        "authorization_code_invalid_code",
+        {
+            "grant_type": "authorization_code",
+            "code": "no-such-code",
+            "redirect_uri": "http://localhost/cb",
+        },
+        AUTH,
+        400,
+        "invalid_grant",
+    ),
+]
+
+
+class TestTokenErrorContract:
+    @pytest.mark.parametrize(
+        "case_id,data,headers,status,error",
+        CASES,
+        ids=[c[0] for c in CASES],
+    )
+    def test_error_is_rfc6749_json(self, client, app, case_id, data, headers, status, error):
+        if callable(data):
+            data = data(app)
+        resp = client.post("/token", data=data, headers=headers)
+        assert resp.status_code == status, resp.data[:200]
+        body = resp.get_json(silent=True)
+        assert body is not None, f"non-JSON body: {resp.data[:200]!r}"
+        assert body["error"] == error
+        assert "error_description" in body
+
+    def test_foreign_client_refresh_is_invalid_grant(self, client, app):
+        """A refresh token issued to another client: invalid_grant 400
+        (used to be a 401 HTML abort). Minted for scoped-client, spent by
+        demo-client."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers=_basic("scoped-client", "scoped-secret"),
+        )
+        assert resp.status_code == 200
+        stolen = resp.get_json()["refresh_token"]
+
+        spent = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": stolen},
+            headers=AUTH,
+        )
+        assert spent.status_code == 400
+        body = spent.get_json()
+        assert body["error"] == "invalid_grant"
+
+    def test_revoked_refresh_is_invalid_grant(self, client, app):
+        resp = client.post(
+            "/token",
+            data={"grant_type": "password", "username": "admin", "password": "admin"},
+            headers=AUTH,
+        )
+        rt = resp.get_json()["refresh_token"]
+        assert (
+            client.post("/revoke", data={"token": rt}, headers=AUTH).status_code == 200
+        )
+        spent = client.post(
+            "/token",
+            data={"grant_type": "refresh_token", "refresh_token": rt},
+            headers=AUTH,
+        )
+        assert spent.status_code == 400
+        assert spent.get_json()["error"] == "invalid_grant"

--- a/tests/test_token_error_contract.py
+++ b/tests/test_token_error_contract.py
@@ -63,6 +63,29 @@ CASES = [
         "unsupported_grant_type",
     ),
     (
+        # #310 review blocker 1: the caller's arbitrary value must NOT be
+        # reflected into error_description (§5.2 restricts it to a narrow
+        # ASCII subset) - this is the case that distinguishes fixed text
+        # from reflection.
+        "unsupported_grant_type_non_ascii",
+        {"grant_type": 'sp\u00e4ce"\U0001f4a5\ntype'},
+        AUTH,
+        400,
+        "unsupported_grant_type",
+    ),
+    (
+        "refresh_token_without_subject",
+        lambda app: {
+            "grant_type": "refresh_token",
+            "refresh_token": _sign(
+                app, {k: v for k, v in _refresh_claims().items() if k != "sub"}
+            ),
+        },
+        AUTH,
+        400,
+        "invalid_grant",
+    ),
+    (
         "exp_not_integer",
         {"grant_type": "client_credentials", "exp": "soon"},
         AUTH,
@@ -183,6 +206,102 @@ class TestTokenErrorContract:
         assert body is not None, f"non-JSON body: {resp.data[:200]!r}"
         assert body["error"] == error
         assert "error_description" in body
+
+    def test_non_ascii_grant_type_is_not_reflected(self, client):
+        """The description is fixed text; the raw value lives in the audit
+        event, not the response (#310 review blocker 1)."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": 'sp\u00e4ce"\U0001f4a5\ntype'},
+            headers=AUTH,
+        )
+        body = resp.get_json()
+        assert body["error_description"] == "The requested grant_type is not supported"
+        assert "\U0001f4a5" not in body["error_description"]
+
+    def test_invalid_client_with_basic_carries_www_authenticate(self, client):
+        """§5.2 MUST (#310 review blocker 2): a client that ATTEMPTED
+        Authorization-header authentication gets 401 with a
+        WWW-Authenticate challenge for the scheme it used."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers=_basic("demo-client", "wrong-secret"),
+        )
+        assert resp.status_code == 401
+        assert resp.get_json()["error"] == "invalid_client"
+        assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
+
+    def test_invalid_client_without_auth_header_has_no_challenge(self, client):
+        """The MUST is conditional on the attempt: no Authorization header
+        sent, no WWW-Authenticate issued."""
+        resp = client.post("/token", data={"grant_type": "client_credentials"})
+        assert resp.status_code == 401
+        assert resp.get_json()["error"] == "invalid_client"
+        assert "WWW-Authenticate" not in resp.headers
+
+    def test_client_id_mismatch_is_json_with_challenge(self, client):
+        """Basic for one client plus a contradictory body client_id: 401
+        invalid_client JSON (was HTML) WITH the challenge - Basic was
+        presented by construction."""
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": "scoped-client",
+            },
+            headers=AUTH,
+        )
+        assert resp.status_code == 401
+        body = resp.get_json()
+        assert body["error"] == "invalid_client"
+        assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
+
+    def test_password_grant_disabled_by_oauth21_is_unsupported_grant_type(
+        self, client, app
+    ):
+        from nanoidp.config import get_config
+
+        with app.app_context():
+            settings = get_config().settings
+            original = settings.security_profile
+            settings.security_profile = "oauth21"
+        try:
+            resp = client.post(
+                "/token",
+                data={"grant_type": "password", "username": "admin", "password": "admin"},
+                headers=AUTH,
+            )
+            assert resp.status_code == 400
+            body = resp.get_json()
+            assert body["error"] == "unsupported_grant_type"
+            assert "oauth21" in body["error_description"]
+        finally:
+            with app.app_context():
+                get_config().settings.security_profile = original
+
+    def test_code_for_a_deleted_user_is_invalid_grant(self, client, app):
+        """An authorization code whose user vanished between /authorize and
+        redemption: invalid_grant JSON (was a 401 HTML abort)."""
+        from nanoidp.services.auth_code import get_auth_code_store
+
+        with app.app_context():
+            code = get_auth_code_store().create_code(
+                client_id="demo-client",
+                redirect_uri="http://localhost/cb",
+                username="ghost-user-never-existed",
+            )
+        resp = client.post(
+            "/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "http://localhost/cb",
+            },
+            headers=AUTH,
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid_grant"
 
     def test_foreign_client_refresh_is_invalid_grant(self, client, app):
         """A refresh token issued to another client: invalid_grant 400

--- a/tests/test_token_error_contract.py
+++ b/tests/test_token_error_contract.py
@@ -54,7 +54,9 @@ def _refresh_claims(**over):
 
 # (case id, form data or callable(app)->data, headers, status, error code)
 CASES = [
-    ("no_client_auth", {"grant_type": "client_credentials"}, {}, 401, "invalid_client"),
+    # 400, not 401: no Authorization header was attempted, and RFC 9110
+    # forbids a challenge-less 401 (#310 review round 2).
+    ("no_client_auth", {"grant_type": "client_credentials"}, {}, 400, "invalid_client"),
     (
         "unsupported_grant_type",
         {"grant_type": "carrier-pigeon"},
@@ -232,13 +234,50 @@ class TestTokenErrorContract:
         assert resp.get_json()["error"] == "invalid_client"
         assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
 
-    def test_invalid_client_without_auth_header_has_no_challenge(self, client):
-        """The MUST is conditional on the attempt: no Authorization header
-        sent, no WWW-Authenticate issued."""
+    def test_invalid_client_without_auth_header_is_400_no_challenge(self, client):
+        """No Authorization header attempted: §5.2's DEFAULT applies -
+        invalid_client 400 - because RFC 9110 §11.6.1 forbids a 401 without
+        a WWW-Authenticate challenge, and issuing a Basic challenge to a
+        client that never tried Basic would be wrong too (#310 round 2)."""
         resp = client.post("/token", data={"grant_type": "client_credentials"})
-        assert resp.status_code == 401
+        assert resp.status_code == 400
         assert resp.get_json()["error"] == "invalid_client"
         assert "WWW-Authenticate" not in resp.headers
+
+    def test_client_secret_post_wrong_secret_is_400_no_basic_challenge(self, client, app):
+        """A client_secret_post client with a wrong BODY secret never
+        touched the Authorization header: 400 invalid_client, and no Basic
+        challenge for a client whose registered method is not Basic
+        (#310 round 2 - the case that makes the 400/401 split matter)."""
+        from nanoidp.config import OAuthClient, get_config
+
+        with app.app_context():
+            settings = get_config().settings
+            settings.clients.append(
+                OAuthClient(
+                    client_id="post-client-310",
+                    client_secret="post-secret",
+                    token_endpoint_auth_method="client_secret_post",
+                )
+            )
+        try:
+            resp = client.post(
+                "/token",
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": "post-client-310",
+                    "client_secret": "wrong",
+                },
+            )
+            assert resp.status_code == 400
+            assert resp.get_json()["error"] == "invalid_client"
+            assert "WWW-Authenticate" not in resp.headers
+        finally:
+            with app.app_context():
+                settings = get_config().settings
+                settings.clients = [
+                    c for c in settings.clients if c.client_id != "post-client-310"
+                ]
 
     def test_client_id_mismatch_is_json_with_challenge(self, client):
         """Basic for one client plus a contradictory body client_id: 401


### PR DESCRIPTION
Closes #308 (in 3.0.0 per maintainer decision). Completes the #287 'Error surfaces' contract on the token endpoint: ~20 conditions across the `/token` shell and all five grant handlers answered Werkzeug `abort()` HTML.

## Mapping (one shared `_oauth_error` helper, fixed-text descriptions, audit events untouched)

- **`invalid_request` 400**: missing `refresh_token`/`code`/`redirect_uri`/password-grant credentials; `exp` bounds; malformed `extra`.
- **`invalid_grant` 400**: invalid/expired code; access token spent as refresh; foreign or revoked refresh token; missing subject; unknown user; bad resource-owner credentials. **Status change**: these used to 401 - §5.2 reserves 401 for CLIENT authentication, not grant validity. CHANGELOGed with a migration line.
- **`unsupported_grant_type` 400**: unknown grant type (FIXED description - the caller's value goes to the audit event, never reflected into error_description, per §5.2's ASCII constraint), and the oauth21-disabled password grant (previously mislabeled as a plain 400).
- **`invalid_client`**: 401 with `WWW-Authenticate: Basic` when the client ATTEMPTED header authentication (the §5.2 MUST), 400 otherwise - §5.2's default, and RFC 9110 §11.6.1 forbids a challenge-less 401; a `client_secret_post` client with a wrong body secret gets 400 with no Basic challenge (Basic is not its method).

## Tests

`tests/test_token_error_contract.py`: a parametric table of (request -> status, error code) with **body assertions** on every case - the guard the old suite lacked (the #308 review's point: it only checked status codes and never saw the HTML). Plus foreign-client and revoked-refresh scenario tests. 7 existing pins updated to the new contract; suite 1915 green, mypy/ruff/import-linter clean.

## Verification note (and a new tracked flake)

Full e2e ran 22+ times on fresh boots during this PR: all green except ONE occurrence of an intermittent 'SAML Attribute Query' failure that predates nothing in this diff - investigated in depth (ghost-server interference ruled out via sanity probes; the shared lxml parser hypothesis probed negative with 16k concurrent parses; 12+12 fresh-boot reproduction attempts all green) and tracked as **#309** with the forensics. This PR adds the diagnosability piece: on failure the e2e message now carries status + body prefix per leg, so the next occurrence identifies itself.
