### PR TITLE
fix: detect an attempted Basic from the raw Authorization header (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,10 @@ previous leniency allowed - needs a one-time adjustment.
   the `WWW-Authenticate: Basic` challenge when the client attempted HTTP
   Basic (the §5.2 MUST), 400 otherwise (§5.2's default; RFC 9110 §11.6.1
   forbids a challenge-less 401, and a Basic challenge would be wrong for
-  a `client_secret_post` client anyway). Descriptions are fixed text (no library
+  a `client_secret_post` client anyway). The attempt is detected from the
+  raw `Authorization` header (#311): a syntactically broken Basic header -
+  which werkzeug parses to nothing - still counts as an attempted Basic
+  and gets the 401 + challenge. Descriptions are fixed text (no library
   detail and no reflected caller input - the unsupported grant type's raw
   value lives in the audit event, not the response). *Migration:* branches that used to answer 401 for GRANT problems
   (revoked/foreign refresh token, unknown user, wrong password) now

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -644,6 +644,19 @@ def client_logo(client_id: str) -> ResponseReturnValue:
 # ============================================================================
 
 
+def _basic_attempted() -> bool:
+    """True when the request ATTEMPTED HTTP Basic authentication (#311).
+
+    Read from the RAW Authorization header, not werkzeug's parsed
+    ``request.authorization``: werkzeug returns None for a syntactically
+    broken Basic header, which would misclassify a botched attempt as
+    no-attempt - answering 400 with no challenge where RFC 6749 §5.2's
+    401 + WWW-Authenticate MUST covers the attempt. The parsed object
+    stays the only source of username/password.
+    """
+    return request.headers.get("Authorization", "").lstrip().lower().startswith("basic")
+
+
 def _token_auth_failed(
     client_id: Optional[str], reason: str, *, basic_attempted: bool
 ) -> ResponseReturnValue:
@@ -745,7 +758,7 @@ def _enforce_token_endpoint_auth(
 
     reason = _enforce_registered_client_auth(config, client_id, auth, body_client_secret)
     return (
-        _token_auth_failed(client_id, reason, basic_attempted=auth is not None)
+        _token_auth_failed(client_id, reason, basic_attempted=_basic_attempted())
         if reason is not None
         else None
     )
@@ -829,7 +842,7 @@ def token() -> ResponseReturnValue:
             details={"reason": "Client authentication required", "grant_type": grant_type},
         )
         return invalid_client_error(
-            "Client authentication required", basic_attempted=auth is not None
+            "Client authentication required", basic_attempted=_basic_attempted()
         )
 
     # Reject if body client_id conflicts with the authenticated client in the header

--- a/src/nanoidp/routes/oauth.py
+++ b/src/nanoidp/routes/oauth.py
@@ -653,8 +653,16 @@ def _basic_attempted() -> bool:
     no-attempt - answering 400 with no challenge where RFC 6749 §5.2's
     401 + WWW-Authenticate MUST covers the attempt. The parsed object
     stays the only source of username/password.
+
+    The SCHEME is compared for equality, not by prefix (#313 review):
+    "BasicFoo xyz" is a different scheme, not a Basic attempt. A bare
+    "Basic" with no credentials still counts - the scheme was named.
     """
-    return request.headers.get("Authorization", "").lstrip().lower().startswith("basic")
+    raw = request.headers.get("Authorization", "").lstrip()
+    if not raw:
+        return False
+    scheme = raw.split(maxsplit=1)[0]
+    return scheme.casefold() == "basic"
 
 
 def _token_auth_failed(

--- a/tests/test_token_error_contract.py
+++ b/tests/test_token_error_contract.py
@@ -398,6 +398,29 @@ class TestBrokenBasicHeaderIsStillAnAttempt:
         assert resp.get_json()["error"] == "invalid_client"
         assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
 
+    def test_basicfoo_scheme_is_not_a_basic_attempt(self, client):
+        """#313 review: the scheme is compared for EQUALITY, not by prefix -
+        'BasicFoo' is a different scheme."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={"Authorization": "BasicFoo whatever"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid_client"
+        assert "WWW-Authenticate" not in resp.headers
+
+    def test_bare_basic_scheme_alone_is_an_attempt(self, client):
+        """'Authorization: Basic' with no credentials named the scheme:
+        still an attempt - 401 + challenge."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={"Authorization": "Basic"},
+        )
+        assert resp.status_code == 401
+        assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
+
     def test_bearer_header_is_not_a_basic_attempt(self, client):
         """A different scheme is not a Basic attempt: no Basic challenge,
         400 per the §5.2 default."""

--- a/tests/test_token_error_contract.py
+++ b/tests/test_token_error_contract.py
@@ -380,3 +380,32 @@ class TestTokenErrorContract:
         )
         assert spent.status_code == 400
         assert spent.get_json()["error"] == "invalid_grant"
+
+
+class TestBrokenBasicHeaderIsStillAnAttempt:
+    """#311: werkzeug parses a syntactically broken Basic header to None,
+    which used to land in the no-attempt branch (400, no challenge). The
+    attempt is now detected from the RAW header: a botched Basic is still
+    a Basic attempt - 401 with the challenge."""
+
+    def test_garbage_basic_header_gets_401_with_challenge(self, client):
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={"Authorization": "Basic %%%not-base64%%%"},
+        )
+        assert resp.status_code == 401
+        assert resp.get_json()["error"] == "invalid_client"
+        assert resp.headers.get("WWW-Authenticate", "").startswith("Basic")
+
+    def test_bearer_header_is_not_a_basic_attempt(self, client):
+        """A different scheme is not a Basic attempt: no Basic challenge,
+        400 per the §5.2 default."""
+        resp = client.post(
+            "/token",
+            data={"grant_type": "client_credentials"},
+            headers={"Authorization": "Bearer some-token"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid_client"
+        assert "WWW-Authenticate" not in resp.headers


### PR DESCRIPTION
Closes #311 (pulled into 3.0.0 so the §5.2 contract born in #310 ships complete, not amended in a minor). The #310 round-3 review edge: werkzeug parses a syntactically broken `Authorization: Basic ...` to `None`, so a botched attempt landed in the no-attempt branch - 400 with no challenge - where the §5.2 MUST covers it as an attempt.

`_basic_attempted()` now reads the RAW header for the ATTEMPT decision only - the scheme token is split off and compared with `casefold()` EQUALITY (review round 1: `startswith` would have classified `BasicFoo` as Basic); `request.authorization` stays the sole source of username/password. Both /token shell call sites converted (the mismatch site already passes `True` by construction).

Pins in `test_token_error_contract.py`, both directions: garbage Basic -> 401 + `WWW-Authenticate: Basic`; a `Bearer` header is NOT a Basic attempt -> 400, no challenge. Suite 1926 green, statics clean.
