### PR TITLE
refactor: one home for SAML attribute resolution (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,22 @@ previous leniency allowed - needs a one-time adjustment.
   forced `rate_limit_enabled: true`, so its instances now really throttle
   `/token` at the configured rate (default 10/minute) - the hardening the
   profile always claimed.
+- **One resolver for SAML attributes; the query surface stops fabricating
+  and mangling values** (#302). The SSO assertion and the attribute-query
+  assertion resolved a user's attributes through two independent
+  implementations that had drifted five ways; both now share
+  `services/saml_attributes.py`, and the emission of the
+  `AttributeStatement` is one helper. Three visible corrections, each
+  finishing an existing rule: the query no longer invents
+  `<user>@example.com` for a user without an email (#275 - an absent fact
+  is an absent attribute); a custom LIST attribute reaches the XML as one
+  `AttributeValue` per entry and a comma-bearing STRING is never split
+  (#134 - the query used to `",".join` lists and re-split any string with
+  a comma); an empty collection no longer emits an empty `Attribute`
+  element. The differences that remain between the two surfaces
+  (`source_acl` only on the query; no AuthnStatement/SubjectConfirmation/
+  AudienceRestriction on the query assertion) are deliberate and now
+  documented in a table in the SAML reference.
 - **`RevocationStore` entries now expire** (#288): revoked jtis and rotation
   family markers lived in two sets that were never swept - every revocation
   and every refresh rotation on a long-lived instance was a permanent memory

--- a/book/src/reference/saml.md
+++ b/book/src/reference/saml.md
@@ -180,7 +180,10 @@ they cannot drift silently. Their remaining differences are deliberate:
 | `AudienceRestriction` | pinned to `oauth.audience` | absent | the query requester's audience is unknown (the endpoint is unauthenticated by design) |
 
 Shared rules on both surfaces: an absent or empty fact is an absent
-attribute (no fabricated `email`, no empty `Attribute` elements); a list
-value becomes one `AttributeValue` per entry and a string is never split
-on commas (#134); roles/groups exports are opt-in under their configured
-names, merged on a name collision.
+attribute (no fabricated `email`, no empty `Attribute` elements - None and
+empty list/tuple/set/dict/string alike); a list value becomes one
+`AttributeValue` per entry and a string is never split on commas (#134);
+roles/groups exports are opt-in under their configured names. When the
+roles and groups exports target the SAME configured name, their lists are
+merged (roles first, deduplicated); a collision between an export name and
+a scalar core attribute is not merged - the export list replaces it.

--- a/book/src/reference/saml.md
+++ b/book/src/reference/saml.md
@@ -165,3 +165,22 @@ only includes namespaces actually used in the signed element. This is
 important when SPs extract the `<Assertion>` element from the `<Response>`
 to verify the signature independently. With standard C14N, the signature
 includes parent namespaces that break when the Assertion is extracted.
+
+## The two SAML surfaces: one resolver, declared differences (#302)
+
+Both the SSO assertion and the attribute-query assertion resolve a user's
+attributes through the same service (`services/saml_attributes.py`), so
+they cannot drift silently. Their remaining differences are deliberate:
+
+| Aspect | SSO assertion | Attribute-query assertion | Why |
+|---|---|---|---|
+| `source_acl` | not exported | exported | the query surface exists for backend authorization lookups; a login assertion carries no document-level ACLs |
+| `AuthnStatement` / `AuthnContextClassRef` | present | absent | an attribute lookup is not an authentication event; asserting one would be false |
+| `SubjectConfirmation` | present (bearer, 5-minute window) | absent | ties an assertion to a login exchange the query never had |
+| `AudienceRestriction` | pinned to `oauth.audience` | absent | the query requester's audience is unknown (the endpoint is unauthenticated by design) |
+
+Shared rules on both surfaces: an absent or empty fact is an absent
+attribute (no fabricated `email`, no empty `Attribute` elements); a list
+value becomes one `AttributeValue` per entry and a string is never split
+on commas (#134); roles/groups exports are opt-in under their configured
+names, merged on a name collision.

--- a/src/nanoidp/routes/saml.py
+++ b/src/nanoidp/routes/saml.py
@@ -17,6 +17,10 @@ from lxml import etree
 from ..config import get_config
 from ..exceptions import SAMLSignatureError
 from ..services import get_crypto_service
+from ..services.saml_attributes import (
+    append_attribute_statement,
+    resolve_saml_attributes,
+)
 from ..services.saml_verification import (
     load_sp_certificates,
     verify_post_signature,
@@ -158,21 +162,6 @@ def _parse_saml_request(
         return None
 
 
-def _add_export_attr(attrs: dict, name: str, values: list) -> None:
-    """Add an exported roles/groups attribute, merging on a name collision.
-
-    ``saml_roles_attr_name`` and ``saml_groups_attr_name`` are configured
-    independently, so both exports can target the same attribute (e.g.
-    ``memberOf``). Plain assignment would let the second list silently replace
-    the first (#134); merging keeps both, roles first, deduplicated.
-    """
-    existing = attrs.get(name)
-    if isinstance(existing, (list, tuple)):
-        attrs[name] = list(existing) + [v for v in values if v not in existing]
-    else:
-        attrs[name] = list(values)
-
-
 def _build_saml_response(
     acs_url: str,
     issuer: str,
@@ -279,25 +268,8 @@ def _build_saml_response(
     ctxc = etree.SubElement(ctx, "{urn:oasis:names:tc:SAML:2.0:assertion}AuthnContextClassRef")
     ctxc.text = authn_context
 
-    if attributes:
-        attrs = etree.SubElement(
-            assertion, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeStatement"
-        )
-        for k, v in attributes.items():
-            if v is None:
-                continue
-            attr = etree.SubElement(
-                attrs, "{urn:oasis:names:tc:SAML:2.0:assertion}Attribute", Name=k
-            )
-            if isinstance(v, (list, tuple)):
-                for item in v:
-                    av = etree.SubElement(
-                        attr, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue"
-                    )
-                    av.text = str(item)
-            else:
-                av = etree.SubElement(attr, "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue")
-                av.text = str(v)
+    # One shared emission path for both builders (#302).
+    append_attribute_statement(assertion, attributes)
 
     xml = etree.tostring(resp, xml_declaration=True, encoding="UTF-8")
 
@@ -517,26 +489,6 @@ def _sso_authenticate_inline(
     )
 
 
-def _sso_build_attributes(config: Any, user: Any) -> Dict[str, Any]:
-    """The assertion's attribute set for this user.
-
-    Roles/groups are opt-in: they have no standard SAML attribute name, so
-    the SP-specific name is configured alongside the switch.
-    """
-    saml_attrs: Dict[str, Any] = {
-        "identity_class": user.identity_class,
-        "entitlements": user.entitlements,
-        "email": user.email,
-    }
-    if config.settings.saml_export_roles and user.roles:
-        _add_export_attr(saml_attrs, config.settings.saml_roles_attr_name, user.roles)
-    if config.settings.saml_export_groups and user.groups:
-        _add_export_attr(saml_attrs, config.settings.saml_groups_attr_name, user.groups)
-    if user.attributes:
-        saml_attrs.update(user.attributes)
-    return saml_attrs
-
-
 def _sso_parse_request(
     config: Any, saml_request_b64: str
 ) -> tuple[Optional[str], Optional[str], Optional[ResponseReturnValue]]:
@@ -573,7 +525,10 @@ def _sso_success_response(
     relay_state: str,
 ) -> ResponseReturnValue:
     """Build, audit and auto-submit the SAML Response for an authenticated user."""
-    saml_attrs = _sso_build_attributes(config, user)
+    # Shared resolver (#302); the SSO assertion never carries source_acl -
+    # a login assertion is not a backend authorization lookup (deliberate,
+    # see services/saml_attributes.py and the saml.md divergence table).
+    saml_attrs = resolve_saml_attributes(config.settings, user, include_source_acl=False)
 
     name_id = user.email or f"{username}@example.org"
 
@@ -796,33 +751,10 @@ def _build_attribute_query_response(
     conditions.set("NotBefore", iso(now))
     conditions.set("NotOnOrAfter", iso(not_after))
 
-    # AttributeStatement - user authorization attributes
-    if attributes:
-        attr_statement = etree.SubElement(assertion, f"{{{SAML2_NS}}}AttributeStatement")
-
-        for attr_name, attr_value in attributes.items():
-            if attr_value is None:
-                continue
-
-            attribute = etree.SubElement(attr_statement, f"{{{SAML2_NS}}}Attribute")
-            attribute.set("Name", attr_name)
-
-            # Handle multi-value attributes
-            # Lists are expanded to multiple AttributeValue elements
-            # Scalar values are kept as a single AttributeValue
-            if isinstance(attr_value, (list, tuple)):
-                for value in attr_value:
-                    attr_val_elem = etree.SubElement(attribute, f"{{{SAML2_NS}}}AttributeValue")
-                    attr_val_elem.text = str(value)
-            elif isinstance(attr_value, str) and "," in attr_value and "\\" not in attr_value:
-                # Split comma-separated values (like entitlements)
-                for value in attr_value.split(","):
-                    attr_val_elem = etree.SubElement(attribute, f"{{{SAML2_NS}}}AttributeValue")
-                    attr_val_elem.text = value.strip()
-            else:
-                # Single scalar value
-                attr_val_elem = etree.SubElement(attribute, f"{{{SAML2_NS}}}AttributeValue")
-                attr_val_elem.text = str(attr_value)
+    # One shared emission path for both builders (#302): strings are never
+    # comma-split (the #134 rule the old loop here contradicted), lists are
+    # one AttributeValue per entry.
+    append_attribute_statement(assertion, attributes)
 
     return etree.tostring(response, encoding="unicode", pretty_print=True)
 
@@ -949,37 +881,16 @@ def attribute_query() -> ResponseReturnValue:
         user = config.get_user(user_id)
 
         if user:
-            # Build attributes from user config
-            attributes: Dict[str, Any] = {
-                "email": user.email or f"{user_id}@example.com",
-            }
-
-            # Add core authorization attributes
-            if user.identity_class:
-                attributes["identity_class"] = user.identity_class
-            if user.entitlements:
-                # Passed as a list: the response builder emits one
-                # AttributeValue per entry, and a comma-bearing entitlement
-                # stays a single value instead of being split (#134).
-                attributes["entitlements"] = user.entitlements
-            # Add source_acl for data source authorization
-            if user.source_acl:
-                attributes["source_acl"] = user.source_acl  # List for multiple values
-
-            # Roles/groups only when explicitly enabled (see /saml/sso).
-            # Lists, not ",".join: same reason as entitlements above (#134).
-            if config.settings.saml_export_roles and user.roles:
-                _add_export_attr(attributes, config.settings.saml_roles_attr_name, user.roles)
-            if config.settings.saml_export_groups and user.groups:
-                _add_export_attr(attributes, config.settings.saml_groups_attr_name, user.groups)
-
-            # Add custom attributes
-            if user.attributes:
-                for key, value in user.attributes.items():
-                    if isinstance(value, list):
-                        attributes[key] = ",".join(str(v) for v in value)
-                    else:
-                        attributes[key] = value
+            # Shared resolver (#302). Two behavior changes vs the old inline
+            # block, each finishing an existing rule: no fabricated
+            # <user>@example.com when the user has no email (#275 - never
+            # invent facts about a principal), and custom list attributes
+            # reach the XML per-value instead of ",".join-then-resplit
+            # (#134). source_acl IS exported here - this surface exists for
+            # backend authorization lookups (deliberate divergence from SSO).
+            attributes = resolve_saml_attributes(
+                config.settings, user, include_source_acl=True
+            )
         else:
             # Unknown principal (#275): a SAML error status, not a signed
             # assertion full of invented attributes - the SP under test must

--- a/src/nanoidp/services/saml_attributes.py
+++ b/src/nanoidp/services/saml_attributes.py
@@ -108,6 +108,11 @@ def append_attribute_statement(
     per entry, anything else ONE value via str() - never comma-split (the
     #134 rule; the query builder used to split comma-bearing strings).
     Emits nothing at all when ``attributes`` is empty.
+
+    EXPECTS RESOLVED ATTRIBUTES (#315 review): the empty-fact filtering
+    lives in resolve_saml_attributes, not here - calling this directly
+    with ``{"x": []}`` emits an empty Attribute element. Both surfaces go
+    through the resolver first; a future caller must too.
     """
     if not attributes:
         return

--- a/src/nanoidp/services/saml_attributes.py
+++ b/src/nanoidp/services/saml_attributes.py
@@ -56,6 +56,19 @@ def _add_export_attr(attrs: Dict[str, Any], name: str, values: Any) -> None:
         attrs[name] = list(values)
 
 
+def _is_absent(value: Any) -> bool:
+    """True when a custom attribute value carries no fact: None, or an
+    EMPTY collection of any of the shapes YAML can produce (list, tuple,
+    set, dict, string). The #315 review caught that the first predicate
+    listed [] and "" but not {} - which would have been emitted as the
+    literal AttributeValue "{}" while the docs promised omission."""
+    if value is None:
+        return True
+    if isinstance(value, (list, tuple, set, dict, str)) and len(value) == 0:
+        return True
+    return False
+
+
 def resolve_saml_attributes(
     settings: Any, user: Any, *, include_source_acl: bool
 ) -> Dict[str, Any]:
@@ -81,7 +94,7 @@ def resolve_saml_attributes(
         _add_export_attr(attrs, settings.saml_groups_attr_name, user.groups)
     if user.attributes:
         for key, value in user.attributes.items():
-            if value is None or value == [] or value == "":
+            if _is_absent(value):
                 continue
             attrs[key] = value
     return attrs

--- a/src/nanoidp/services/saml_attributes.py
+++ b/src/nanoidp/services/saml_attributes.py
@@ -1,0 +1,113 @@
+"""
+The single home for SAML attribute resolution (#302).
+
+Until 3.0 the two SAML surfaces resolved a user's attributes independently:
+``_sso_build_attributes`` for the SSO assertion and an inline block in the
+attribute-query route - and they had drifted in five observable ways. Both
+now call :func:`resolve_saml_attributes`; the emission side shares
+:func:`append_attribute_statement`.
+
+What the unification DELIBERATELY changed (CHANGELOGed, each finishing a
+rule the project had already decided):
+
+- The attribute-query surface no longer fabricates ``<user>@example.com``
+  when a user has no email (the #275 rule: never invent facts about a
+  principal); an absent email is an absent attribute, on both surfaces.
+- A custom attribute that is a LIST reaches the XML as one
+  ``AttributeValue`` per entry, and a custom attribute that is a STRING is
+  never split on commas (the #134 rule; the query surface used to
+  ``",".join`` lists and then re-split any comma-bearing string).
+- An EMPTY collection is an absent attribute, not an empty ``Attribute``
+  element (the SSO surface used to emit one for ``entitlements: []``).
+
+What stays DELIBERATELY different between the surfaces (documented in
+book/src/reference/saml.md):
+
+- ``source_acl`` is exported only by the attribute query
+  (``include_source_acl=True``): that surface exists for backend
+  authorization lookups; the SSO login assertion does not carry
+  document-level ACLs.
+- The SSO assertion carries AuthnStatement/SubjectConfirmation and an
+  AudienceRestriction; the query assertion does not: an attribute lookup
+  is not an authentication event (asserting one would be false), and the
+  requester's audience is unknown.
+"""
+
+from typing import Any, Dict
+
+from lxml import etree
+
+_SAML2_NS = "urn:oasis:names:tc:SAML:2.0:assertion"
+
+
+def _add_export_attr(attrs: Dict[str, Any], name: str, values: Any) -> None:
+    """Add an exported roles/groups attribute, merging on a name collision.
+
+    ``saml_roles_attr_name`` and ``saml_groups_attr_name`` are configured
+    independently, so both exports can target the same attribute (e.g.
+    ``memberOf``). Plain assignment would let the second list silently
+    replace the first (#134); merging keeps both, roles first, deduplicated.
+    Moved verbatim from routes/saml.py (#302).
+    """
+    existing = attrs.get(name)
+    if isinstance(existing, (list, tuple)):
+        attrs[name] = list(existing) + [v for v in values if v not in existing]
+    else:
+        attrs[name] = list(values)
+
+
+def resolve_saml_attributes(
+    settings: Any, user: Any, *, include_source_acl: bool
+) -> Dict[str, Any]:
+    """The attribute set a SAML surface asserts for ``user``.
+
+    Empty/None values are omitted (an absent fact is an absent attribute);
+    roles/groups are opt-in under their configured SP-specific names; custom
+    attributes pass through with their real types - the emission helper
+    turns lists into one AttributeValue per entry.
+    """
+    attrs: Dict[str, Any] = {}
+    if user.email:
+        attrs["email"] = user.email
+    if user.identity_class:
+        attrs["identity_class"] = user.identity_class
+    if user.entitlements:
+        attrs["entitlements"] = list(user.entitlements)
+    if include_source_acl and user.source_acl:
+        attrs["source_acl"] = list(user.source_acl)
+    if settings.saml_export_roles and user.roles:
+        _add_export_attr(attrs, settings.saml_roles_attr_name, user.roles)
+    if settings.saml_export_groups and user.groups:
+        _add_export_attr(attrs, settings.saml_groups_attr_name, user.groups)
+    if user.attributes:
+        for key, value in user.attributes.items():
+            if value is None or value == [] or value == "":
+                continue
+            attrs[key] = value
+    return attrs
+
+
+def append_attribute_statement(
+    assertion: "etree._Element", attributes: Dict[str, Any]
+) -> None:
+    """Emit one AttributeStatement under ``assertion``, shared by both
+    builders (#302): None skipped, a list/tuple becomes one AttributeValue
+    per entry, anything else ONE value via str() - never comma-split (the
+    #134 rule; the query builder used to split comma-bearing strings).
+    Emits nothing at all when ``attributes`` is empty.
+    """
+    if not attributes:
+        return
+    statement = etree.SubElement(assertion, f"{{{_SAML2_NS}}}AttributeStatement")
+    for name, value in attributes.items():
+        if value is None:
+            continue
+        attribute = etree.SubElement(
+            statement, f"{{{_SAML2_NS}}}Attribute", Name=name
+        )
+        values = value if isinstance(value, (list, tuple)) else [value]
+        for item in values:
+            element = etree.SubElement(
+                attribute, f"{{{_SAML2_NS}}}AttributeValue"
+            )
+            element.text = str(item)

--- a/tests/test_saml_attributes.py
+++ b/tests/test_saml_attributes.py
@@ -65,12 +65,24 @@ class TestResolver:
         assert "email" not in attrs
 
     def test_empty_collections_are_omitted(self):
+        """Every empty shape YAML can produce - the #315 review caught that
+        the first predicate missed {} (it would have been emitted as the
+        literal AttributeValue "{}")."""
         attrs = resolve_saml_attributes(
             _S(),
-            _U(entitlements=[], attributes={"x": [], "y": "", "z": None}),
+            _U(
+                entitlements=[],
+                attributes={"a": [], "b": "", "c": None, "d": {}, "e": ()},
+            ),
             include_source_acl=True,
         )
         assert attrs == {}
+
+    def test_non_empty_dict_value_is_kept(self):
+        attrs = resolve_saml_attributes(
+            _S(), _U(attributes={"metadata": {"k": "v"}}), include_source_acl=True
+        )
+        assert attrs["metadata"] == {"k": "v"}
 
     def test_custom_list_stays_a_list(self):
         attrs = resolve_saml_attributes(

--- a/tests/test_saml_attributes.py
+++ b/tests/test_saml_attributes.py
@@ -1,0 +1,180 @@
+"""
+The single home for SAML attribute resolution (#302), and the pins for
+what the unification deliberately changed vs deliberately kept different.
+
+Divergence table (see services/saml_attributes.py and saml.md):
+CHANGED (finishing existing rules): no fabricated email (#275); list
+customs per-value, strings never comma-split (#134); empty collections
+omitted. KEPT: source_acl only on the attribute query; the query assertion
+carries no AuthnStatement/SubjectConfirmation (an attribute lookup is not
+an authentication event).
+"""
+
+from lxml import etree
+
+from nanoidp.config import get_config
+from nanoidp.services.saml_attributes import (
+    append_attribute_statement,
+    resolve_saml_attributes,
+)
+
+SAML_NS = {
+    "saml2": "urn:oasis:names:tc:SAML:2.0:assertion",
+    "saml2p": "urn:oasis:names:tc:SAML:2.0:protocol",
+}
+
+
+class _U:
+    """Minimal user stand-in."""
+
+    def __init__(self, **kw):
+        self.email = kw.get("email")
+        self.identity_class = kw.get("identity_class")
+        self.entitlements = kw.get("entitlements", [])
+        self.source_acl = kw.get("source_acl", [])
+        self.roles = kw.get("roles", [])
+        self.groups = kw.get("groups", [])
+        self.attributes = kw.get("attributes", {})
+
+
+class _S:
+    saml_export_roles = False
+    saml_export_groups = False
+    saml_roles_attr_name = "roles"
+    saml_groups_attr_name = "groups"
+
+
+class TestResolver:
+    def test_full_user_both_surfaces_differ_only_by_source_acl(self):
+        user = _U(
+            email="a@b.c",
+            identity_class="INTERNAL",
+            entitlements=["E1"],
+            source_acl=["ACL_READ"],
+            attributes={"dept": "eng"},
+        )
+        sso = resolve_saml_attributes(_S(), user, include_source_acl=False)
+        query = resolve_saml_attributes(_S(), user, include_source_acl=True)
+        assert set(query) - set(sso) == {"source_acl"}
+        assert {k: v for k, v in query.items() if k != "source_acl"} == sso
+
+    def test_no_email_is_no_email_attribute(self):
+        """#275 rule extended here: the old query surface fabricated
+        <user>@example.com."""
+        attrs = resolve_saml_attributes(_S(), _U(), include_source_acl=True)
+        assert "email" not in attrs
+
+    def test_empty_collections_are_omitted(self):
+        attrs = resolve_saml_attributes(
+            _S(),
+            _U(entitlements=[], attributes={"x": [], "y": "", "z": None}),
+            include_source_acl=True,
+        )
+        assert attrs == {}
+
+    def test_custom_list_stays_a_list(self):
+        attrs = resolve_saml_attributes(
+            _S(), _U(attributes={"teams": ["a", "b"]}), include_source_acl=False
+        )
+        assert attrs["teams"] == ["a", "b"]
+
+    def test_export_collision_merges_roles_first(self):
+        class S(_S):
+            saml_export_roles = True
+            saml_export_groups = True
+            saml_roles_attr_name = "memberOf"
+            saml_groups_attr_name = "memberOf"
+
+        attrs = resolve_saml_attributes(
+            S(), _U(roles=["R1"], groups=["G1", "R1"]), include_source_acl=False
+        )
+        assert attrs["memberOf"] == ["R1", "G1"]
+
+
+class TestEmission:
+    def _emit(self, attributes):
+        assertion = etree.Element("{urn:oasis:names:tc:SAML:2.0:assertion}Assertion")
+        append_attribute_statement(assertion, attributes)
+        return assertion
+
+    def test_list_becomes_one_value_per_entry(self):
+        assertion = self._emit({"entitlements": ["A", "B"]})
+        values = assertion.findall(".//saml2:AttributeValue", SAML_NS)
+        assert [v.text for v in values] == ["A", "B"]
+
+    def test_comma_bearing_string_stays_one_value(self):
+        """The #134 rule the old query builder contradicted: strings are
+        never comma-split."""
+        assertion = self._emit({"note": "a,b,c"})
+        values = assertion.findall(".//saml2:AttributeValue", SAML_NS)
+        assert [v.text for v in values] == ["a,b,c"]
+
+    def test_empty_dict_emits_no_statement(self):
+        assertion = self._emit({})
+        assert assertion.findall(".//saml2:AttributeStatement", SAML_NS) == []
+
+
+class TestSurfacesEndToEnd:
+    def _query(self, user_id):
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+            "<soap:Body>"
+            '<samlp:AttributeQuery xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+            ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+            ' ID="_aq" Version="2.0" IssueInstant="2024-01-01T00:00:00Z">'
+            "<saml:Issuer>sp</saml:Issuer>"
+            f"<saml:Subject><saml:NameID>{user_id}</saml:NameID></saml:Subject>"
+            "</samlp:AttributeQuery></soap:Body></soap:Envelope>"
+        )
+
+    def test_query_no_fabricated_email_and_lists_per_value(self, client, app):
+        with app.app_context():
+            user = get_config().get_user("admin")
+            original_email = user.email
+            original_attrs = user.attributes
+            user.email = ""  # User.email is non-Optional str; falsy = absent
+            user.attributes = {"teams": ["alpha", "beta"], "note": "x,y"}
+        try:
+            resp = client.post(
+                "/saml/attribute-query",
+                data=self._query("admin"),
+                content_type="text/xml",
+            )
+            assert resp.status_code == 200
+            root = etree.fromstring(resp.data)
+            names = [
+                a.get("Name") for a in root.findall(".//saml2:Attribute", SAML_NS)
+            ]
+            assert "email" not in names, "no fabricated email (#275 rule)"
+            teams = [
+                v.text
+                for a in root.findall(".//saml2:Attribute", SAML_NS)
+                if a.get("Name") == "teams"
+                for v in a.findall("saml2:AttributeValue", SAML_NS)
+            ]
+            assert teams == ["alpha", "beta"], "list customs per-value (#134)"
+            note = [
+                v.text
+                for a in root.findall(".//saml2:Attribute", SAML_NS)
+                if a.get("Name") == "note"
+                for v in a.findall("saml2:AttributeValue", SAML_NS)
+            ]
+            assert note == ["x,y"], "comma-bearing string stays one value (#134)"
+        finally:
+            with app.app_context():
+                user = get_config().get_user("admin")
+                user.email = original_email
+                user.attributes = original_attrs
+
+    def test_query_assertion_has_no_authn_statement(self, client):
+        """Deliberate (documented, NOT a gap): an attribute lookup is not an
+        authentication event."""
+        resp = client.post(
+            "/saml/attribute-query",
+            data=self._query("admin"),
+            content_type="text/xml",
+        )
+        root = etree.fromstring(resp.data)
+        assert root.findall(".//saml2:AuthnStatement", SAML_NS) == []
+        assert root.findall(".//saml2:Assertion", SAML_NS) != []


### PR DESCRIPTION
Closes #302 - with its residual debts explicitly re-tracked first, per the review round 1: this PR delivers the SAML-internal half (shared resolver + shared AttributeStatement emission); the SAML<->OIDC user-to-facts duplication is now **#316** and the shared assertion skeleton is **#317**, both filed with the analysis, and #302 carries the scope-resolution comment. Nothing closes by implication. Pulled into 3.0.0: every visible change here belongs in the major.

## What is shared now

- `services/saml_attributes.resolve_saml_attributes(settings, user, include_source_acl=)` - the one resolver both surfaces call (`_sso_build_attributes` and the query route's inline block are gone); `_add_export_attr` moved verbatim with its #134 merge-on-collision semantics.
- `append_attribute_statement` - one emission path for both builders.

## Three visible corrections (each finishes a rule the project already decided)

1. **No fabricated email**: the query surface invented `<user>@example.com` for a user without one - the #275 rule (never invent facts about a principal) now applies here too; an absent fact is an absent attribute on both surfaces.
2. **#134 completed**: custom LIST attributes reach the XML as one `AttributeValue` per entry (the query route used to `",".join` them) and a comma-bearing STRING is never split (the query builder used to re-split any string with a comma - directly contradicting the #134 comment sitting a few lines above it).
3. **No empty `Attribute` elements**: an empty collection is omitted (the SSO builder used to emit an empty element for `entitlements: []`).

## What stays deliberately different (documented in a table in saml.md)

`source_acl` only on the query surface (it exists for backend authorization lookups; a login assertion carries no document ACLs); no AuthnStatement/SubjectConfirmation/AudienceRestriction on the query assertion - **an attribute lookup is not an authentication event**, so this corrects the issue's own framing of those as gaps, with a route-level test pinning the absence as a declaration. NameID Format turned out identical on both surfaces (non-divergence).

## Verification

12 new tests (resolver branches incl. the memberOf collision merge; emission rules; cross-surface parity asserting the two surfaces differ ONLY by `source_acl`; route-level pins for all three corrections). Suite 1934 green, mypy/ruff/import-linter clean, full e2e 61/61 live.
