### PR TITLE
chore: bump to 3.0.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "3.0.0rc1"
+version = "3.0.0rc2"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only; CHANGELOG stays under [Unreleased] until the final, per house policy. rc2 absorbs everything merged since rc1: #274 and the full architecture-audit wave (#275-#288, #291, #306, #308). Release notes drafted for the tag.