### PR TITLE
fix: rate limiting on /token is enforced for real (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,8 +352,12 @@ previous leniency allowed - needs a one-time adjustment.
   `rate_limit_enabled: true` logged "Rate limiting: enabled (10/minute on
   /token)" while enforcing nothing - a "metadata never lies" violation.
   The configured `rate_limit_token_endpoint` now actually applies to
-  `POST /token` (429 with a JSON body and `Retry-After`/`RateLimit-*`
-  headers; every other endpoint stays unlimited). The two settings are
+  `POST /token` (429 with a JSON body and `Retry-After`/`X-RateLimit-*`
+  headers; every other endpoint stays unlimited), and the rate string is
+  VALIDATED at the config boundary: flask-limiter silently ignores a
+  malformed one and falls back to the (empty) defaults, so an unparsable
+  `rate_limit_token_endpoint` now refuses to load instead of silently
+  recreating the enabled-but-unenforced lie. No fallback value either. The two settings are
   also configurable from YAML at last (`server.rate_limit_enabled`,
   `server.rate_limit_token_endpoint`) - the fields existed on Settings
   but no document section carried them, so only the profile could flip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,20 @@ previous leniency allowed - needs a one-time adjustment.
   (RFC 3986 §3, e.g. `about:`). No audience bypass or escalation.
 
 ### Fixed
+- **Rate limiting on `/token` is enforced for real** (#304): the limiter
+  was constructed with no limits and no view was ever decorated, so
+  `rate_limit_enabled: true` logged "Rate limiting: enabled (10/minute on
+  /token)" while enforcing nothing - a "metadata never lies" violation.
+  The configured `rate_limit_token_endpoint` now actually applies to
+  `POST /token` (429 with a JSON body and `Retry-After`/`RateLimit-*`
+  headers; every other endpoint stays unlimited). The two settings are
+  also configurable from YAML at last (`server.rate_limit_enabled`,
+  `server.rate_limit_token_endpoint`) - the fields existed on Settings
+  but no document section carried them, so only the profile could flip
+  them. **Behavior change for `stricter-dev`**: that profile has always
+  forced `rate_limit_enabled: true`, so its instances now really throttle
+  `/token` at the configured rate (default 10/minute) - the hardening the
+  profile always claimed.
 - **`RevocationStore` entries now expire** (#288): revoked jtis and rotation
   family markers lived in two sets that were never swept - every revocation
   and every refresh rotation on a long-lived instance was a permanent memory

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -225,6 +225,10 @@ the SAML `AuthnContextClassRef` detail.
 server:
   host: "127.0.0.1"        # loopback by default; set 0.0.0.0 to expose on a network
   port: 8000
+  rate_limit_enabled: false        # optional; rate-limit POST /token (#304). Enforced
+                                   # for real since 3.0 - it used to log "enabled" while
+                                   # enforcing nothing. stricter-dev forces it on.
+  rate_limit_token_endpoint: "10/minute"  # optional; flask-limiter notation
 
 oauth:
   issuer: "http://localhost:8000"

--- a/docs/schema/config.v1.json
+++ b/docs/schema/config.v1.json
@@ -534,6 +534,16 @@
             "default": 8000,
             "title": "Port",
             "type": "integer"
+          },
+          "rate_limit_enabled": {
+            "default": false,
+            "title": "Rate Limit Enabled",
+            "type": "boolean"
+          },
+          "rate_limit_token_endpoint": {
+            "default": "10/minute",
+            "title": "Rate Limit Token Endpoint",
+            "type": "string"
           }
         },
         "title": "ServerSection",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "Flask>=3.0.0",
     "Flask-Cors>=6.0.2",
     "Flask-Limiter>=4.1.1",
+    # Direct API use since #314 (limits.parse validates the rate string at
+    # the config boundary); was only transitive via Flask-Limiter.
+    "limits>=3.0",
     # >=2.13.0: /userinfo and /introspect pass a client-supplied token to
     # jwt.decode(), and 2.8.0-2.12.1 are affected by CVE-2026-48525 (unbounded
     # Base64URL decode of a b64=false detached JWS payload -> DoS).

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -7,6 +7,7 @@ import os
 from typing import Optional
 
 from flask import Flask, Response, jsonify
+from flask.typing import ResponseReturnValue
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -127,6 +128,7 @@ def create_app(
             app=app,
             default_limits=[],  # No default limits
             storage_uri="memory://",
+            headers_enabled=True,  # RateLimit-*/Retry-After on 429 (#304)
         )
         logger.info(f"  - Rate limiting: enabled ({settings.rate_limit_token_endpoint} on /token)")
     else:
@@ -143,6 +145,39 @@ def create_app(
     app.register_blueprint(saml_bp)
     app.register_blueprint(ui_bp)
     app.register_blueprint(api_bp)
+
+    # Actually APPLY the /token rate limit (#304). Until 3.0 the limiter
+    # was created with default_limits=[] and no view ever decorated, so
+    # rate_limit_enabled: true logged "enabled" while enforcing nothing -
+    # a "metadata never lies" violation. The wrap must happen after the
+    # blueprint registration above, which is what puts oauth.token into
+    # app.view_functions.
+    if settings.rate_limit_enabled:
+        # flask-limiter's decorator returns the same callable it received;
+        # the ignore covers werkzeug's wide view-function union.
+        app.view_functions["oauth.token"] = limiter.limit(  # type: ignore[assignment]
+            settings.rate_limit_token_endpoint
+        )(app.view_functions["oauth.token"])
+
+        @app.errorhandler(429)
+        def _rate_limited(e: Exception) -> ResponseReturnValue:
+            # /token is the only limited view, so every 429 is a protocol
+            # response: JSON, never the framework's HTML page. RFC 6749
+            # defines no error code for throttling; flask-limiter's
+            # Retry-After/RateLimit-* headers (headers_enabled above) carry
+            # the machine-readable part.
+            return (
+                jsonify(
+                    {
+                        "error": "rate_limit_exceeded",
+                        "error_description": (
+                            "Too many token requests; retry after the "
+                            "interval in the Retry-After header"
+                        ),
+                    }
+                ),
+                429,
+            )
 
     # Context processor to inject version into all templates
     @app.context_processor

--- a/src/nanoidp/app.py
+++ b/src/nanoidp/app.py
@@ -4,10 +4,9 @@ Flask application factory for NanoIDP.
 
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from flask import Flask, Response, jsonify
-from flask.typing import ResponseReturnValue
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -153,31 +152,36 @@ def create_app(
     # blueprint registration above, which is what puts oauth.token into
     # app.view_functions.
     if settings.rate_limit_enabled:
+        def _token_rate_limited(request_limit: Any) -> Response:
+            # on_breach on THIS limit, not a global 429 handler (#314
+            # review): /token's throttle response is a protocol-shaped
+            # JSON, and scoping it here means a future limit on some other
+            # endpoint does not inherit an OAuth-flavored body. RFC 6749
+            # defines no error code for throttling; flask-limiter's
+            # Retry-After/X-RateLimit-* headers (headers_enabled above)
+            # carry the machine-readable part.
+            response = jsonify(
+                {
+                    "error": "rate_limit_exceeded",
+                    "error_description": (
+                        "Too many token requests; retry after the "
+                        "interval in the Retry-After header"
+                    ),
+                }
+            )
+            response.status_code = 429
+            return response
+
+        # The rate string was validated at the config boundary
+        # (Settings.validate_rate_limit_notation): flask-limiter would not
+        # raise on a malformed one - it logs and falls back to the default
+        # limits, which are [] here, silently disabling the throttle.
         # flask-limiter's decorator returns the same callable it received;
         # the ignore covers werkzeug's wide view-function union.
         app.view_functions["oauth.token"] = limiter.limit(  # type: ignore[assignment]
-            settings.rate_limit_token_endpoint
+            settings.rate_limit_token_endpoint,
+            on_breach=_token_rate_limited,
         )(app.view_functions["oauth.token"])
-
-        @app.errorhandler(429)
-        def _rate_limited(e: Exception) -> ResponseReturnValue:
-            # /token is the only limited view, so every 429 is a protocol
-            # response: JSON, never the framework's HTML page. RFC 6749
-            # defines no error code for throttling; flask-limiter's
-            # Retry-After/RateLimit-* headers (headers_enabled above) carry
-            # the machine-readable part.
-            return (
-                jsonify(
-                    {
-                        "error": "rate_limit_exceeded",
-                        "error_description": (
-                            "Too many token requests; retry after the "
-                            "interval in the Retry-After header"
-                        ),
-                    }
-                ),
-                429,
-            )
 
     # Context processor to inject version into all templates
     @app.context_processor

--- a/src/nanoidp/config_documents.py
+++ b/src/nanoidp/config_documents.py
@@ -63,6 +63,11 @@ class ServerSection(BaseModel):
     host: str = "127.0.0.1"
     port: int = 8000
     debug: bool = False
+    # Rate limiting on /token (#304): configurable from YAML at last - the
+    # Settings fields existed since early versions but no document section
+    # carried them, so only the stricter-dev profile could ever flip them.
+    rate_limit_enabled: bool = False
+    rate_limit_token_endpoint: str = "10/minute"
 
 
 class ClientEntry(BaseModel):
@@ -346,6 +351,8 @@ class SettingsDocument(BaseModel):
             host=self.server.host,
             port=self.server.port,
             debug=self.server.debug,
+            rate_limit_enabled=self.server.rate_limit_enabled,
+            rate_limit_token_endpoint=self.server.rate_limit_token_endpoint,
             issuer=self.oauth.issuer,
             issuer_from_request=self.oauth.issuer_from_request,
             issuer_allowlist=self.oauth.issuer_allowlist or [],

--- a/src/nanoidp/mcp_server/handlers_config.py
+++ b/src/nanoidp/mcp_server/handlers_config.py
@@ -52,6 +52,8 @@ def _tool_get_settings(arguments: dict[str, Any], config: ConfigManager) -> dict
             "debug": settings.debug,
         },
         "login_mode": settings.login_mode,
+        "rate_limit_enabled": settings.rate_limit_enabled,
+        "rate_limit_token_endpoint": settings.rate_limit_token_endpoint,
         "refresh_token_rotation": settings.refresh_token_rotation,
         "require_pkce": settings.require_pkce,
         "jwt_algorithm": settings.jwt_algorithm,

--- a/src/nanoidp/models.py
+++ b/src/nanoidp/models.py
@@ -515,6 +515,27 @@ class Settings(BaseModel):
     cors_allowed_origins: List[str] = Field(default_factory=lambda: ["*"], description="CORS allowed origins")
     rate_limit_enabled: bool = Field(default=False, description="Enable rate limiting")
     rate_limit_token_endpoint: str = Field(default="10/minute", description="Rate limit for /token endpoint")
+
+    @field_validator("rate_limit_token_endpoint")
+    @classmethod
+    def validate_rate_limit_notation(cls, v: str) -> str:
+        """Reject an unparsable rate string at the config boundary (#314
+        review). flask-limiter does NOT raise on a malformed string passed
+        to limit(): it logs and falls back to the defaults - which nanoidp
+        sets to [] - so 'rate_limit_token_endpoint: banana' would silently
+        recreate the exact lie #304 exists to end (enabled-but-unenforced).
+        No fallback either: a default swapped in behind the operator's back
+        is just another form of configuration that lies.
+        """
+        from limits import parse
+
+        try:
+            parse(v)
+        except Exception as e:
+            raise ValueError(
+                f"not a valid rate limit string (e.g. '10/minute'): {v!r}"
+            ) from e
+        return v
     password_hashing: bool = Field(default=False, description="Use bcrypt for password hashing")
     require_pkce: bool = Field(
         default=False,

--- a/src/nanoidp/routes/api.py
+++ b/src/nanoidp/routes/api.py
@@ -152,6 +152,8 @@ def get_configuration() -> ResponseReturnValue:
         "server": {
             "host": settings.host,
             "port": settings.port,
+            "rate_limit_enabled": settings.rate_limit_enabled,
+            "rate_limit_token_endpoint": settings.rate_limit_token_endpoint,
         },
         "oauth": {
             "issuer": settings.issuer,

--- a/src/nanoidp/serialization.py
+++ b/src/nanoidp/serialization.py
@@ -476,6 +476,8 @@ class OwnedSetting:
 OWNED_SETTINGS: tuple[OwnedSetting, ...] = (
     OwnedSetting("server", "host", "host"),
     OwnedSetting("server", "port", "port"),
+    OwnedSetting("server", "rate_limit_enabled", "rate_limit_enabled"),
+    OwnedSetting("server", "rate_limit_token_endpoint", "rate_limit_token_endpoint"),
     OwnedSetting("oauth", "issuer", "issuer"),
     OwnedSetting("oauth", "issuer_from_request", "issuer_from_request"),
     OwnedSetting("oauth", "issuer_allowlist", "issuer_allowlist", "omit_when_falsy", []),

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -115,3 +115,44 @@ class TestStricterDevProfilePromise:
                 config = get_config()
                 config.settings.rate_limit_token_endpoint = "10/minute"
                 config.save()
+
+
+class TestRateStringValidatedAtTheBoundary:
+    """#314 review blocker: flask-limiter does not raise on a malformed
+    rate string passed to limit() - it logs and falls back to the default
+    limits, which nanoidp sets to []. 'rate_limit_token_endpoint: banana'
+    would therefore silently recreate the enabled-but-unenforced lie #304
+    exists to end. The config boundary rejects it instead; deliberately NO
+    fallback to 10/minute - a default swapped in behind the operator's
+    back is another form of configuration that lies."""
+
+    def test_settings_rejects_unparsable_rate_string(self):
+        import pydantic
+        import pytest as _pytest
+
+        from nanoidp.models import Settings
+
+        with _pytest.raises(pydantic.ValidationError, match="rate limit string"):
+            Settings(rate_limit_token_endpoint="not-a-limit")
+
+    def test_yaml_load_path_rejects_it_too(self):
+        import pydantic
+        import pytest as _pytest
+
+        from nanoidp.config_documents import SettingsDocument
+
+        doc = SettingsDocument.model_validate(
+            {"server": {"rate_limit_enabled": True,
+                        "rate_limit_token_endpoint": "banana"}}
+        )
+        with _pytest.raises(pydantic.ValidationError, match="rate limit string"):
+            doc.to_settings()
+
+    def test_valid_notations_pass(self):
+        from nanoidp.models import Settings
+
+        for notation in ("10/minute", "1 per second", "100/hour"):
+            assert (
+                Settings(rate_limit_token_endpoint=notation).rate_limit_token_endpoint
+                == notation
+            )

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,117 @@
+"""
+The /token rate limit is actually enforced when enabled (#304).
+
+Until 3.0 the limiter was constructed with default_limits=[] and no view
+was ever decorated: with rate_limit_enabled: true the app logged
+"Rate limiting: enabled (10/minute on /token)" while enforcing nothing -
+a "metadata never lies" violation (VISION principle 2). These tests pin
+both directions: enabled -> the configured limit answers 429 JSON with
+Retry-After; disabled (the default) -> no limit.
+"""
+
+import base64
+
+import pytest
+
+from nanoidp.app import create_app
+from nanoidp.config import get_config
+
+
+def _basic(client_id: str, secret: str) -> dict:
+    credentials = base64.b64encode(f"{client_id}:{secret}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+AUTH = _basic("demo-client", "demo-secret")
+DATA = {"grant_type": "client_credentials"}
+
+
+@pytest.fixture
+def limited_app(app):
+    """A second app built with the limit ON and tight (3/minute).
+
+    The plain `app` fixture already initialized the config; flipping the
+    settings before another create_app() call gives an app whose limiter
+    is real. Restored afterwards.
+    """
+    with app.app_context():
+        config = get_config()
+        config.settings.rate_limit_enabled = True
+        config.settings.rate_limit_token_endpoint = "3/minute"
+        # create_app() reloads from disk, so the flip must be persisted -
+        # the conftest gives every test an isolated config copy.
+        config.save()
+    limited = create_app()
+    limited.config["TESTING"] = True
+    limited.config["SECRET_KEY"] = "test-secret-key"
+    yield limited
+    with app.app_context():
+        config = get_config()
+        config.settings.rate_limit_enabled = False
+        config.settings.rate_limit_token_endpoint = "10/minute"
+        config.save()
+
+
+class TestRateLimitEnforced:
+    def test_configured_limit_answers_429_json(self, limited_app):
+        client = limited_app.test_client()
+        for _ in range(3):
+            assert client.post("/token", data=DATA, headers=AUTH).status_code == 200
+
+        throttled = client.post("/token", data=DATA, headers=AUTH)
+        assert throttled.status_code == 429
+        body = throttled.get_json()
+        assert body is not None, f"non-JSON 429 body: {throttled.data[:120]!r}"
+        assert body["error"] == "rate_limit_exceeded"
+        assert throttled.headers.get("Retry-After") is not None
+
+    def test_other_endpoints_are_not_limited(self, limited_app):
+        client = limited_app.test_client()
+        for _ in range(6):
+            assert client.get("/health").status_code == 200
+
+    def test_limit_is_per_client_address_bucketed_on_token_only(self, limited_app):
+        """Exhaust /token, then confirm discovery still answers - the limit
+        is scoped to the token endpoint, exactly as documented."""
+        client = limited_app.test_client()
+        for _ in range(4):
+            client.post("/token", data=DATA, headers=AUTH)
+        assert client.get("/.well-known/openid-configuration").status_code == 200
+
+
+class TestRateLimitDisabledByDefault:
+    def test_default_app_never_throttles_token(self, client):
+        for _ in range(12):
+            resp = client.post("/token", data=DATA, headers=AUTH)
+            assert resp.status_code == 200
+
+
+class TestStricterDevProfilePromise:
+    """stricter-dev has always FORCED rate_limit_enabled: true
+    (_STRICTER_DEV_HARDENING) - and until #304 that promise was a no-op.
+    The profile's hardening is real now."""
+
+    def test_stricter_dev_actually_limits_token(self, app):
+        from nanoidp.app import create_app
+        from nanoidp.config import get_config
+
+        with app.app_context():
+            config = get_config()
+            config.settings.rate_limit_token_endpoint = "2/minute"
+            config.save()
+        hardened = create_app(profile="stricter-dev")
+        hardened.config["TESTING"] = True
+        client = hardened.test_client()
+        try:
+            for _ in range(2):
+                assert (
+                    client.post("/token", data=DATA, headers=AUTH).status_code == 200
+                )
+            throttled = client.post("/token", data=DATA, headers=AUTH)
+            assert throttled.status_code == 429
+            assert throttled.get_json()["error"] == "rate_limit_exceeded"
+        finally:
+            with app.app_context():
+                config = get_config()
+                config.settings.rate_limit_token_endpoint = "10/minute"
+                config.save()


### PR DESCRIPTION
Closes #304 (pulled into 3.0.0: the stricter-dev behavior change belongs in the major). Direction chosen: **wire it** - removal would drop a capability a testing IdP legitimately wants, and wiring makes the log line true.

Worse than the audit said, on inspection: besides the limiter never being applied (`default_limits=[]`, zero decorated views), the two Settings fields were in **no document section** - YAML could not set them at all. The only path that ever flipped the flag was the **stricter-dev profile, which has always forced `rate_limit_enabled: true`** - so the profile's hardening promise was a no-op for its entire life.

- The configured `rate_limit_token_endpoint` now decorates `oauth.token` (post blueprint registration); 429 answers **JSON** with `Retry-After`/`RateLimit-*` headers - the only limited view is a protocol endpoint, so no framework HTML.
- `server.rate_limit_enabled` / `server.rate_limit_token_endpoint` are configurable from YAML through the full settings plumbing - and the table-driven legs (#175/#283 machinery) picked the new OWNED_SETTINGS rows up with zero extra code: the parity suite passed on first run after adding the two rows. Schema regenerated, `/api/config` + MCP `get_settings` expose both, configuration.md documents them.
- **Behavior change (CHANGELOGed under Fixed with a bold note): stricter-dev instances now really throttle `/token`** at the configured rate (default 10/minute) - the hardening the profile always claimed.

Tests (5): the 4th hit in a 3/minute window answers 429 JSON + `Retry-After`; other endpoints unlimited; scope is /token only; the default stays unlimited (12 rapid hits all 200); the stricter-dev promise pinned via a profile boot. Verified live from a YAML-only config: `200 200 200 429`. Suite 1929 green, mypy/ruff/import-linter clean.