### PR TITLE
chore: bump to 3.0.0rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanoidp"
-version = "3.0.0rc2"
+version = "3.0.0rc3"
 description = "A lightweight, configurable Identity Provider for development and testing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only; CHANGELOG stays under [Unreleased] until the final, per policy. rc3 absorbs the one feature merged since rc2: auto-login personas (#318, contributed by @gprossliner). Tag v3.0.0-rc3 follows on the merge commit.